### PR TITLE
feat: Use wrappers around existing CARTO sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,24 @@
 # deck.gl data widgets
 
+## References
+
 - [Product feature brief](https://docs.google.com/document/d/1ZWiVB_rgXf1WAEF1TjJgEHxp92kREYQrWG3O8jYV0Zk/edit)
 - [Architecture document](https://app.shortcut.com/cartoteam/write/IkRvYyI6I3V1aWQgIjY2MzE1NDU0LTIyZTAtNDI4YS04NzMzLTc3YzZjN2I2MjVjYSI=?commentId=e509d33c6cdedf90599a5d3a937336d8e&commentThreadId=e7dbf03c9bd7b0fd3de40ebacbea67ee9)
+
+## Quickstart
+
+```bash
+# install dependencies
+yarn
+
+# build package once
+yarn build
+
+# build package and watch for changes
+yarn build:watch
+
+# build package, watch for changes, and start a local server for examples
+yarn dev
+```
+
+After running `yarn dev`, a browser window should open with links to examples. Unless a different port number is required, the local URL will be `localhost:5173`.

--- a/examples/index.html
+++ b/examples/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en-GB">
+  <head>
+    <meta charset="utf-8" />
+    <link rel="stylesheet" href="./style.css" />
+    <style>
+      body {
+        box-sizing: border-box;
+        padding: 2em;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Examples</h1>
+    <ol>
+      <li><a href="./pure-js.html">pure js</a></li>
+      <li>react (TODO)</li>
+      <li>angular (TODO)</li>
+      <li>vue (TODO)</li>
+    </ol>
+  </body>
+</html>

--- a/examples/pure-js.html
+++ b/examples/pure-js.html
@@ -11,9 +11,25 @@
         <canvas id="deck-canvas"></canvas>
       </section>
       <section id="rail">
-        <formula-widget id="formula" header="Total"></formula-widget>
-        <category-widget id="category" header="Store type"></category-widget>
-        <pie-widget id="pie" header="Store type"></pie-widget>
+        <formula-widget
+          id="formula"
+          header="Total"
+          aggregation="count"
+        ></formula-widget>
+
+        <category-widget
+          id="category"
+          header="Store type"
+          aggregation="count"
+          column="storetype"
+        ></category-widget>
+
+        <pie-widget
+          id="pie"
+          header="Store type"
+          aggregation="count"
+          column="storetype"
+        ></pie-widget>
       </section>
       <footer id="footer"></footer>
     </main>

--- a/examples/pure-js.ts
+++ b/examples/pure-js.ts
@@ -58,6 +58,7 @@ updateSources();
 
 function updateSources() {
   data = vectorTableSource({
+    // @ts-expect-error
     accessToken: import.meta.env.VITE_CARTO_ACCESS_TOKEN,
     connectionName: 'carto_dw',
     tableName: 'carto-demo-data.demo_tables.retail_stores',

--- a/examples/pure-js.ts
+++ b/examples/pure-js.ts
@@ -1,27 +1,23 @@
 import maplibregl from 'maplibre-gl';
 import {Deck} from '@deck.gl/core';
-import {VectorTileLayer, vectorTableSource} from '@deck.gl/carto';
+import {VectorTileLayer} from '@deck.gl/carto';
 import {
-  TableDataView,
   AggregationTypes,
   FormulaWidget,
   CategoryWidget,
   FilterEvent,
   Filter,
   PieWidget,
+  vectorTableSource,
+  VectorTableSourceResponse,
 } from '../';
 
 /**************************************************************************
  * REACTIVE STATE
  */
 
-const railEl = document.querySelector('#rail')!;
-const formulaWidget = railEl.querySelector('#formula') as FormulaWidget;
-const categoryWidget = railEl.querySelector('#category') as CategoryWidget;
-const pieWidget = railEl.querySelector('#pie') as PieWidget;
-const footerEl = document.querySelector('#footer')!;
-
-let viewState = {latitude: 40.7128, longitude: -74.0060, zoom: 12};
+let data: Promise<VectorTableSourceResponse>;
+let viewState = {latitude: 40.7128, longitude: -74.006, zoom: 12};
 let filters: Record<string, Filter> = {};
 
 /**************************************************************************
@@ -51,88 +47,103 @@ deck.setProps({
   },
 });
 
-updateLayers();
-updateWidgets();
+const widgets = [
+  bindWidget('formula', {
+    source: {
+      data: 'carto-demo-data.demo_tables.retail_stores', // REDUNDANT
+      type: 'table', // REDUNDANT
+      filtersLogicalOperator: 'and',
+      queryParameters: [],
+      geoColumn: 'geom',
+      provider: 'bigquery',
+      filters: filters, // REDUNDANT
+    },
+    operation: AggregationTypes.COUNT,
+    column: '',
+    global: false,
+  }),
+  bindWidget('category', {
+    source: {
+      data: 'carto-demo-data.demo_tables.retail_stores', // REDUNDANT
+      type: 'table', // REDUNDANT
+      filtersLogicalOperator: 'and',
+      queryParameters: [],
+      geoColumn: 'geom', // REDUNDANT
+      provider: 'bigquery',
+      filters: filters, // REDUNDANT
+    },
+    operation: AggregationTypes.COUNT,
+    column: 'storetype',
+    global: false,
+  }),
+  bindWidget('pie', {
+    source: {
+      data: 'carto-demo-data.demo_tables.retail_stores',
+      type: 'table',
+      filtersLogicalOperator: 'and',
+      queryParameters: [],
+      geoColumn: 'geom', // REDUNDANT
+      provider: 'bigquery',
+      filters: filters, // REDUNDANT
+    },
+    operation: AggregationTypes.COUNT,
+    column: 'storetype',
+    global: false,
+  }),
+];
+
+updateSources();
 
 /**************************************************************************
- * LAYERS
+ * UPDATES
  */
 
-function updateLayers() {
-  const cartoData = vectorTableSource({
+function updateSources() {
+  data = vectorTableSource({
     accessToken: import.meta.env.VITE_CARTO_ACCESS_TOKEN,
     connectionName: 'carto_dw',
     tableName: 'carto-demo-data.demo_tables.retail_stores',
     filters,
   });
 
+  updateLayers();
+  updateWidgets();
+}
+
+function updateLayers() {
   const layer = new VectorTileLayer({
     id: 'retail_stores',
-    data: cartoData,
+    data,
     pointRadiusMinPixels: 4,
     getFillColor: [200, 0, 80],
   });
 
   deck.setProps({layers: [layer]});
-  cartoData.then(({attribution}) => (footerEl.innerHTML = attribution));
+  data.then(({attribution}) => {
+    document.querySelector('#footer')!.innerHTML = attribution;
+  });
 }
-
-/**************************************************************************
- * WIDGETS
- */
 
 function updateWidgets() {
-  const dataView = new TableDataView({
-    accessToken: import.meta.env.VITE_CARTO_ACCESS_TOKEN,
-    connectionName: 'carto_dw',
-    tableName: 'carto-demo-data.demo_tables.retail_stores',
-    viewState,
-  });
-
-  formulaWidget.dataView = dataView;
-  formulaWidget.config = {
-    // TODO(cleanup)
-    source: {
-      data: 'carto-demo-data.demo_tables.retail_stores',
-      type: 'table',
-      filtersLogicalOperator: 'and',
-      queryParameters: [],
-      geoColumn: 'geom',
-      provider: 'bigquery',
-      filters: filters,
-    },
-    operation: AggregationTypes.COUNT,
-    column: '',
-    global: false,
-  };
-
-  categoryWidget.dataView = pieWidget.dataView = dataView;
-  categoryWidget.config = pieWidget.config = {
-    // TODO(cleanup)
-    source: {
-      data: 'carto-demo-data.demo_tables.retail_stores',
-      type: 'table',
-      filtersLogicalOperator: 'and',
-      queryParameters: [],
-      geoColumn: 'geom',
-      provider: 'bigquery',
-      filters: filters,
-    },
-    operation: AggregationTypes.COUNT,
-    column: 'storetype',
-    global: false,
-  };
-  // TODO: Type definitions for events.
-  (categoryWidget as any).addEventListener('filter', onFilterChange);
-  (pieWidget as any).addEventListener('filter', onFilterChange);
+  for (const widget of widgets) {
+    widget.data = data;
+    widget.viewState = viewState;
+  }
 }
 
 /**************************************************************************
- * EVENT LISTENERS
+ * INITIALIZATION
  */
 
-function onFilterChange(event: FilterEvent) {
-  filters = event.detail.filters;
-  updateLayers();
-  updateWidgets();
+// TODO: Improve type definitions.
+function bindWidget(id: string, config: unknown): CategoryWidget | PieWidget | FormulaWidget {
+  const widget = document.querySelector(`#${id}`) as any;
+  widget.config = config;
+
+  widget.addEventListener('filter', (event: FilterEvent) => {
+    filters = event.detail.filters;
+    updateSources();
+  });
+
+  return widget;
 }

--- a/examples/pure-js.ts
+++ b/examples/pure-js.ts
@@ -2,14 +2,11 @@ import maplibregl from 'maplibre-gl';
 import {Deck} from '@deck.gl/core';
 import {VectorTileLayer} from '@deck.gl/carto';
 import {
-  AggregationTypes,
-  FormulaWidget,
-  CategoryWidget,
   FilterEvent,
   Filter,
-  PieWidget,
   vectorTableSource,
   VectorTableSourceResponse,
+  Widget,
 } from '../';
 
 /**************************************************************************
@@ -47,49 +44,10 @@ deck.setProps({
   },
 });
 
-const widgets = [
-  bindWidget('formula', {
-    source: {
-      data: 'carto-demo-data.demo_tables.retail_stores', // REDUNDANT
-      type: 'table', // REDUNDANT
-      filtersLogicalOperator: 'and',
-      queryParameters: [],
-      geoColumn: 'geom',
-      provider: 'bigquery',
-      filters: filters, // REDUNDANT
-    },
-    operation: AggregationTypes.COUNT,
-    column: '',
-    global: false,
-  }),
-  bindWidget('category', {
-    source: {
-      data: 'carto-demo-data.demo_tables.retail_stores', // REDUNDANT
-      type: 'table', // REDUNDANT
-      filtersLogicalOperator: 'and',
-      queryParameters: [],
-      geoColumn: 'geom', // REDUNDANT
-      provider: 'bigquery',
-      filters: filters, // REDUNDANT
-    },
-    operation: AggregationTypes.COUNT,
-    column: 'storetype',
-    global: false,
-  }),
-  bindWidget('pie', {
-    source: {
-      data: 'carto-demo-data.demo_tables.retail_stores',
-      type: 'table',
-      filtersLogicalOperator: 'and',
-      queryParameters: [],
-      geoColumn: 'geom', // REDUNDANT
-      provider: 'bigquery',
-      filters: filters, // REDUNDANT
-    },
-    operation: AggregationTypes.COUNT,
-    column: 'storetype',
-    global: false,
-  }),
+const widgets: Widget[] = [
+  bindWidget('#formula'),
+  bindWidget('#category'),
+  bindWidget('#pie'),
 ];
 
 updateSources();
@@ -136,11 +94,10 @@ function updateWidgets() {
  */
 
 // TODO: Improve type definitions.
-function bindWidget(id: string, config: unknown): CategoryWidget | PieWidget | FormulaWidget {
-  const widget = document.querySelector(`#${id}`) as any;
-  widget.config = config;
+function bindWidget(selector: string): Widget {
+  const widget = document.querySelector<Widget>(selector)!;
 
-  widget.addEventListener('filter', (event: FilterEvent) => {
+  (widget as any).addEventListener('filter', (event: FilterEvent) => {
     filters = event.detail.filters;
     updateSources();
   });

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "build": "tsc",
     "build:watch": "tsc --watch",
-    "dev": "concurrently \"yarn build:watch\" \"vite -c examples/vite.config.js\"",
+    "dev": "concurrently \"yarn build:watch\" \"vite --config examples/vite.config.js --open\"",
     "clean": "rimraf my-element.{d.ts,d.ts.map,js,js.map} test/my-element.{d.ts,d.ts.map,js,js.map} test/my-element_test.{d.ts,d.ts.map,js,js.map}",
     "lint": "npm run lint:lit-analyzer",
     "lint:lit-analyzer": "lit-analyzer",

--- a/src/data-view.ts
+++ b/src/data-view.ts
@@ -11,7 +11,6 @@ import {
   MAP_TYPES,
 } from './vendor/carto-constants.js';
 import {
-  MapType,
   SourceOptions,
   VectorQuerySourceOptions,
   VectorTableSourceOptions,
@@ -62,7 +61,7 @@ export class CartoDataView<Props extends SourceOptions> implements DataView {
   }
   protected getSource(): WidgetSource {
     return {
-      ...this.props as any,
+      ...(this.props as any),
       credentials: this.credentials,
       connection: this.connectionName,
     };
@@ -145,7 +144,7 @@ export class TableDataView extends CartoDataView<VectorTableSourceOptions> {
     return {
       ...super.getSource(),
       type: MAP_TYPES.TABLE,
-      data: this.props.tableName
+      data: this.props.tableName,
     };
   }
 }
@@ -155,7 +154,7 @@ export class QueryDataView extends CartoDataView<VectorQuerySourceOptions> {
     return {
       ...super.getSource(),
       type: MAP_TYPES.QUERY,
-      data: this.props.sqlQuery
+      data: this.props.sqlQuery,
     };
   }
 }

--- a/src/data-view.ts
+++ b/src/data-view.ts
@@ -15,23 +15,7 @@ import {
   VectorQuerySourceOptions,
   VectorTableSourceOptions,
 } from '@deck.gl/carto';
-
-// TODO: legacy
-interface WidgetSource {
-  id: string;
-  data: string;
-  type: MAP_TYPES;
-  credentials: {
-    apiVersion: API_VERSIONS;
-    accessToken: string;
-  };
-  connection: string;
-  filtersLogicalOperator: string;
-  queryParameters: unknown[];
-  geoColumn: string;
-  provider: string;
-  filters: Record<string, unknown>;
-}
+import {getWidgetFilters} from './utils.js';
 
 // TODO: types
 const DEFAULT_PROPS: any = {
@@ -59,31 +43,33 @@ export class CartoDataView<Props extends SourceOptions> implements DataView {
     };
     this.connectionName = props.connectionName;
   }
-  protected getSource(): WidgetSource {
+  protected getSource(owner: string): $TODO {
     return {
       ...(this.props as any),
+      filters: getWidgetFilters(owner, (this.props as any).filters),
       credentials: this.credentials,
       connection: this.connectionName,
     };
   }
   getFormula(props: $TODO): $TODO {
-    const {spatialFilter, abortController, operationExp, ...params} = props;
+    const {owner, spatialFilter, abortController, operationExp, ...params} =
+      props;
     const {column, operation} = params;
     return executeModel({
       model: 'formula',
-      source: this.getSource(),
+      source: this.getSource(owner),
       spatialFilter: spatialFilter,
       params: {column: column ?? '*', operation, operationExp},
       opts: {abortController},
     }).then((res: $TODO) => normalizeObjectKeys(res.rows[0]));
   }
   getCategories(props: $TODO): $TODO {
-    const {spatialFilter, abortController, ...params} = props;
+    const {owner, spatialFilter, abortController, ...params} = props;
     const {column, operation, operationColumn} = params;
 
     return executeModel({
       model: 'category',
-      source: this.getSource(),
+      source: this.getSource(owner),
       spatialFilter: spatialFilter,
       params: {
         column,
@@ -94,24 +80,24 @@ export class CartoDataView<Props extends SourceOptions> implements DataView {
     }).then((res: $TODO) => normalizeObjectKeys(res.rows));
   }
   getRange(props: $TODO): $TODO {
-    const {spatialFilter, abortController, ...params} = props;
+    const {owner, spatialFilter, abortController, ...params} = props;
     const {column} = params;
 
     return executeModel({
       model: 'range',
-      source: this.getSource(),
+      source: this.getSource(owner),
       spatialFilter: spatialFilter,
       params: {column},
       opts: {abortController},
     }).then((res: $TODO) => normalizeObjectKeys(res.rows[0]));
   }
   getTable(props: $TODO): $TODO {
-    const {spatialFilter, abortController, ...params} = props;
+    const {owner, spatialFilter, abortController, ...params} = props;
     const {columns, sortBy, sortDirection, page, rowsPerPage} = params;
 
     return executeModel({
       model: 'table',
-      source: this.getSource(),
+      source: this.getSource(owner),
       spatialFilter: spatialFilter,
       params: {
         column: columns,
@@ -140,9 +126,9 @@ export class CartoDataView<Props extends SourceOptions> implements DataView {
 }
 
 export class TableDataView extends CartoDataView<VectorTableSourceOptions> {
-  protected override getSource(): WidgetSource {
+  protected override getSource(owner: string): $TODO {
     return {
-      ...super.getSource(),
+      ...super.getSource(owner),
       type: MAP_TYPES.TABLE,
       data: this.props.tableName,
     };
@@ -150,9 +136,9 @@ export class TableDataView extends CartoDataView<VectorTableSourceOptions> {
 }
 
 export class QueryDataView extends CartoDataView<VectorQuerySourceOptions> {
-  protected override getSource(): WidgetSource {
+  protected override getSource(owner: string): $TODO {
     return {
-      ...super.getSource(),
+      ...super.getSource(owner),
       type: MAP_TYPES.QUERY,
       data: this.props.sqlQuery,
     };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,13 @@
 // core
-export {MAP_TYPES, API_VERSIONS, AggregationTypes} from './vendor/carto-constants';
-export type {Filter} from './vendor/deck-carto';
+export {MAP_TYPES, API_VERSIONS, AggregationTypes} from './vendor/carto-constants.js';
+export type {Filter} from './vendor/deck-carto.js';
 
-// data views
-export {TableDataView, QueryDataView} from './data-view';
-export {TableDataViewProps, QueryDataViewProps, FilterEvent} from './types';
+// data sources
+export * from './sources.js';
+export {TableDataView, QueryDataView} from './data-view.js';
+export {FilterEvent} from './types.js';
 
 // widgets
-export {CategoryWidget} from './widgets/category-widget';
-export {FormulaWidget} from './widgets/formula-widget';
-export {PieWidget} from './widgets/pie-widget';
+export {CategoryWidget} from './widgets/category-widget.js';
+export {FormulaWidget} from './widgets/formula-widget.js';
+export {PieWidget} from './widgets/pie-widget.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,8 @@ export {TableDataView, QueryDataView} from './data-view.js';
 export {FilterEvent} from './types.js';
 
 // widgets
-export {CategoryWidget} from './widgets/category-widget.js';
-export {FormulaWidget} from './widgets/formula-widget.js';
-export {PieWidget} from './widgets/pie-widget.js';
+import {CategoryWidget} from './widgets/category-widget.js';
+import {FormulaWidget} from './widgets/formula-widget.js';
+import {PieWidget} from './widgets/pie-widget.js';
+export type Widget = CategoryWidget | PieWidget | FormulaWidget;
+export {CategoryWidget, FormulaWidget, PieWidget};

--- a/src/sources.ts
+++ b/src/sources.ts
@@ -1,0 +1,75 @@
+import {
+  vectorTableSource as _vectorTableSource,
+  vectorQuerySource as _vectorQuerySource,
+  VectorTableSourceOptions,
+  VectorQuerySourceOptions,
+} from '@deck.gl/carto';
+import {QueryDataView, TableDataView} from './data-view.js';
+
+/******************************************************************************
+ * VECTOR SOURCES
+ */
+
+type _VectorTableSourceResponse = Awaited<
+  ReturnType<typeof _vectorTableSource>
+>;
+export type VectorTableSourceResponse = _VectorTableSourceResponse & {
+  dataView: TableDataView;
+};
+
+type _VectorQuerySourceResponse = Awaited<
+  ReturnType<typeof _vectorQuerySource>
+>;
+export type VectorQuerySourceResponse = _VectorQuerySourceResponse & {
+  dataView: QueryDataView;
+};
+
+export async function vectorTableSource(
+  props: VectorTableSourceOptions
+): Promise<VectorTableSourceResponse> {
+  return {
+    ...(await _vectorTableSource(props)),
+    dataView: new TableDataView(props),
+  };
+}
+
+export async function vectorQuerySource(
+  props: VectorQuerySourceOptions
+): Promise<VectorQuerySourceResponse> {
+  return {
+    ...(await _vectorQuerySource(props)),
+    dataView: new QueryDataView(props),
+  };
+}
+
+export const vectorTilesetSource = () => {
+  throw new Error('not implemented');
+};
+
+/******************************************************************************
+ * H3 SOURCES
+ */
+
+export const h3TableSource = () => {
+  throw new Error('not implemented');
+};
+export const h3QuerySource = () => {
+  throw new Error('not implemented');
+};
+export const h3TilesetSource = () => {
+  throw new Error('not implemented');
+};
+
+/******************************************************************************
+ * QUADBIN SOURCES
+ */
+
+export const quadbinTableSource = () => {
+  throw new Error('not implemented');
+};
+export const quadbinQuerySource = () => {
+  throw new Error('not implemented');
+};
+export const quadbinTilesetSource = () => {
+  throw new Error('not implemented');
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,30 +1,5 @@
-import {
-  VectorTableSourceOptions,
-  VectorQuerySourceOptions,
-  SourceOptions,
-} from '@deck.gl/carto';
-import { MapViewState } from '@deck.gl/core';
-
 export type $TODO = any;
-
-export type CartoDataViewProps = SourceOptions & {
-  viewState: MapViewState;
-};
-
-export type TableDataViewProps = CartoDataViewProps &
-  VectorTableSourceOptions & {
-    tableName: string;
-    onFilterChange?: (filters: Record<string, unknown>) => void;
-  };
-
-export type QueryDataViewProps = CartoDataViewProps &
-  VectorQuerySourceOptions & {
-    sqlQuery: string;
-    onFilterChange?: (filters: Record<string, unknown>) => void;
-  };
-
 export interface DataView {}
-
 export interface FilterEvent extends CustomEvent {
   detail: {filters: any}
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,5 @@
-import { Filter, FilterTypes } from "./vendor/deck-carto";
+import { MapViewState, WebMercatorViewport } from "@deck.gl/core";
+import { Filter, FilterTypes } from "./vendor/deck-carto.js";
 
 export function sleep (ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms))
@@ -18,4 +19,20 @@ export function getWidgetFilters(owner: string, allFilters?: Record<string, Filt
   }
 
   return widgetFilters;
+}
+
+export function getSpatialFilter(viewState: MapViewState): any {
+  const viewport = new WebMercatorViewport(viewState);
+  return {
+    type: 'Polygon',
+    coordinates: [
+      [
+        viewport.unproject([0, 0]),
+        viewport.unproject([viewport.width, 0]),
+        viewport.unproject([viewport.width, viewport.height]),
+        viewport.unproject([0, viewport.height]),
+        viewport.unproject([0, 0]),
+      ],
+    ],
+  };
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,16 +1,25 @@
-import { MapViewState, WebMercatorViewport } from "@deck.gl/core";
-import { Filter, FilterTypes } from "./vendor/deck-carto.js";
+import {MapViewState, WebMercatorViewport} from '@deck.gl/core';
+import {Filter, FilterTypes} from './vendor/deck-carto.js';
 
-export function sleep (ms: number) {
-  return new Promise((resolve) => setTimeout(resolve, ms))
+const FILTER_TYPES = new Set(Object.values(FilterTypes));
+
+export function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-export function getWidgetFilters(owner: string, allFilters?: Record<string, Filter>): Record<string, Filter> {
+export function getWidgetFilters(
+  owner: string,
+  allFilters?: Record<string, Filter>
+): Record<string, Filter> {
   if (!allFilters) return {};
+  if (!owner) return allFilters;
 
   const widgetFilters: Record<string, Filter> = {};
+
   for (const column in allFilters) {
-    for (const type in FilterTypes) {
+    for (const type in allFilters[column]) {
+      if (!FILTER_TYPES.has(type as FilterTypes)) continue;
+
       const filter = allFilters[column][type];
       if (filter && filter.owner !== owner) {
         widgetFilters[column] = allFilters[column];

--- a/src/widgets/category-widget.ts
+++ b/src/widgets/category-widget.ts
@@ -103,6 +103,8 @@ export class CategoryWidget extends LitElement {
       this.chart.on('click', ({name}) => this._toggleFilter(name));
     }
 
+    // TODO: If another widget overrides this widget's filters, what happens?
+
     this._updateChart();
   }
 

--- a/src/widgets/category-widget.ts
+++ b/src/widgets/category-widget.ts
@@ -14,7 +14,6 @@ import {
 } from './styles';
 import {cache} from 'lit/directives/cache.js';
 import {AggregationTypes} from '../vendor/carto-constants';
-import {CartoDataView} from '../data-view';
 
 type Category = {name: string; value: number};
 
@@ -57,8 +56,8 @@ export class CategoryWidget extends LitElement {
       const {dataView} = await data;
       const spatialFilter = viewState ? getSpatialFilter(viewState) : undefined;
 
-      // TODO: Pass widget ID for filter exclusions?
       return (await dataView.getCategories({
+        owner: this.widgetId,
         operation,
         column,
         spatialFilter,

--- a/src/widgets/formula-widget.ts
+++ b/src/widgets/formula-widget.ts
@@ -1,9 +1,8 @@
 import {LitElement, html, css} from 'lit';
 import {Task} from '@lit/task';
 import {customElement, property} from 'lit/decorators.js';
-import {CartoDataView} from '../data-view';
 import {DEBOUNCE_TIME_MS} from '../constants';
-import {sleep} from '../utils';
+import {getSpatialFilter, sleep} from '../utils';
 
 @customElement('formula-widget')
 export class FormulaWidget extends LitElement {
@@ -35,20 +34,28 @@ export class FormulaWidget extends LitElement {
   @property({type: String})
   caption = 'Formula widget';
 
-  @property({type: CartoDataView, attribute: false}) // TODO: DataView
-  dataView = null;
+  @property({type: Object, attribute: false}) // TODO: types
+  data = null;
 
   @property({type: Object, attribute: false}) // TODO: types
   config = null;
 
+  @property({type: Object, attribute: false}) // TODO: types
+  viewState = null;
+
   private _formulaTask = new Task(this, {
-    task: async ([dataView, config], {signal}) => {
+    task: async ([data, config, viewState], {signal}) => {
+      if (!data) return -1;
+
       await sleep(DEBOUNCE_TIME_MS);
       signal.throwIfAborted();
-      const response = await dataView.getFormula({...config}); // TODO: signal
+
+      const {dataView} = await data;
+      const spatialFilter = viewState ? getSpatialFilter(viewState) : undefined;
+      const response = await dataView.getFormula({...config, spatialFilter}); // TODO: signal
       return response.value as number;
     },
-    args: () => [this.dataView, this.config],
+    args: () => [this.data, this.config, this.viewState],
   });
 
   override render() {

--- a/src/widgets/formula-widget.ts
+++ b/src/widgets/formula-widget.ts
@@ -3,6 +3,7 @@ import {Task} from '@lit/task';
 import {customElement, property} from 'lit/decorators.js';
 import {DEBOUNCE_TIME_MS} from '../constants';
 import {getSpatialFilter, sleep} from '../utils';
+import { AggregationTypes } from '../vendor/carto-constants';
 
 @customElement('formula-widget')
 export class FormulaWidget extends LitElement {
@@ -37,14 +38,17 @@ export class FormulaWidget extends LitElement {
   @property({type: Object, attribute: false}) // TODO: types
   data = null;
 
-  @property({type: Object, attribute: false}) // TODO: types
-  config = null;
+  @property({type: AggregationTypes})
+  operation = AggregationTypes.COUNT;
+
+  @property({type: String})
+  column = '';
 
   @property({type: Object, attribute: false}) // TODO: types
   viewState = null;
 
   private _formulaTask = new Task(this, {
-    task: async ([data, config, viewState], {signal}) => {
+    task: async ([data, operation, column, viewState], {signal}) => {
       if (!data) return -1;
 
       await sleep(DEBOUNCE_TIME_MS);
@@ -52,10 +56,10 @@ export class FormulaWidget extends LitElement {
 
       const {dataView} = await data;
       const spatialFilter = viewState ? getSpatialFilter(viewState) : undefined;
-      const response = await dataView.getFormula({...config, spatialFilter}); // TODO: signal
+      const response = await dataView.getFormula({operation, column, spatialFilter}); // TODO: signal
       return response.value as number;
     },
-    args: () => [this.data, this.config, this.viewState],
+    args: () => [this.data, this.operation, this.column, this.viewState],
   });
 
   override render() {


### PR DESCRIPTION
Hides DataView objects as an internal implementation detail. Wraps `vectorTableSource` and other functions, returning data for the widget alongside data for the layer. Possibly that can be upstreamed into the actual source functions later.

Simplifies use of widgets considerably, and reduces API surface.

In the current branch, I've broken the behavior that allows widgets to exclude themselves from filters they 'own', but that shouldn't be a problem to restore soon.