### PR TITLE
feat: Infer clientId where possible

### DIFF
--- a/src/models/model.ts
+++ b/src/models/model.ts
@@ -67,7 +67,8 @@ export function executeModel(props: {
   );
 
   const {model, source, params, opts} = props;
-  const {type, apiVersion, apiBaseUrl, accessToken, connectionName} = source;
+  const {type, apiVersion, apiBaseUrl, accessToken, connectionName, clientId} =
+    source;
 
   assert(apiBaseUrl, 'executeModel: missing apiBaseUrl');
   assert(accessToken, 'executeModel: missing accessToken');
@@ -83,7 +84,7 @@ export function executeModel(props: {
 
   const queryParams: Record<string, string> = {
     type,
-    client: getClient(),
+    client: clientId,
     source: data,
     params: JSON.stringify(params),
     queryParameters,

--- a/src/sources/wrappers.ts
+++ b/src/sources/wrappers.ts
@@ -11,6 +11,7 @@ import {
   H3QuerySourceOptions as _H3QuerySourceOptions,
   QuadbinTableSourceOptions as _QuadbinTableSourceOptions,
   QuadbinQuerySourceOptions as _QuadbinQuerySourceOptions,
+  SourceOptions,
 } from '@deck.gl/carto';
 import {WidgetBaseSourceProps} from './widget-base-source.js';
 import {WidgetQuerySource} from './widget-query-source.js';
@@ -54,6 +55,7 @@ export type VectorQuerySourceOptions =
 export async function vectorTableSource(
   props: VectorTableSourceOptions
 ): Promise<VectorTableSourceResponse> {
+  assignDefaultProps(props);
   const response = await _vectorTableSource(props as _VectorTableSourceOptions);
   return {...response, widgetSource: new WidgetTableSource(props)};
 }
@@ -62,13 +64,9 @@ export async function vectorTableSource(
 export async function vectorQuerySource(
   props: VectorQuerySourceOptions
 ): Promise<VectorQuerySourceResponse> {
+  assignDefaultProps(props);
   const response = await _vectorQuerySource(props as _VectorQuerySourceOptions);
   return {...response, widgetSource: new WidgetQuerySource(props)};
-}
-
-/** Wrapper adding Widget API support to [vectorTilesetSource](https://deck.gl/docs/api-reference/carto/data-sources). */
-export async function vectorTilesetSource() {
-  throw new Error('not implemented');
 }
 
 /******************************************************************************
@@ -82,6 +80,7 @@ export type H3QuerySourceOptions = WrappedSourceOptions<_H3QuerySourceOptions>;
 export async function h3TableSource(
   props: H3TableSourceOptions
 ): Promise<H3TableSourceResponse> {
+  assignDefaultProps(props);
   const response = await _h3TableSource(props);
   return {...response, widgetSource: new WidgetTableSource(props)};
 }
@@ -90,13 +89,9 @@ export async function h3TableSource(
 export async function h3QuerySource(
   props: H3QuerySourceOptions
 ): Promise<H3QuerySourceResponse> {
+  assignDefaultProps(props);
   const response = await _h3QuerySource(props);
   return {...response, widgetSource: new WidgetQuerySource(props)};
-}
-
-/** Wrapper adding Widget API support to [h3TilesetSource](https://deck.gl/docs/api-reference/carto/data-sources). */
-export async function h3TilesetSource() {
-  throw new Error('not implemented');
 }
 
 /******************************************************************************
@@ -113,6 +108,7 @@ export type QuadbinQuerySourceOptions =
 export async function quadbinTableSource(
   props: QuadbinTableSourceOptions & WidgetBaseSourceProps
 ): Promise<QuadbinTableSourceResponse> {
+  assignDefaultProps(props);
   const response = await _quadbinTableSource(props);
   return {...response, widgetSource: new WidgetTableSource(props)};
 }
@@ -121,11 +117,21 @@ export async function quadbinTableSource(
 export async function quadbinQuerySource(
   props: QuadbinQuerySourceOptions & WidgetBaseSourceProps
 ): Promise<QuadbinQuerySourceResponse> {
+  assignDefaultProps(props);
   const response = await _quadbinQuerySource(props);
   return {...response, widgetSource: new WidgetQuerySource(props)};
 }
 
-/** Wrapper adding Widget API support to [quadbinTilesetSource](https://deck.gl/docs/api-reference/carto/data-sources). */
-export async function quadbinTilesetSource() {
-  throw new Error('not implemented');
+/******************************************************************************
+ * DEFAULT PROPS
+ */
+
+declare const deck: {VERSION?: string} | undefined;
+function assignDefaultProps<T extends SourceOptions>(props: T): void {
+  if (typeof deck !== 'undefined' && deck && deck.VERSION) {
+    props.clientId ||= 'deck-gl-carto';
+    // TODO: Uncomment if/when `@deck.gl/carto` devDependency is removed,
+    // and source functions are moved here rather than wrapped.
+    // props.deckglVersion ||= deck.VERSION;
+  }
 }

--- a/test/sources/wrappers.test.ts
+++ b/test/sources/wrappers.test.ts
@@ -2,13 +2,10 @@ import {afterEach, expect, test, vi} from 'vitest';
 import {
   vectorQuerySource,
   vectorTableSource,
-  vectorTilesetSource,
   h3QuerySource,
   h3TableSource,
-  h3TilesetSource,
   quadbinQuerySource,
   quadbinTableSource,
-  quadbinTilesetSource,
   WidgetQuerySource,
   WidgetTableSource,
 } from '@carto/api-client';
@@ -60,11 +57,6 @@ test('vectorTableSource', async () => {
   expect(widgetSource).toBeInstanceOf(WidgetTableSource);
 });
 
-test('vectorTilesetSource', async () => {
-  expect(vectorTilesetSource).toBeDefined();
-  expect(() => vectorTilesetSource()).rejects.toThrowError(/not implemented/i);
-});
-
 /******************************************************************************
  * H3 SOURCES
  */
@@ -95,11 +87,6 @@ test('h3TableSource', async () => {
   expect(widgetSource).toBeInstanceOf(WidgetTableSource);
 });
 
-test('h3TilesetSource', async () => {
-  expect(h3TilesetSource).toBeDefined();
-  expect(() => h3TilesetSource()).rejects.toThrowError(/not implemented/i);
-});
-
 /******************************************************************************
  * QUADBIN SOURCES
  */
@@ -128,9 +115,4 @@ test('quadbinTableSource', async () => {
   });
 
   expect(widgetSource).toBeInstanceOf(WidgetTableSource);
-});
-
-test('quadbinTilesetSource', async () => {
-  expect(quadbinTilesetSource).toBeDefined();
-  expect(() => quadbinTilesetSource()).rejects.toThrowError(/not implemented/i);
 });


### PR DESCRIPTION
Check for `deck.VERSION`, override default `clientId` when available.