### PR TITLE
chore(ci): Set up publish-by-pull-request workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,5 +54,6 @@ jobs:
     needs: build
     if: |
       github.ref == 'ref/head/main' &&
-      "contains(github.event.head_commit.message, 'chore(release)')"
+      github.event_name == 'push' &&
+      contains(github.event.head_commit.message, 'chore(release)')
     uses: ./.github/workflows/release.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,6 @@ jobs:
     name: 'Release (precheck)'
     needs: build
     if: |
-      {{ github.ref == 'ref/head/main' }} &&
+      github.ref == 'ref/head/main' &&
       "contains(github.event.head_commit.message, 'chore(release)')"
     uses: ./.github/workflows/release.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,47 +3,38 @@ name: CI
 on:
   push:
     branches: [main]
-    tags: ['*']
-
   pull_request:
     branches: [main]
 
+env:
+  CI: true
+
 jobs:
+  ##########################################################################
+  # Build
+  ##########################################################################
+
   build:
     name: Build [Node.js ${{ matrix.node-version }}]
     runs-on: ubuntu-22.04
 
     strategy:
       matrix:
-        include:
-          - node-version: 18.x
-            publish: false
-          - node-version: 20.x
-            publish: true # Publish on npm
-          - node-version: 22.x
-            publish: false
-
-    env:
-      CI: true
+        node-version: [18.x, 20.x, 22.x]
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      ##########################################################################
-      # Build
-      ##########################################################################
 
       - name: Set up Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
 
-      - name: Enable Corepack
-        run: corepack enable
-
       - name: Install
-        run: yarn install
+        run: |
+          corepack enable
+          yarn install
 
       - name: Lint
         run: yarn lint
@@ -54,56 +45,14 @@ jobs:
       - name: Test
         run: yarn test
 
-      ##########################################################################
-      # Publish
-      ##########################################################################
+  ##########################################################################
+  # Release precheck
+  ##########################################################################
 
-      - name: Check tag format
-        id: check-tag-format
-        if: startsWith(github.ref, 'refs/tags/') && matrix.publish
-        uses: nowsprinting/check-version-format-action@v4
-
-      - name: Exit on invalid tag format
-        if: startsWith(github.ref, 'refs/tags/') && !steps.check-tag-format.outputs.is_valid && matrix.publish
-        run: echo "Tag must follow SemVer convention. Aborting." && exit 1
-
-      - name: Get release type
-        if: startsWith(github.ref, 'refs/tags/') && matrix.publish
-        id: get-release-type
-        uses: actions/github-script@v7
-        with:
-          result-encoding: string
-          script: |
-            const regex = /(alpha|beta)/
-            const refName = context.ref.replace('refs/tags/', '')
-            console.log(`Ref tag: ${refName}`)
-            const releaseTypeMatch = refName.match(regex)
-            if (!releaseTypeMatch) {
-              releaseType = 'latest'
-            } else {
-              releaseType =  releaseTypeMatch[0]
-            }
-            console.log(`Release type: ${releaseType}`)
-            return releaseType
-
-      # TODO: Enable after reaching 1.0.0.
-      # This may indicate that the tag set has a typo, e.g., alpah, betta, etc.
-      # - name: Verify tag format
-      #   if: steps.check-tag-format.outputs.is_stable == 'false' && steps.get-release-type.outputs.result == 'latest'
-      #   run: echo "Tag set may be incorrect. Please, review" && exit 1
-
-      - name: Configure yarn to publish packages
-        if: startsWith(github.ref, 'refs/tags/') && matrix.publish
-        env:
-          # The following token has been manually issued in the CartoDB
-          # organization for npmjs.com
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_CARTODB_AUTH_TOKEN }}
-        run: |
-          yarn config set npmPublishRegistry "https://registry.npmjs.org/"
-          yarn config set npmAuthToken "${NODE_AUTH_TOKEN}"
-
-      - name: Publish package
-        if: startsWith(github.ref, 'refs/tags/') && matrix.publish
-        env:
-          RELEASE_TYPE: ${{ steps.get-release-type.outputs.result }}
-        run: yarn npm publish --tag ${RELEASE_TYPE}
+  release_precheck:
+    name: 'Release (precheck)'
+    needs: build
+    if: |
+      {{ github.ref == 'ref/head/main' }} &&
+      "contains(github.event.head_commit.message, 'chore(release)')"
+    uses: ./.github/workflows/release.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,79 @@
+name: Release
+
+on:
+  workflow_call:
+
+env:
+  NODE_VERSION: 20
+  CI: true
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-22.04
+
+    if: |
+      "contains(github.event.head_commit.message, 'chore(release)')" &&
+      startsWith(github.ref, 'refs/tags/')
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Load version from git tag
+        id: version
+        uses: nowsprinting/check-version-format-action@v4
+
+      - name: Validate version from git tag
+        if: steps.version.outputs.is_valid != 'true'
+        run: echo "Tag must follow SemVer convention. Aborting." && exit 1
+
+      - name: Set up Node.js ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Assign dist tag
+        id: dist-tag
+        uses: actions/github-script@v7
+        with:
+          result-encoding: string
+          script: |
+            console.log(`Ref tag: ${context.ref}`)
+            const refTagMatch = context.ref.match(/(alpha|beta)/)
+            if (!refTagMatch) {
+              distTag = 'latest'
+            } else {
+              distTag =  refTagMatch[0]
+            }
+            console.log(`npm dist tag: ${distTag}`)
+            return distTag
+
+      # TODO: Enable after reaching 1.0.0.
+      # This may indicate that the tag set has a typo ("alpah", etc.)
+      # - name: Validate parsed version
+      #   if: steps.version.outputs.is_stable == 'false' && steps.get-release-type.outputs.result == 'latest'
+      #   run: echo "Tag set may be incorrect. Please, review." && exit 1
+
+      - name: Install
+        run: |
+          corepack enable
+          yarn install
+
+      - name: Build
+        run: |
+          yarn lint
+          yarn build
+          yarn test
+
+      - name: Configure yarn to publish packages
+        env:
+          NPM_AUTH_TOKEN: ${{ secrets.NPM_CARTODB_AUTH_TOKEN }}
+        run: |
+          yarn config set npmPublishRegistry "https://registry.npmjs.org/"
+          yarn config set npmAuthToken "${NPM_AUTH_TOKEN}"
+
+      - name: Publish
+        env:
+          DIST_TAG: ${{ steps.dist-tag.outputs.result }}
+        run: yarn npm publish --tag ${DIST_TAG}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     if: |
-      "contains(github.event.head_commit.message, 'chore(release)')" &&
+      contains(github.event.head_commit.message, 'chore(release)') &&
       startsWith(github.ref, 'refs/tags/')
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,6 @@
 name: Release
 
-on:
-  workflow_call:
+on: [workflow_call, workflow_dispatch]
 
 env:
   NODE_VERSION: 20

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "clean": "rimraf build/*",
     "postversion": "yarn postversion:check && yarn postversion:commit && yarn postversion:push",
     "postversion:check": "yarn lint && yarn test",
-    "postversion:commit": "VERSION=v$npm_package_version && git add -u && git commit -m $VERSION && git tag -a $VERSION -m $VERSION",
+    "postversion:commit": "VERSION=v$npm_package_version && if [[ $(git rev-parse --abbrev-ref HEAD) == main ]]; then git checkout -b 'release/$VERSION'; fi && git add -u && git commit -m 'chore(release): $VERSION' && git tag -a $VERSION -m $VERSION",
     "postversion:push": "git push && git push --tags",
     "prepublish": "yarn lint && yarn test",
     "prepack": "yarn clean && yarn build"


### PR DESCRIPTION
Proposed release process:

1. Update changelog
2. Run `yarn version patch`
3. Run `yarn postversion`. If current branch is `main`, script creates a new branch (`release/$VERSION`) and pushes. Otherwise, script creates a new commit on the current branch and pushes.
4. If previous step created a new branch, then open a PR, get approval, and merge. Releases merged to `main` are published to npm automatically. Otherwise, trigger the workflow manually from the GitHub Actions panel.
