### PR TITLE
fix(deps): Avoid conflict between with version constants

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
     "node >= 18"
   ],
   "scripts": {
-    "build": "microbundle --format cjs,modern --no-compress --define VERSION=$npm_package_version",
-    "build:watch": "microbundle watch --format cjs,modern --no-compress --define VERSION=$npm_package_version",
+    "build": "microbundle --format cjs,modern --no-compress --define __CARTO_API_CLIENT_VERSION=$npm_package_version",
+    "build:watch": "microbundle watch --format cjs,modern --no-compress --define __CARTO_API_CLIENT_VERSION=$npm_package_version",
     "dev": "concurrently \"yarn build:watch\" \"vite --config examples/vite.config.ts --open\"",
     "test": "vitest run --typecheck",
     "test:watch": "vitest watch --typecheck",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,6 @@
+/** Current version of @carto/api-client. */
+export const API_CLIENT_VERSION = __CARTO_API_CLIENT_VERSION;
+
 /**
  * Defines a comparator used when matching a column's values against given filter values.
  *

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,0 +1,6 @@
+/**
+ * Injected by microbundle. The `@deck.gl/core` checkVersion()
+ * function will detect globally-defined 'VERSION' variables, and is inlined
+ * in the client bundle, so the 'VERSION' name should be avoided.
+ */
+declare const __CARTO_API_CLIENT_VERSION: string;

--- a/src/models/model.ts
+++ b/src/models/model.ts
@@ -1,4 +1,3 @@
-import {getClient} from '../client.js';
 import {
   ApiVersion,
   DEFAULT_GEO_COLUMN,


### PR DESCRIPTION
The "VERSION" constant injected in our build has a naming conflict with init.js from `@deck.gl/core` here:

https://github.com/visgl/deck.gl/blob/master/modules/core/src/lib/init.ts

To avoid the conflict, I've renamed the injected API client version as `__CARTO_API_CLIENT_VERSION`. It will be exported from the API client package separately.