### PR TITLE
fix(coverage): Exclude build/

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "dev": "concurrently \"yarn build:watch\" \"vite --config examples/vite.config.ts --open\"",
     "test": "vitest run --typecheck",
     "test:watch": "vitest watch --typecheck",
-    "coverage": "vitest run --coverage",
+    "coverage": "vitest run --coverage.enabled --coverage.all false",
     "lint": "prettier \"**/*.{cjs,html,js,json,md,ts}\" --ignore-path ./.eslintignore --check",
     "format": "prettier \"**/*.{cjs,html,js,json,md,ts}\" --ignore-path ./.eslintignore --write",
     "clean": "rimraf build/*",


### PR DESCRIPTION
Currently `yarn coverage` reports a large block of uncovered files in `build/` and `node_modules/`. As far as I can tell, this happens because tests execute the `build/` files, and use sourcemaps to assign coverage back to the source files. We bundle some source files from `node_modules/` (to be removed in #28 soon), and so certain files from `node_modules/@deck.gl/...` also end up in our coverage report.

Based on the configuration options listed at https://vitest.dev/guide/coverage, I would have thought `--coverage.exclude build` would be the way to fix this, but it seems to apply the exclusion before resolving sourcemaps, and so _no coverage_ is reported with that option. The best working option I've been able to find is `--coverage.all false` which simply does not report files with no coverage. All of the "real" source files have >0 coverage (excluding types-only files, which contain no runtime code), so this does not hide any source files from the report, but in theory it could.
