### PR TITLE
enable control of cache behavior for source and query APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Not released
+
+- add cache control mechanism for sources and query APIs
+
 ## 0.4
 
 ### 0.4.0

--- a/src/api/query.ts
+++ b/src/api/query.ts
@@ -23,6 +23,7 @@ export const query = async function (
     apiBaseUrl = SOURCE_DEFAULTS.apiBaseUrl,
     clientId = SOURCE_DEFAULTS.clientId,
     maxLengthURL = SOURCE_DEFAULTS.maxLengthURL,
+    localCache,
     connectionName,
     sqlQuery,
     queryParameters,
@@ -52,5 +53,6 @@ export const query = async function (
     headers,
     errorContext,
     maxLengthURL,
+    localCache,
   });
 };

--- a/src/api/request-with-parameters.ts
+++ b/src/api/request-with-parameters.ts
@@ -49,7 +49,7 @@ export async function requestWithParameters<T = any>({
     cache: REQUEST_CACHE,
     canReadCache,
     canStoreInCache,
-  } = getCacheSettings(localCache, customHeaders);
+  } = getCacheSettings(localCache);
 
   if (canReadCache && REQUEST_CACHE.has(key)) {
     return REQUEST_CACHE.get(key) as Promise<T>;
@@ -95,17 +95,13 @@ export async function requestWithParameters<T = any>({
   return jsonPromise;
 }
 
-function getCacheSettings(
-  localCache: LocalCacheOptions | undefined,
-  headers: Record<string, string>
-) {
-  const cacheControl = headers['Cache-Control'];
-  const canReadCache = localCache
-    ? localCache.canReadCache
-    : !cacheControl?.includes('no-cache');
-  const canStoreInCache = localCache
-    ? localCache.canStoreInCache
-    : !cacheControl?.includes('no-store');
+function getCacheSettings(localCache: LocalCacheOptions | undefined) {
+  const canReadCache = localCache?.cacheControl?.includes('no-cache')
+    ? false
+    : true;
+  const canStoreInCache = localCache?.cacheControl?.includes('no-store')
+    ? false
+    : true;
   const cache = localCache?.cache || DEFAULT_REQUEST_CACHE;
 
   return {

--- a/src/sources/base-source.ts
+++ b/src/sources/base-source.ts
@@ -45,7 +45,7 @@ export async function baseSource<UrlParameters extends Record<string, unknown>>(
     }
   }
   const baseUrl = buildSourceUrl(mergedOptions);
-  const {clientId, maxLengthURL, format} = mergedOptions;
+  const {clientId, maxLengthURL, format, localCache} = mergedOptions;
   const headers = {
     Authorization: `Bearer ${options.accessToken}`,
     ...options.headers,
@@ -65,6 +65,7 @@ export async function baseSource<UrlParameters extends Record<string, unknown>>(
       headers,
       errorContext,
       maxLengthURL,
+      localCache,
     });
 
   const dataUrl = mapInstantiation[format].url[0];
@@ -82,6 +83,7 @@ export async function baseSource<UrlParameters extends Record<string, unknown>>(
       headers,
       errorContext,
       maxLengthURL,
+      localCache,
     });
     if (accessToken) {
       json.accessToken = accessToken;
@@ -94,5 +96,6 @@ export async function baseSource<UrlParameters extends Record<string, unknown>>(
     headers,
     errorContext,
     maxLengthURL,
+    localCache,
   });
 }

--- a/src/sources/types.ts
+++ b/src/sources/types.ts
@@ -47,6 +47,24 @@ export type SourceOptionalOptions = {
    * @default {@link DEFAULT_MAX_LENGTH_URL}
    */
   maxLengthURL?: number;
+
+  /**
+   * Local cache options.
+   *  * `canReadCache`: If `true`, the source will try to read from the local memory cache.
+   *  * `canStoreInCache`: If `true`, the source will store the response in the local memory cache.
+   *  * `cache`: A map of promises that are used to store the responses.
+   *
+   * If not provided, source will try to detect `CacheControl: no-cache or no-store` headers in the response and disable respective caching modes.
+   *
+   * By default, local in-memory caching is enabled
+   */
+  localCache?: LocalCacheOptions;
+};
+
+export type LocalCacheOptions = {
+  canReadCache?: boolean;
+  canStoreInCache?: boolean;
+  cache?: Map<string, Promise<unknown>>;
 };
 
 export type SourceOptions = SourceRequiredOptions &

--- a/src/sources/types.ts
+++ b/src/sources/types.ts
@@ -49,22 +49,25 @@ export type SourceOptionalOptions = {
   maxLengthURL?: number;
 
   /**
-   * Local cache options.
-   *  * `canReadCache`: If `true`, the source will try to read from the local memory cache.
-   *  * `canStoreInCache`: If `true`, the source will store the response in the local memory cache.
-   *  * `cache`: A map of promises that are used to store the responses.
-   *
-   * If not provided, source will try to detect `CacheControl: no-cache or no-store` headers in the response and disable respective caching modes.
-   *
-   * By default, local in-memory caching is enabled
+   * By default, local in-memory caching is enabled.
    */
   localCache?: LocalCacheOptions;
 };
 
 export type LocalCacheOptions = {
-  canReadCache?: boolean;
-  canStoreInCache?: boolean;
+  /**
+   * Map that stores requests and their responses.
+   */
   cache?: Map<string, Promise<unknown>>;
+
+  /**
+   * Cache control
+   *  * `no-cache`: If present, the source will always fetch from original source.
+   *  * `no-store`: If present, source will not store result in cache (for later reuse).
+   *
+   * See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#directives
+   */
+  cacheControl?: ('no-cache' | 'no-store')[];
 };
 
 export type SourceOptions = SourceRequiredOptions &


### PR DESCRIPTION
Add cache control parameters to sources and `query` API.

* ~detect caching from HTTP headers.~
* allow selecting cache behavior as well as providing custom cache storage


Usage example:

```ts
  // for new users: will obey standard HTTP Control-Cache
  const myCache = new Map()
  const widgetSource = new vectorQuerySource({
    sqlQuery: 'select * from ...',
    // disable local cache, note browser and proxy cache can still cache something
    localCache: { cacheControl: 'no-cache' }
    // to completly prevent caching you must *also* set headers
    headers: { 'Cache-Control: no-cache' },
    // use specific map for cache cache
    localCache: { cache: myCache }
  });
  
  something.onClick() = {
    // clear cache before in context let's say - refresh action
    myCache.clear()
    rerenderLayers()
  }
```