### PR TITLE
chore(release): v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## 0.4
+
+### 0.4.0
+
+- feat: Add Picking Model API
+- refactor: Migrate sources from `@deck.gl/carto` to `@carto/api-client`
+- deps: Remove `@deck.gl/carto` bundled dependency
+
 ## 0.3
 
 ### 0.3.0

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "repository": "github:CartoDB/carto-api-client",
   "author": "Don McCurdy <donmccurdy@carto.com>",
   "packageManager": "yarn@4.3.1",
-  "version": "0.4.0-alpha.6",
+  "version": "0.4.0",
   "license": "MIT",
   "publishConfig": {
     "access": "public",
@@ -98,6 +98,5 @@
     "vite": "^5.2.10",
     "vitest": "1.6.0",
     "vue": "^3.4.27"
-  },
-  "stableVersion": "0.3.1"
+  }
 }


### PR DESCRIPTION
- feat: Add Picking Model API
- refactor: Migrate sources from `@deck.gl/carto` to `@carto/api-client`
- deps: Remove `@deck.gl/carto` bundled dependency