### PR TITLE
refactor(sources): Add *SourceResponse types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ export * from './client.js';
 export * from './constants.js';
 export * from './filters.js';
 export * from './geo.js';
+export * from './sources/index.js';
 export * from './widget-sources/index.js';
 export * from './types.js';
 
@@ -15,39 +16,3 @@ export {
   query,
   requestWithParameters,
 } from './api/index.js';
-
-export {
-  BoundaryQuerySourceOptions,
-  BoundaryTableSourceOptions,
-  GeojsonResult,
-  H3QuerySourceOptions,
-  H3TableSourceOptions,
-  H3TilesetSourceOptions,
-  JsonResult,
-  QuadbinQuerySourceOptions,
-  QuadbinTableSourceOptions,
-  QuadbinTilesetSourceOptions,
-  QueryResult,
-  QuerySourceOptions,
-  RasterSourceOptions,
-  SOURCE_DEFAULTS,
-  SourceOptions,
-  TableSourceOptions,
-  TilejsonResult,
-  TilesetSourceOptions,
-  VectorQuerySourceOptions,
-  VectorTableSourceOptions,
-  VectorTilesetSourceOptions,
-  boundaryQuerySource,
-  boundaryTableSource,
-  h3QuerySource,
-  h3TableSource,
-  h3TilesetSource,
-  quadbinQuerySource,
-  quadbinTableSource,
-  quadbinTilesetSource,
-  rasterSource,
-  vectorQuerySource,
-  vectorTableSource,
-  vectorTilesetSource,
-} from './sources/index.js';

--- a/src/sources/boundary-query-source.ts
+++ b/src/sources/boundary-query-source.ts
@@ -21,9 +21,11 @@ type UrlParameters = {
   queryParameters?: Record<string, unknown> | unknown[];
 };
 
+export type BoundaryQuerySourceResponse = TilejsonResult;
+
 export const boundaryQuerySource = async function (
   options: BoundaryQuerySourceOptions
-): Promise<TilejsonResult> {
+): Promise<BoundaryQuerySourceResponse> {
   const {
     columns,
     filters,
@@ -49,5 +51,5 @@ export const boundaryQuerySource = async function (
     'boundary',
     options,
     urlParameters
-  ) as Promise<TilejsonResult>;
+  ) as Promise<BoundaryQuerySourceResponse>;
 };

--- a/src/sources/boundary-table-source.ts
+++ b/src/sources/boundary-table-source.ts
@@ -18,9 +18,11 @@ type UrlParameters = {
   propertiesTableName: string;
 };
 
+export type BoundaryTableSourceResponse = TilejsonResult;
+
 export const boundaryTableSource = async function (
   options: BoundaryTableSourceOptions
-): Promise<TilejsonResult> {
+): Promise<BoundaryTableSourceResponse> {
   const {filters, tilesetTableName, columns, propertiesTableName} = options;
   const urlParameters: UrlParameters = {
     tilesetTableName,
@@ -37,5 +39,5 @@ export const boundaryTableSource = async function (
     'boundary',
     options,
     urlParameters
-  ) as Promise<TilejsonResult>;
+  ) as Promise<BoundaryTableSourceResponse>;
 };

--- a/src/sources/h3-query-source.ts
+++ b/src/sources/h3-query-source.ts
@@ -29,9 +29,11 @@ type UrlParameters = {
   filters?: Record<string, unknown>;
 };
 
+export type H3QuerySourceResponse = TilejsonResult & WidgetQuerySourceResult;
+
 export const h3QuerySource = async function (
   options: H3QuerySourceOptions
-): Promise<TilejsonResult & WidgetQuerySourceResult> {
+): Promise<H3QuerySourceResponse> {
   const {
     aggregationExp,
     aggregationResLevel = DEFAULT_AGGREGATION_RES_LEVEL_H3,

--- a/src/sources/h3-table-source.ts
+++ b/src/sources/h3-table-source.ts
@@ -29,9 +29,11 @@ type UrlParameters = {
   filters?: Record<string, unknown>;
 };
 
+export type H3TableSourceResponse = TilejsonResult & WidgetTableSourceResult;
+
 export const h3TableSource = async function (
   options: H3TableSourceOptions
-): Promise<TilejsonResult & WidgetTableSourceResult> {
+): Promise<H3TableSourceResponse> {
   const {
     aggregationExp,
     aggregationResLevel = DEFAULT_AGGREGATION_RES_LEVEL_H3,

--- a/src/sources/h3-tileset-source.ts
+++ b/src/sources/h3-tileset-source.ts
@@ -12,9 +12,11 @@ import type {
 export type H3TilesetSourceOptions = SourceOptions & TilesetSourceOptions;
 type UrlParameters = {name: string};
 
+export type H3TilesetSourceResponse = TilejsonResult;
+
 export const h3TilesetSource = async function (
   options: H3TilesetSourceOptions
-): Promise<TilejsonResult> {
+): Promise<H3TilesetSourceResponse> {
   const {tableName} = options;
   const urlParameters: UrlParameters = {name: tableName};
 
@@ -22,5 +24,5 @@ export const h3TilesetSource = async function (
     'tileset',
     options,
     urlParameters
-  ) as Promise<TilejsonResult>;
+  ) as Promise<H3TilesetSourceResponse>;
 };

--- a/src/sources/index.ts
+++ b/src/sources/index.ts
@@ -4,56 +4,86 @@
 
 export {SOURCE_DEFAULTS} from './base-source';
 export type {
-  VectorLayer,
-  RasterMetadataBandStats,
-  RasterBandColorinterp,
-  RasterMetadataBand,
-  RasterMetadata,
-  TilejsonResult,
   GeojsonResult,
   JsonResult,
   QueryResult,
+  QuerySourceOptions,
+  RasterBandColorinterp,
+  RasterMetadata,
+  RasterMetadataBand,
+  RasterMetadataBandStats,
+  SourceOptions,
+  TableSourceOptions,
+  TilejsonResult,
+  TilesetSourceOptions,
+  VectorLayer,
 } from './types';
 
 export {boundaryQuerySource} from './boundary-query-source';
-export type {BoundaryQuerySourceOptions} from './boundary-query-source';
+export type {
+  BoundaryQuerySourceOptions,
+  BoundaryQuerySourceResponse,
+} from './boundary-query-source';
 
 export {boundaryTableSource} from './boundary-table-source';
-export type {BoundaryTableSourceOptions} from './boundary-table-source';
+export type {
+  BoundaryTableSourceOptions,
+  BoundaryTableSourceResponse,
+} from './boundary-table-source';
 
 export {h3QuerySource} from './h3-query-source';
-export type {H3QuerySourceOptions} from './h3-query-source';
+export type {
+  H3QuerySourceOptions,
+  H3QuerySourceResponse,
+} from './h3-query-source';
 
 export {h3TableSource} from './h3-table-source';
-export type {H3TableSourceOptions} from './h3-table-source';
+export type {
+  H3TableSourceOptions,
+  H3TableSourceResponse,
+} from './h3-table-source';
 
 export {h3TilesetSource} from './h3-tileset-source';
-export type {H3TilesetSourceOptions} from './h3-tileset-source';
+export type {
+  H3TilesetSourceOptions,
+  H3TilesetSourceResponse,
+} from './h3-tileset-source';
 
 export {rasterSource} from './raster-source';
-export type {RasterSourceOptions} from './raster-source';
+export type {RasterSourceOptions, RasterSourceResponse} from './raster-source';
 
 export {quadbinQuerySource} from './quadbin-query-source';
-export type {QuadbinQuerySourceOptions} from './quadbin-query-source';
+export type {
+  QuadbinQuerySourceOptions,
+  QuadbinQuerySourceResponse,
+} from './quadbin-query-source';
 
 export {quadbinTableSource} from './quadbin-table-source';
-export type {QuadbinTableSourceOptions} from './quadbin-table-source';
+export type {
+  QuadbinTableSourceOptions,
+  QuadbinTableSourceResponse,
+} from './quadbin-table-source';
 
 export {quadbinTilesetSource} from './quadbin-tileset-source';
-export type {QuadbinTilesetSourceOptions} from './quadbin-tileset-source';
+export type {
+  QuadbinTilesetSourceOptions,
+  QuadbinTilesetSourceResponse,
+} from './quadbin-tileset-source';
 
 export {vectorQuerySource} from './vector-query-source';
-export type {VectorQuerySourceOptions} from './vector-query-source';
+export type {
+  VectorQuerySourceOptions,
+  VectorQuerySourceResponse,
+} from './vector-query-source';
 
 export {vectorTableSource} from './vector-table-source';
-export type {VectorTableSourceOptions} from './vector-table-source';
+export type {
+  VectorTableSourceOptions,
+  VectorTableSourceResponse,
+} from './vector-table-source';
 
 export {vectorTilesetSource} from './vector-tileset-source';
-export type {VectorTilesetSourceOptions} from './vector-tileset-source';
-
 export type {
-  SourceOptions,
-  QuerySourceOptions,
-  TableSourceOptions,
-  TilesetSourceOptions,
-} from './types';
+  VectorTilesetSourceOptions,
+  VectorTilesetSourceResponse,
+} from './vector-tileset-source';

--- a/src/sources/quadbin-query-source.ts
+++ b/src/sources/quadbin-query-source.ts
@@ -30,9 +30,12 @@ type UrlParameters = {
   filters?: Record<string, unknown>;
 };
 
+export type QuadbinQuerySourceResponse = TilejsonResult &
+  WidgetQuerySourceResult;
+
 export const quadbinQuerySource = async function (
   options: QuadbinQuerySourceOptions
-): Promise<TilejsonResult & WidgetQuerySourceResult> {
+): Promise<QuadbinQuerySourceResponse> {
   const {
     aggregationExp,
     aggregationResLevel = DEFAULT_AGGREGATION_RES_LEVEL_QUADBIN,

--- a/src/sources/quadbin-table-source.ts
+++ b/src/sources/quadbin-table-source.ts
@@ -29,9 +29,12 @@ type UrlParameters = {
   filters?: Record<string, unknown>;
 };
 
+export type QuadbinTableSourceResponse = TilejsonResult &
+  WidgetTableSourceResult;
+
 export const quadbinTableSource = async function (
   options: QuadbinTableSourceOptions
-): Promise<TilejsonResult & WidgetTableSourceResult> {
+): Promise<QuadbinTableSourceResponse> {
   const {
     aggregationExp,
     aggregationResLevel = DEFAULT_AGGREGATION_RES_LEVEL_QUADBIN,

--- a/src/sources/quadbin-tileset-source.ts
+++ b/src/sources/quadbin-tileset-source.ts
@@ -12,9 +12,11 @@ import type {
 export type QuadbinTilesetSourceOptions = SourceOptions & TilesetSourceOptions;
 type UrlParameters = {name: string};
 
+export type QuadbinTilesetSourceResponse = TilejsonResult;
+
 export const quadbinTilesetSource = async function (
   options: QuadbinTilesetSourceOptions
-): Promise<TilejsonResult> {
+): Promise<QuadbinTilesetSourceResponse> {
   const {tableName} = options;
   const urlParameters: UrlParameters = {name: tableName};
 
@@ -22,5 +24,5 @@ export const quadbinTilesetSource = async function (
     'tileset',
     options,
     urlParameters
-  ) as Promise<TilejsonResult>;
+  ) as Promise<QuadbinTilesetSourceResponse>;
 };

--- a/src/sources/raster-source.ts
+++ b/src/sources/raster-source.ts
@@ -18,9 +18,11 @@ type UrlParameters = {
   filters?: Record<string, unknown>;
 };
 
+export type RasterSourceResponse = TilejsonResult;
+
 export const rasterSource = async function (
   options: RasterSourceOptions
-): Promise<TilejsonResult> {
+): Promise<RasterSourceResponse> {
   const {tableName, filters} = options;
   const urlParameters: UrlParameters = {name: tableName};
   if (filters) {
@@ -30,5 +32,5 @@ export const rasterSource = async function (
     'raster',
     options,
     urlParameters
-  ) as Promise<TilejsonResult>;
+  ) as Promise<RasterSourceResponse>;
 };

--- a/src/sources/vector-query-source.ts
+++ b/src/sources/vector-query-source.ts
@@ -33,9 +33,12 @@ type UrlParameters = {
   queryParameters?: Record<string, unknown> | unknown[];
 };
 
+export type VectorQuerySourceResponse = TilejsonResult &
+  WidgetQuerySourceResult;
+
 export const vectorQuerySource = async function (
   options: VectorQuerySourceOptions
-): Promise<TilejsonResult & WidgetQuerySourceResult> {
+): Promise<VectorQuerySourceResponse> {
   const {
     columns,
     filters,

--- a/src/sources/vector-table-source.ts
+++ b/src/sources/vector-table-source.ts
@@ -31,9 +31,12 @@ type UrlParameters = {
   name: string;
 };
 
+export type VectorTableSourceResponse = TilejsonResult &
+  WidgetTableSourceResult;
+
 export const vectorTableSource = async function (
   options: VectorTableSourceOptions
-): Promise<TilejsonResult & WidgetTableSourceResult> {
+): Promise<VectorTableSourceResponse> {
   const {
     columns,
     filters,

--- a/src/sources/vector-tileset-source.ts
+++ b/src/sources/vector-tileset-source.ts
@@ -12,9 +12,11 @@ import type {
 export type VectorTilesetSourceOptions = SourceOptions & TilesetSourceOptions;
 type UrlParameters = {name: string};
 
+export type VectorTilesetSourceResponse = TilejsonResult;
+
 export const vectorTilesetSource = async function (
   options: VectorTilesetSourceOptions
-): Promise<TilejsonResult> {
+): Promise<VectorTilesetSourceResponse> {
   const {tableName} = options;
   const urlParameters: UrlParameters = {name: tableName};
 
@@ -22,5 +24,5 @@ export const vectorTilesetSource = async function (
     'tileset',
     options,
     urlParameters
-  ) as Promise<TilejsonResult>;
+  ) as Promise<VectorTilesetSourceResponse>;
 };


### PR DESCRIPTION
Adds types for the responses of source functions. Mainly this disambiguates which `WidgetSource` object will be returned, the other properties are just common Tilejson. We may want to separate those two, not to be returned by the same function, but for now they are and it would be helpful to have types.