### PR TITLE
chore(deps): Pin Rollup v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "@luma.gl/core": "^9.0.27",
     "@luma.gl/engine": "^9.0.27",
     "@types/json-schema": "^7.0.15",
+    "@types/react": "^18.3.18",
     "@types/semver": "^7.5.8",
     "@vitest/coverage-istanbul": "^1.6.0",
     "@webcomponents/webcomponentsjs": "^2.8.0",
@@ -88,5 +89,8 @@
     "typescript": "~5.3.3",
     "vite": "^5.2.10",
     "vitest": "1.6.0"
+  },
+  "resolutions": {
+    "rollup": "^4.20.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1467,6 +1467,7 @@ __metadata:
     "@turf/union": "npm:^7.1.0"
     "@types/geojson": "npm:^7946.0.14"
     "@types/json-schema": "npm:^7.0.15"
+    "@types/react": "npm:^18.3.18"
     "@types/semver": "npm:^7.5.8"
     "@vitest/coverage-istanbul": "npm:^1.6.0"
     "@webcomponents/webcomponentsjs": "npm:^2.8.0"
@@ -3056,6 +3057,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/prop-types@npm:*":
+  version: 15.7.14
+  resolution: "@types/prop-types@npm:15.7.14"
+  checksum: 10c0/1ec775160bfab90b67a782d735952158c7e702ca4502968aa82565bd8e452c2de8601c8dfe349733073c31179116cf7340710160d3836aa8a1ef76d1532893b1
+  languageName: node
+  linkType: hard
+
+"@types/react@npm:^18.3.18":
+  version: 18.3.18
+  resolution: "@types/react@npm:18.3.18"
+  dependencies:
+    "@types/prop-types": "npm:*"
+    csstype: "npm:^3.0.2"
+  checksum: 10c0/8fb2b00672072135d0858dc9db07873ea107cc238b6228aaa2a9afd1ef7a64a7074078250db38afbeb19064be8ea6af5eac32d404efdd5f45e093cc4829d87f8
+  languageName: node
+  linkType: hard
+
 "@types/resolve@npm:1.17.1":
   version: 1.17.1
   resolution: "@types/resolve@npm:1.17.1"
@@ -4145,6 +4163,13 @@ __metadata:
   dependencies:
     css-tree: "npm:^1.1.2"
   checksum: 10c0/f8c6b1300efaa0f8855a7905ae3794a29c6496e7f16a71dec31eb6ca7cfb1f058a4b03fd39b66c4deac6cb06bf6b4ba86da7b67d7320389cb9994d52b924b903
+  languageName: node
+  linkType: hard
+
+"csstype@npm:^3.0.2":
+  version: 3.1.3
+  resolution: "csstype@npm:3.1.3"
+  checksum: 10c0/80c089d6f7e0c5b2bd83cf0539ab41474198579584fa10d86d0cafe0642202343cbc119e076a0b1aece191989477081415d66c9fefbf3c957fc2fc4b7009f248
   languageName: node
   linkType: hard
 
@@ -8200,20 +8225,6 @@ __metadata:
   dependencies:
     estree-walker: "npm:^0.6.1"
   checksum: 10c0/20947bec5a5dd68b5c5c8423911e6e7c0ad834c451f1a929b1f4e2bc08836ad3f1a722ef2bfcbeca921870a0a283f13f064a317dc7a6768496e98c9a641ba290
-  languageName: node
-  linkType: hard
-
-"rollup@npm:^2.35.1":
-  version: 2.79.1
-  resolution: "rollup@npm:2.79.1"
-  dependencies:
-    fsevents: "npm:~2.3.2"
-  dependenciesMeta:
-    fsevents:
-      optional: true
-  bin:
-    rollup: dist/bin/rollup
-  checksum: 10c0/421418687f5dcd7324f4387f203c6bfc7118b7ace789e30f5da022471c43e037a76f5fd93837052754eeeae798a4fb266ac05ccee1e594406d912a59af98dde9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Pins rollup v4 to resolutions. Previously Vite was using v4 (examples, local testing) but microbundle was using v2 (library builds). I tried switching over entirely to Vite, using Vite's [Library Mode](https://vite.dev/guide/build#library-mode) for the library builds (https://github.com/CartoDB/carto-api-client/pull/60) but — as awesome as Vite is for building applications! — it seems really finicky for building libraries, I needed a lot of unexpected configuration just to get things working, and even then I couldn't get the sourcemaps or code coverage working.

It looks like Microbundle is already working on an update for Rollup, so I'd rather keep using that for now. We can remove the pinned resolution after the next Microbundle update, I'm tracking these issues:

- https://github.com/developit/microbundle/pull/1081
- https://github.com/developit/microbundle/pull/1082
- https://github.com/developit/microbundle/pull/1083