### PR TITLE
feat: Export getHexagonResolution helper

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,4 +17,4 @@ export {
   requestWithParameters,
 } from './api/index.js';
 
-export {getHexagonResolution} from './spatial-index.js';
+export {_getHexagonResolution} from './spatial-index.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,3 +16,5 @@ export {
   query,
   requestWithParameters,
 } from './api/index.js';
+
+export {getHexagonResolution} from './spatial-index.js';

--- a/src/spatial-index.ts
+++ b/src/spatial-index.ts
@@ -40,7 +40,7 @@ export function getSpatialFiltersResolution(
       : dataResolution;
 
     const hexagonResolution =
-      getHexagonResolution(viewState, tileSize) + aggregationResLevelOffset;
+      _getHexagonResolution(viewState, tileSize) + aggregationResLevelOffset;
 
     return Math.min(hexagonResolution, maxSpatialFiltersResolution);
   }
@@ -88,10 +88,13 @@ const maxH3SpatialFiltersResolutions = [
 // Relative scale factor (0 = no biasing, 2 = a few hexagons cover view)
 const BIAS = 2;
 
-// Resolution conversion function. Takes a WebMercatorViewport and returns
-// a H3 resolution such that the screen space size of the hexagons is
-// similar
-export function getHexagonResolution(
+/**
+ * Resolution conversion function. Takes a WebMercatorViewport and returns
+ * a H3 resolution such that the screen space size of the hexagons is
+ * "similar" to the given tileSize on screen. Intended for use with deck.gl.
+ * @internal
+ */
+export function _getHexagonResolution(
   viewport: {zoom: number; latitude: number},
   tileSize: number
 ): number {

--- a/test/spatial-index.test.ts
+++ b/test/spatial-index.test.ts
@@ -1,0 +1,21 @@
+import {describe, expect, test} from 'vitest';
+import {getHexagonResolution} from '@carto/api-client';
+
+describe('getHexagonResolution', () => {
+  test.each([
+    // latitude
+    [{zoom: 10, latitude: 89, tileSize: 512}, 8],
+    [{zoom: 10, latitude: 45, tileSize: 512}, 5],
+    [{zoom: 10, latitude: 0, tileSize: 512}, 4],
+    // zoom
+    [{zoom: 4, latitude: 0, tileSize: 512}, 0],
+    [{zoom: 8, latitude: 0, tileSize: 512}, 3],
+    [{zoom: 12, latitude: 0, tileSize: 512}, 6],
+    // tileSize
+    [{zoom: 8, latitude: 0, tileSize: 256}, 4],
+    [{zoom: 8, latitude: 0, tileSize: 512}, 3],
+    [{zoom: 8, latitude: 0, tileSize: 1024}, 2],
+  ])('%s -> %i', ({zoom, latitude, tileSize}, expected) => {
+    expect(getHexagonResolution({zoom, latitude}, tileSize)).toBe(expected);
+  });
+});

--- a/test/spatial-index.test.ts
+++ b/test/spatial-index.test.ts
@@ -1,7 +1,7 @@
 import {describe, expect, test} from 'vitest';
-import {getHexagonResolution} from '@carto/api-client';
+import {_getHexagonResolution} from '@carto/api-client';
 
-describe('getHexagonResolution', () => {
+describe('_getHexagonResolution', () => {
   test.each([
     // latitude
     [{zoom: 10, latitude: 89, tileSize: 512}, 8],
@@ -16,6 +16,6 @@ describe('getHexagonResolution', () => {
     [{zoom: 8, latitude: 0, tileSize: 512}, 3],
     [{zoom: 8, latitude: 0, tileSize: 1024}, 2],
   ])('%s -> %i', ({zoom, latitude, tileSize}, expected) => {
-    expect(getHexagonResolution({zoom, latitude}, tileSize)).toBe(expected);
+    expect(_getHexagonResolution({zoom, latitude}, tileSize)).toBe(expected);
   });
 });


### PR DESCRIPTION
This is subjective (there is no "right" choice of hexagon resolution for a given map viewport) but we do want to be consistent and it seems that we need this function in multiple places, so I'm including the export here.