### PR TITLE
feat(rasters): Support widget calculations on rasters

### DIFF
--- a/examples/05-raster/app.ts
+++ b/examples/05-raster/app.ts
@@ -67,6 +67,10 @@ await updateSources();
  */
 
 async function updateSources() {
+  if (data?.widgetSource) {
+    data.widgetSource.destroy();
+  }
+
   data = await rasterSource({
     connectionName: 'amanzanares-bq',
     tableName: 'cartodb-on-gcp-pm-team.amanzanares_raster.classification_us',

--- a/examples/05-raster/app.ts
+++ b/examples/05-raster/app.ts
@@ -1,0 +1,140 @@
+import maplibregl from 'maplibre-gl';
+import {Color, Deck} from '@deck.gl/core';
+import {RasterTileLayer} from '@deck.gl/carto';
+import {
+  rasterSource,
+  TilejsonResult,
+  WidgetRasterSource,
+} from '@carto/api-client';
+import '../components/index.js';
+import type {
+  Widget,
+  CategoryWidget,
+  HistogramWidget,
+} from '../components/index.js';
+
+/**************************************************************************
+ * REACTIVE STATE
+ */
+
+let data: TilejsonResult & {widgetSource: WidgetRasterSource};
+let viewState = {latitude: 42.728, longitude: -87.731, zoom: 8.75};
+
+const _getFillColor = (value: number): Color => {
+  if (value === 0) {
+    return [0, 0, 0, 0];
+  } else if (value < 64) {
+    return [255, 0, 0, 255];
+  } else if (value < 128) {
+    return [0, 255, 0, 255];
+  } else if (value < 192) {
+    return [0, 0, 255, 255];
+  } else {
+    return [0, 255, 255, 255];
+  }
+};
+const getFillColorLayer = (d: any): Color => _getFillColor(d.properties.band_1);
+const getFillColorCSS = (item: string | number): string =>
+  `rgba(${_getFillColor(Number(item)).join()})`;
+
+/**************************************************************************
+ * DECK.GL
+ */
+
+const deck = new Deck({
+  canvas: 'deck-canvas',
+  initialViewState: viewState,
+  controller: true,
+  layers: [],
+});
+
+const map = new maplibregl.Map({
+  container: 'map',
+  style:
+    'https://basemaps.cartocdn.com/gl/positron-nolabels-gl-style/style.json',
+  interactive: false,
+});
+
+const formulaWidget = bindWidget('#formula');
+const categoryWidget = bindWidget('#category') as CategoryWidget;
+const histogramWidget = bindWidget('#histogram') as HistogramWidget;
+const widgets: Widget[] = [formulaWidget, categoryWidget, histogramWidget];
+
+await updateSources();
+
+/**************************************************************************
+ * UPDATES
+ */
+
+async function updateSources() {
+  data = await rasterSource({
+    connectionName: 'amanzanares-bq',
+    tableName: 'cartodb-on-gcp-pm-team.amanzanares_raster.classification_us',
+    accessToken:
+      'eyJhbGciOiJIUzI1NiJ9.eyJhIjoiYWNfNDd1dW5tZWciLCJqdGkiOiI1Njc2MDQ0NCJ9.p2_1ts1plciXMI3Pk0GJaHjhdZUd0lKITgdO9BaX2ho',
+  });
+
+  document.querySelector('#footer')!.innerHTML = data.attribution;
+
+  updateLayers();
+}
+
+function updateLayers() {
+  const layer = new RasterTileLayer({
+    id: 'raster',
+    data: data,
+    tileSize: 1024,
+    getFillColor: getFillColorLayer,
+    onViewportLoad: updateTiles,
+  });
+
+  deck.setProps({layers: [layer]});
+}
+
+function updateTiles(tiles: unknown[]) {
+  data.widgetSource.loadTiles(tiles);
+  updateWidgetsDebounced();
+}
+
+function updateWidgets() {
+  for (const widget of widgets) {
+    widget.data = Promise.resolve(data);
+    widget.viewState = viewState;
+  }
+  categoryWidget.getItemColor = getFillColorCSS;
+  histogramWidget.getItemColor = getFillColorCSS;
+}
+
+const updateWidgetsDebounced = debounce(updateWidgets, 200);
+
+/**************************************************************************
+ * INITIALIZATION
+ */
+
+deck.setProps({
+  onViewStateChange: (params) => {
+    viewState = params.viewState;
+    const {longitude, latitude, ...rest} = viewState;
+    map.jumpTo({center: [longitude, latitude], ...rest});
+    updateWidgetsDebounced();
+  },
+});
+
+function bindWidget(selector: string): Widget {
+  return document.querySelector<Widget>(selector)!;
+}
+
+/**************************************************************************
+ * UTILS
+ */
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+function debounce<T extends Function>(callback: T, ms: number): T {
+  let timeoutID: number = -1;
+  return ((...args: unknown[]) => {
+    window.clearTimeout(timeoutID);
+    timeoutID = window.setTimeout(() => {
+      callback(...args);
+    }, ms);
+  }) as unknown as T;
+}

--- a/examples/05-raster/index.html
+++ b/examples/05-raster/index.html
@@ -1,0 +1,43 @@
+<!doctype html>
+<html lang="en-US">
+  <head>
+    <meta charset="utf-8" />
+    <title>Examples / Raster</title>
+    <link rel="stylesheet" href="../style.css" />
+  </head>
+  <body>
+    <main id="app">
+      <header>
+        <h1>Raster</h1>
+        <a href="../">← Back</a>
+      </header>
+      <section id="view">
+        <div id="map"></div>
+        <canvas id="deck-canvas"></canvas>
+      </section>
+      <section id="rail">
+        <formula-widget
+          id="formula"
+          header="Cells"
+          operation="count"
+        ></formula-widget>
+
+        <histogram-widget
+          id="histogram"
+          header="Distribution"
+          column="band_1"
+          ticks="[0, 1, 64, 128, 192, 256]"
+        ></histogram-widget>
+
+        <category-widget
+          id="category"
+          header="Frequent values"
+          operation="count"
+          column="band_1"
+        ></category-widget>
+      </section>
+      <footer id="footer"></footer>
+    </main>
+    <script type="module" src="./app.ts"></script>
+  </body>
+</html>

--- a/examples/components/widgets/category-widget.ts
+++ b/examples/components/widgets/category-widget.ts
@@ -3,7 +3,13 @@ import {Task, TaskStatus} from '@lit/task';
 import {Ref, createRef, ref} from 'lit/directives/ref.js';
 import {cache} from 'lit/directives/cache.js';
 import * as echarts from 'echarts';
-import {Filter, FilterType, addFilter, removeFilter} from '@carto/api-client';
+import {
+  CategoryResponse,
+  Filter,
+  FilterType,
+  addFilter,
+  removeFilter,
+} from '@carto/api-client';
 
 import {DEFAULT_PALETTE, DEFAULT_TEXT_STYLE} from './styles.js';
 import {DEBOUNCE_TIME_MS} from '../constants.js';
@@ -27,12 +33,14 @@ export class CategoryWidget extends BaseWidget {
       ...super.properties,
       operation: {type: String},
       column: {type: String},
+      getItemColor: {type: Function, attribute: false},
       _filterValues: {state: true},
     };
   }
 
   declare column: string;
   declare operation: 'count' | 'avg' | 'min' | 'max' | 'sum';
+  declare getItemColor?: (item: string | number) => string;
 
   protected _chart: echarts.ECharts | null = null;
   protected _chartRef: Ref<HTMLElement> = createRef();
@@ -54,13 +62,13 @@ export class CategoryWidget extends BaseWidget {
 
       const {widgetSource} = await data;
 
-      return await widgetSource.getCategories({
+      return (await widgetSource.getCategories({
         filterOwner: this._widgetId,
         spatialFilter: this.getSpatialFilterOrViewState(),
         operation,
         column,
         spatialIndexReferenceViewState: this.viewState ?? undefined,
-      });
+      })) as CategoryResponse;
     },
     args: () =>
       [
@@ -161,10 +169,14 @@ export class CategoryWidget extends BaseWidget {
       .sort((a: Category, b: Category) => (a.value > b.value ? -1 : 1));
 
     const data = categories.map(({name, value}: Category, index: number) => {
-      let color = DEFAULT_PALETTE[index % DEFAULT_PALETTE.length];
+      let color = this.getItemColor
+        ? this.getItemColor(name)
+        : DEFAULT_PALETTE[index % DEFAULT_PALETTE.length];
+
       if (this._filterValues.length > 0) {
         color = this._filterValues.includes(name) ? color : '#cccccc';
       }
+
       return {value, name, itemStyle: {color}};
     });
 

--- a/examples/components/widgets/category-widget.ts
+++ b/examples/components/widgets/category-widget.ts
@@ -62,13 +62,13 @@ export class CategoryWidget extends BaseWidget {
 
       const {widgetSource} = await data;
 
-      return (await widgetSource.getCategories({
+      return await widgetSource.getCategories({
         filterOwner: this._widgetId,
         spatialFilter: this.getSpatialFilterOrViewState(),
         operation,
         column,
         spatialIndexReferenceViewState: this.viewState ?? undefined,
-      })) as CategoryResponse;
+      });
     },
     args: () =>
       [

--- a/examples/components/widgets/histogram-widget.ts
+++ b/examples/components/widgets/histogram-widget.ts
@@ -9,6 +9,7 @@ import {DEBOUNCE_TIME_MS} from '../constants.js';
 import {sleep} from '../utils.js';
 import {DEFAULT_TEXT_STYLE} from './styles.js';
 import {BaseWidget} from './base-widget.js';
+import {HistogramResponse} from '@carto/api-client';
 
 const DEFAULT_HISTOGRAM_GRID = {
   left: 0,
@@ -26,12 +27,14 @@ export class HistogramWidget extends BaseWidget {
       column: {type: String},
       operation: {type: String},
       ticks: {type: Array},
+      getItemColor: {type: Function, attribute: false},
     };
   }
 
   declare column: string;
   declare operation: 'count' | 'avg' | 'min' | 'max' | 'sum';
   declare ticks: number[];
+  declare getItemColor?: (item: string | number) => string;
 
   protected _chart: echarts.ECharts | null = null;
   protected _chartRef: Ref<HTMLElement> = createRef();
@@ -52,14 +55,14 @@ export class HistogramWidget extends BaseWidget {
 
       const {widgetSource} = await data;
 
-      return await widgetSource.getHistogram({
+      return (await widgetSource.getHistogram({
         filterOwner: this._widgetId,
         spatialFilter: this.getSpatialFilterOrViewState(),
         column,
         operation,
         ticks,
         spatialIndexReferenceViewState: this.viewState ?? undefined,
-      });
+      })) as HistogramResponse;
     },
     args: () =>
       [
@@ -115,6 +118,9 @@ export class HistogramWidget extends BaseWidget {
     const data = values.map((value: number, binIndex: number) => ({
       name: getTickLabel(binIndex, this.ticks),
       value,
+      ...(this.getItemColor && {
+        itemStyle: {color: this.getItemColor(this.ticks[binIndex - 1])},
+      }),
     }));
 
     this._chart!.setOption({

--- a/examples/components/widgets/histogram-widget.ts
+++ b/examples/components/widgets/histogram-widget.ts
@@ -55,14 +55,14 @@ export class HistogramWidget extends BaseWidget {
 
       const {widgetSource} = await data;
 
-      return (await widgetSource.getHistogram({
+      return await widgetSource.getHistogram({
         filterOwner: this._widgetId,
         spatialFilter: this.getSpatialFilterOrViewState(),
         column,
         operation,
         ticks,
         spatialIndexReferenceViewState: this.viewState ?? undefined,
-      })) as HistogramResponse;
+      });
     },
     args: () =>
       [

--- a/examples/index.html
+++ b/examples/index.html
@@ -20,6 +20,9 @@
       <li>
         <a href="/04-tileset-h3/index.html">tileset - H3</a>
       </li>
+      <li>
+        <a href="/05-raster/index.html">raster</a>
+      </li>
     </ol>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -73,7 +73,8 @@
     "@turf/invariant": "^7.2.0",
     "@turf/union": "^7.2.0",
     "@types/geojson": "^7946.0.16",
-    "h3-js": "4.1.0"
+    "h3-js": "4.1.0",
+    "quadbin": "^0.4.0-alpha.2"
   },
   "devDependencies": {
     "@deck.gl/aggregation-layers": "~9.1.4",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "format:check": "prettier \"**/*.{cjs,html,js,json,md,ts}\" --check",
     "clean": "rimraf build/*",
     "postversion": "yarn postversion:check && yarn postversion:commit && yarn postversion:push",
-    "postversion:check": "yarn lint && yarn test",
+    "postversion:check": "yarn lint && yarn format:check && yarn test",
     "postversion:commit": "node scripts/postversion-commit.js",
     "postversion:push": "git push && git push --tags",
     "prepublish": "yarn lint && yarn test",

--- a/src/filters/tileFeatures.ts
+++ b/src/filters/tileFeatures.ts
@@ -1,10 +1,12 @@
-import {SpatialFilter, SpatialIndexTile, Tile} from '../types.js';
+import {RasterTile, SpatialFilter, SpatialIndexTile, Tile} from '../types.js';
 import {tileFeaturesGeometries} from './tileFeaturesGeometries.js';
 import {tileFeaturesSpatialIndex} from './tileFeaturesSpatialIndex.js';
 import {TileFormat} from '../constants.js';
 import {DEFAULT_GEO_COLUMN} from '../constants-internal.js';
 import {FeatureData} from '../types-internal.js';
-import {SpatialDataType} from '../sources/types.js';
+import {RasterMetadata, SpatialDataType} from '../sources/types.js';
+import {isRasterTile, tileFeaturesRaster} from './tileFeaturesRaster.js';
+import {assert} from '../utils.js';
 
 /** @privateRemarks Source: @carto/react-core */
 export type TileFeatures = {
@@ -14,6 +16,7 @@ export type TileFeatures = {
   spatialDataColumn?: string;
   spatialFilter: SpatialFilter;
   uniqueIdProperty?: string;
+  rasterMetadata?: RasterMetadata;
   options?: TileFeatureExtractOptions;
 };
 
@@ -31,21 +34,34 @@ export function tileFeatures({
   tileFormat,
   spatialDataColumn = DEFAULT_GEO_COLUMN,
   spatialDataType,
+  rasterMetadata,
   options = {},
 }: TileFeatures): FeatureData[] {
-  if (spatialDataType !== 'geo') {
-    return tileFeaturesSpatialIndex({
-      tiles: tiles as SpatialIndexTile[],
+  if (spatialDataType === 'geo') {
+    return tileFeaturesGeometries({
+      tiles,
+      tileFormat,
+      spatialFilter,
+      uniqueIdProperty,
+      options,
+    });
+  }
+
+  if (tiles.some(isRasterTile)) {
+    assert(rasterMetadata, 'Missing raster metadata');
+    return tileFeaturesRaster({
+      tiles: tiles as RasterTile[],
       spatialFilter,
       spatialDataColumn,
       spatialDataType,
+      rasterMetadata,
     });
   }
-  return tileFeaturesGeometries({
-    tiles,
-    tileFormat,
+
+  return tileFeaturesSpatialIndex({
+    tiles: tiles as SpatialIndexTile[],
     spatialFilter,
-    uniqueIdProperty,
-    options,
+    spatialDataColumn,
+    spatialDataType,
   });
 }

--- a/src/filters/tileFeaturesRaster.ts
+++ b/src/filters/tileFeaturesRaster.ts
@@ -64,8 +64,9 @@ export function tileFeaturesRaster({
 
       for (const band in tile.data.cells.numericProps) {
         const value = tile.data.cells.numericProps[band].value[i];
-        // TODO(cleanup): nodata should be a number, not a string.
-        if (Number(bandMetadataByName[band].nodata) !== value) {
+        const bandMetadata = bandMetadataByName[band];
+
+        if (isValidBandValue(value, bandMetadata)) {
           cellData[band] = tile.data.cells.numericProps[band].value[i];
           cellDataExists = true;
         }
@@ -108,4 +109,25 @@ function cellToChildrenSorted(parent: bigint, resolution: bigint): bigint[] {
       return tileA.x > tileB.x ? 1 : -1;
     }
   );
+}
+
+/**
+ * Returns true if the given value is valid (not NaN, not 'nodata')
+ * for the given raster band.
+ */
+function isValidBandValue(
+  value: unknown,
+  bandMetadata: RasterMetadataBand
+): value is number {
+  if (Number.isNaN(value)) {
+    return false;
+  }
+
+  // TODO(cleanup): Remove after API is updated to return 'nodata' as a number.
+  const nodata = bandMetadata.nodata;
+  if (typeof nodata === 'string') {
+    return Number(nodata) !== value;
+  }
+
+  return nodata !== value;
 }

--- a/src/filters/tileFeaturesRaster.ts
+++ b/src/filters/tileFeaturesRaster.ts
@@ -1,0 +1,111 @@
+import {
+  cellToChildren as _cellToChildren,
+  cellToTile,
+  geometryToCells,
+  getResolution,
+} from 'quadbin';
+import {RasterTile, SpatialFilter, Tile} from '../types.js';
+import {FeatureData} from '../types-internal.js';
+import {
+  RasterMetadata,
+  RasterMetadataBand,
+  SpatialDataType,
+} from '../sources/types.js';
+
+export type TileFeaturesRasterOptions = {
+  tiles: RasterTile[];
+  spatialFilter: SpatialFilter;
+  spatialDataColumn: string;
+  spatialDataType: SpatialDataType;
+  rasterMetadata: RasterMetadata;
+};
+
+export function tileFeaturesRaster({
+  tiles,
+  ...options
+}: TileFeaturesRasterOptions): FeatureData[] {
+  // Cache band metadata for faster lookup while iterating over pixels.
+  const bandMetadataByName: Record<string, RasterMetadataBand> = {};
+  for (const band of options.rasterMetadata.bands) {
+    bandMetadataByName[band.name] = band;
+  }
+
+  // Omit empty and invisible tiles for simpler processing and types.
+  tiles = tiles.filter(isRasterTileVisible);
+  if (tiles.length === 0) return [];
+
+  // Raster tiles, and all pixels, are quadbin cells. Resolution of a pixel is
+  // the resolution of the tile, plus the number of subdivisions. Block size
+  // must be square, N x N, where N is a power of two.
+  const tileResolution = getResolution(tiles[0].index.q);
+  const tileBlockSize = tiles[0].data!.blockSize;
+  const cellResolution = tileResolution + BigInt(Math.log2(tileBlockSize));
+
+  // Compute covering cells for the spatial filter, at same resolution as the
+  // raster pixels, to be used as a mask.
+  const spatialFilterCells = new Set(
+    geometryToCells(options.spatialFilter, cellResolution)
+  );
+
+  const data = new Map<bigint, FeatureData>();
+
+  for (const tile of tiles as Required<RasterTile>[]) {
+    const parent = tile.index.q;
+
+    const children = cellToChildrenSorted(parent, cellResolution);
+
+    // For each pixel/cell within the spatial filter, create a FeatureData.
+    // Order is row-major, starting from NW and ending at SE.
+    for (let i = 0; i < children.length; i++) {
+      if (!spatialFilterCells.has(children[i])) continue;
+
+      const cellData: FeatureData = {};
+      let cellDataExists = false;
+
+      for (const band in tile.data.cells.numericProps) {
+        const value = tile.data.cells.numericProps[band].value[i];
+        // TODO(cleanup): nodata should be a number, not a string.
+        if (Number(bandMetadataByName[band].nodata) !== value) {
+          cellData[band] = tile.data.cells.numericProps[band].value[i];
+          cellDataExists = true;
+        }
+      }
+
+      if (cellDataExists) {
+        data.set(children[i], cellData);
+      }
+    }
+  }
+
+  return Array.from(data.values());
+}
+
+/**
+ * Detects whether a given {@link Tile} is a {@link RasterTile}.
+ * @privateRemarks Method of detection is arbitrary, and may be changed.
+ */
+export function isRasterTile(tile: Tile): tile is RasterTile {
+  return !!(tile.data as Record<string, unknown>)?.cells;
+}
+
+function isRasterTileVisible(tile: RasterTile): tile is Required<RasterTile> {
+  return !!(tile.isVisible && tile.data?.cells?.numericProps);
+}
+
+/**
+ * For the raster format, children are sorted in row-major order, starting from
+ * NW and ending at SE. Order returned by quadbin's cellToChildren() is not
+ * defined (and not related to the raster format), so sort explicitly here.
+ */
+function cellToChildrenSorted(parent: bigint, resolution: bigint): bigint[] {
+  return _cellToChildren(parent, resolution).sort(
+    (cellA: bigint, cellB: bigint) => {
+      const tileA = cellToTile(cellA);
+      const tileB = cellToTile(cellB);
+      if (tileA.y !== tileB.y) {
+        return tileA.y > tileB.y ? 1 : -1;
+      }
+      return tileA.x > tileB.x ? 1 : -1;
+    }
+  );
+}

--- a/src/sources/types.ts
+++ b/src/sources/types.ts
@@ -379,7 +379,7 @@ export type RasterMetadataBand = {
   /**
    * Default color mapping for unique values (or if coloprinterp is `palette`)
    */
-  colortable?: Record<string, number[]>;
+  colortable?: Record<string, [number, number, number, number]>;
 
   /**
    * No value representation.

--- a/src/sources/types.ts
+++ b/src/sources/types.ts
@@ -364,8 +364,20 @@ export enum RasterBandColorinterp {
   Palette = 'palette',
 }
 
+export type RasterBandType =
+  | 'uint8'
+  | 'int8'
+  | 'uint16'
+  | 'int16'
+  | 'uint32'
+  | 'int32'
+  | 'uint64'
+  | 'int64'
+  | 'float32'
+  | 'float64';
+
 export type RasterMetadataBand = {
-  type: string;
+  type: RasterBandType;
   name: string;
   stats: RasterMetadataBandStats;
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,6 +40,12 @@ export type SpatialIndexTile = Tile & {
   data?: (Feature & {id: bigint})[];
 };
 
+export type RasterTile = Tile & {
+  id: string;
+  index: {q: bigint; i: string};
+  data?: Raster;
+};
+
 /** @privateRemarks Source: @deck.gl/carto */
 export type Raster = {
   blockSize: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,8 +28,6 @@ export type Viewport = [number, number, number, number];
 export type Tile = {
   index: {x: number; y: number; z: number};
   id: string;
-  content: unknown;
-  zoom: number;
   bbox: {west: number; east: number; north: number; south: number};
   isVisible: boolean;
   data?: BinaryFeatureCollection;

--- a/src/widget-sources/index.ts
+++ b/src/widget-sources/index.ts
@@ -1,5 +1,6 @@
 export * from './widget-source.js';
 export * from './widget-query-source.js';
+export * from './widget-raster-source.js';
 export * from './widget-remote-source.js';
 export * from './widget-table-source.js';
 export * from './widget-tileset-source.js';

--- a/src/widget-sources/widget-raster-source.ts
+++ b/src/widget-sources/widget-raster-source.ts
@@ -1,0 +1,14 @@
+import {RasterMetadata} from '../sources/index.js';
+import {
+  WidgetTilesetSource,
+  WidgetTilesetSourceProps,
+} from './widget-tileset-source.js';
+
+export type WidgetRasterSourceProps = WidgetTilesetSourceProps & {
+  rasterMetadata: RasterMetadata;
+  spatialDataType: 'quadbin';
+};
+
+export type WidgetRasterSourceResult = {widgetSource: WidgetRasterSource};
+
+export class WidgetRasterSource extends WidgetTilesetSource<WidgetRasterSourceProps> {}

--- a/src/widget-sources/widget-tileset-source-impl.ts
+++ b/src/widget-sources/widget-tileset-source-impl.ts
@@ -84,13 +84,10 @@ export class WidgetTilesetSourceImpl extends WidgetSource<WidgetTilesetSourcePro
     }
 
     this._features = tileFeatures({
-      tiles: this._tiles,
-      tileFormat: this.props.tileFormat,
+      ...this.props,
       ...this._tileFeatureExtractOptions,
-
+      tiles: this._tiles,
       spatialFilter,
-      spatialDataColumn: this.props.spatialDataColumn,
-      spatialDataType: this.props.spatialDataType,
     });
 
     prevInputs.spatialFilter = spatialFilter;

--- a/src/widget-sources/widget-tileset-source.ts
+++ b/src/widget-sources/widget-tileset-source.ts
@@ -200,11 +200,22 @@ export class WidgetTilesetSource<
 
     const worker = this._getWorker();
 
-    tiles = (tiles as Tile[]).map(({id, bbox, data}) => ({
-      id,
-      bbox,
-      data,
-    }));
+    // We cannot pass an instance of Tile2DHeader to a Web Worker, and must
+    // extract properties required for widget calculations. Note that the
+    // `tile: Tile = {...}` assignment is structured so TS will warn if any
+    // types required by the internal 'Tile' type are missing.
+    tiles = (tiles as Tile[]).map(
+      ({id, index, bbox, isVisible, data}: Tile) => {
+        const tile: Tile = {
+          id,
+          index,
+          isVisible,
+          data,
+          bbox,
+        };
+        return tile;
+      }
+    );
 
     worker.postMessage({
       method: Method.LOAD_TILES,

--- a/src/widget-sources/widget-tileset-source.ts
+++ b/src/widget-sources/widget-tileset-source.ts
@@ -55,14 +55,16 @@ export type WidgetTilesetSourceResult = {widgetSource: WidgetTilesetSource};
  * const { widgetSource } = await data;
  * ```
  */
-export class WidgetTilesetSource extends WidgetSource<WidgetTilesetSourceProps> {
+export class WidgetTilesetSource<
+  Props extends WidgetTilesetSourceProps = WidgetTilesetSourceProps,
+> extends WidgetSource<Props> {
   protected _localImpl: WidgetTilesetSourceImpl | null = null;
 
   protected _workerImpl: Worker | null = null;
   protected _workerEnabled: boolean;
   protected _workerNextRequestId = 1;
 
-  constructor(props: WidgetTilesetSourceProps) {
+  constructor(props: Props) {
     super(props);
 
     this._workerEnabled =

--- a/test/filters/tileFeaturesRaster.test.ts
+++ b/test/filters/tileFeaturesRaster.test.ts
@@ -1,0 +1,83 @@
+import {expect, test} from 'vitest';
+import {
+  tileFeatures,
+  Tile,
+  TileFormat,
+  RasterMetadata,
+  RasterMetadataBandStats,
+} from '@carto/api-client';
+import {
+  cellToBoundary,
+  getCellPolygon,
+  tileToCell,
+  bigIntToHex,
+  cellToChildren,
+  hexToBigInt,
+} from 'quadbin';
+import {buffer} from '@turf/buffer';
+
+test('tileFeaturesRaster', () => {
+  // Defines a parent tile at z=8.
+  const parentTile = {z: 8, x: 59, y: 97};
+  const parent = tileToCell(parentTile);
+  const parentBbox = getCellPolygon(parent);
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const [east, north, _, south, west] = parentBbox;
+
+  // Defines a child tile at NW quadrant of parent, z=9.
+  const childTile = {z: 9, x: 118, y: 194};
+  const child = tileToCell(childTile);
+
+  // Creates a mock 'RasterTile' from the parent cell, with 8x8 pixel resolution
+  // where each pixel has band_1 = 0.
+  const tile = {
+    id: bigIntToHex(parent),
+    index: {q: parent, i: bigIntToHex(parent)},
+    zoom: 8,
+    isVisible: true,
+    bbox: {west, east, north, south},
+    data: {
+      blockSize: 8,
+      cells: {
+        properties: [],
+        numericProps: {
+          band_1: {value: new Uint8Array(8 ** 2).fill(127)},
+        },
+      },
+    },
+  } as unknown as Tile;
+
+  const rasterMetadata: Partial<RasterMetadata> = {
+    bands: [
+      {
+        name: 'band_1',
+        nodata: 0,
+        type: 'uint8',
+        stats: {min: 0, max: 255} as RasterMetadataBandStats,
+      },
+    ],
+  };
+
+  // Filter to the NW quadrant with a slight inset to avoid precision issues.
+  const spatialFilter = buffer(cellToBoundary(child), -0.01, {
+    units: 'degrees',
+  }).geometry;
+
+  // Extract features, which should return all the upper quadrant,
+  // of the parent tile, a 4x4 block of pixels.
+  const features = tileFeatures({
+    tiles: [tile],
+    tileFormat: TileFormat.BINARY,
+    spatialDataType: 'quadbin',
+    spatialFilter,
+    rasterMetadata: rasterMetadata as RasterMetadata,
+  });
+
+  expect(features.length).toBe(16);
+
+  // TODO: Should an ID property be added, and what should it be called?
+  // expect(features.map((f) => hexToBigInt(f.id as string))).toEqual(
+  //   cellToChildren(child, 11n)
+  // );
+});

--- a/test/filters/tileFeaturesRaster.test.ts
+++ b/test/filters/tileFeaturesRaster.test.ts
@@ -1,4 +1,4 @@
-import {expect, test} from 'vitest';
+import {describe, expect, test} from 'vitest';
 import {
   tileFeatures,
   Tile,
@@ -9,7 +9,7 @@ import {
 import {cellToBoundary, getCellPolygon, tileToCell, bigIntToHex} from 'quadbin';
 import {buffer} from '@turf/buffer';
 
-test('tileFeaturesRaster', () => {
+describe('tileFeaturesRaster', () => {
   // Defines a parent tile at z=8.
   const parentTile = {z: 8, x: 59, y: 97};
   const parent = tileToCell(parentTile);
@@ -22,55 +22,90 @@ test('tileFeaturesRaster', () => {
   const childTile = {z: 9, x: 118, y: 194};
   const child = tileToCell(childTile);
 
-  // Creates a mock 'RasterTile' from the parent cell, with 8x8 pixel resolution
-  // where each pixel has band_1 = 0.
-  const tile = {
-    id: bigIntToHex(parent),
-    index: {q: parent, i: bigIntToHex(parent)},
-    zoom: 8,
-    isVisible: true,
-    bbox: {west, east, north, south},
-    data: {
-      blockSize: 8,
-      cells: {
-        properties: [],
-        numericProps: {
-          band_1: {value: new Uint8Array(8 ** 2).fill(127)},
+  test('pixels', () => {
+    // Creates a mock 'RasterTile' from the parent cell, with 8x8 pixel resolution
+    // where each pixel has band_1 = 0.
+    const tile = {
+      id: bigIntToHex(parent),
+      index: {q: parent, i: bigIntToHex(parent)},
+      zoom: 8,
+      isVisible: true,
+      bbox: {west, east, north, south},
+      data: {
+        blockSize: 8,
+        cells: {
+          properties: [],
+          numericProps: {
+            band_1: {value: new Uint8Array(8 ** 2).fill(127)},
+          },
         },
       },
-    },
-  } as unknown as Tile;
+    } as unknown as Tile;
 
-  const rasterMetadata: Partial<RasterMetadata> = {
-    bands: [
-      {
-        name: 'band_1',
-        nodata: 0,
-        type: 'uint8',
-        stats: {min: 0, max: 255} as RasterMetadataBandStats,
-      },
-    ],
-  };
+    const rasterMetadata: Partial<RasterMetadata> = {
+      bands: [
+        {
+          name: 'band_1',
+          nodata: 0,
+          type: 'uint8',
+          stats: {min: 0, max: 255} as RasterMetadataBandStats,
+        },
+      ],
+    };
 
-  // Filter to the NW quadrant with a slight inset to avoid precision issues.
-  const spatialFilter = buffer(cellToBoundary(child), -0.01, {
-    units: 'degrees',
-  }).geometry;
+    // Filter to the NW quadrant with a slight inset to avoid precision issues.
+    const spatialFilter = buffer(cellToBoundary(child), -0.01, {
+      units: 'degrees',
+    }).geometry;
 
-  // Extract features, which should return all the upper quadrant,
-  // of the parent tile, a 4x4 block of pixels.
-  const features = tileFeatures({
-    tiles: [tile],
-    tileFormat: TileFormat.BINARY,
-    spatialDataType: 'quadbin',
-    spatialFilter,
-    rasterMetadata: rasterMetadata as RasterMetadata,
+    // Extract features, which should return all the upper quadrant,
+    // of the parent tile, a 4x4 block of pixels.
+    const features = tileFeatures({
+      tiles: [tile],
+      tileFormat: TileFormat.BINARY,
+      spatialDataType: 'quadbin',
+      spatialFilter,
+      rasterMetadata: rasterMetadata as RasterMetadata,
+    });
+
+    expect(features.length).toBe(16);
   });
 
-  expect(features.length).toBe(16);
+  test('pixels - nodata', () => {
+    const band_1 = {value: new Float32Array([-1, 0, NaN, 1])};
 
-  // TODO: Should an ID property be added, and what should it be called?
-  // expect(features.map((f) => hexToBigInt(f.id as string))).toEqual(
-  //   cellToChildren(child, 11n)
-  // );
+    const tile = {
+      id: bigIntToHex(parent),
+      index: {q: parent, i: bigIntToHex(parent)},
+      zoom: 8,
+      isVisible: true,
+      bbox: {west, east, north, south},
+      data: {
+        blockSize: 2,
+        cells: {properties: [], numericProps: {band_1}},
+      },
+    } as unknown as Tile;
+
+    const createTileFeatures = (nodata: string | number): unknown[] =>
+      tileFeatures({
+        tiles: [tile],
+        tileFormat: TileFormat.BINARY,
+        spatialDataType: 'quadbin',
+        spatialFilter: buffer(cellToBoundary(parent), 100).geometry,
+        rasterMetadata: {bands: [{name: 'band_1', nodata}]} as RasterMetadata,
+      }).map(({band_1}) => band_1);
+
+    expect(createTileFeatures(-2)).toEqual([-1, 0, 1]);
+    expect(createTileFeatures(-1)).toEqual([0, 1]);
+    expect(createTileFeatures(0)).toEqual([-1, 1]);
+    expect(createTileFeatures(1)).toEqual([-1, 0]);
+    expect(createTileFeatures(NaN)).toEqual([-1, 0, 1]);
+
+    // TODO(cleanup): Remove after API is updated to return 'nodata' as a number.
+    expect(createTileFeatures('-2')).toEqual([-1, 0, 1]);
+    expect(createTileFeatures('-1')).toEqual([0, 1]);
+    expect(createTileFeatures('0')).toEqual([-1, 1]);
+    expect(createTileFeatures('1')).toEqual([-1, 0]);
+    expect(createTileFeatures('NaN')).toEqual([-1, 0, 1]);
+  });
 });

--- a/test/filters/tileFeaturesRaster.test.ts
+++ b/test/filters/tileFeaturesRaster.test.ts
@@ -6,14 +6,7 @@ import {
   RasterMetadata,
   RasterMetadataBandStats,
 } from '@carto/api-client';
-import {
-  cellToBoundary,
-  getCellPolygon,
-  tileToCell,
-  bigIntToHex,
-  cellToChildren,
-  hexToBigInt,
-} from 'quadbin';
+import {cellToBoundary, getCellPolygon, tileToCell, bigIntToHex} from 'quadbin';
 import {buffer} from '@turf/buffer';
 
 test('tileFeaturesRaster', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -272,6 +272,7 @@ __metadata:
     lit-analyzer: "npm:^2.0.3"
     maplibre-gl: "npm:^5.2.0"
     prettier: "npm:^3.5.3"
+    quadbin: "npm:^0.4.0-alpha.2"
     rimraf: "npm:^6.0.1"
     semver: "npm:^7.7.1"
     thenby: "npm:^1.3.4"
@@ -5196,6 +5197,16 @@ __metadata:
   dependencies:
     "@mapbox/tile-cover": "npm:3.0.1"
   checksum: 10c0/314377d80c17b114c5f97c562113955da152b2346efcf9ac9200e3ede995393fa23986d9653a19e1d503a983dc7f97f9a9b60483201f567cbd2da1eb529cc232
+  languageName: node
+  linkType: hard
+
+"quadbin@npm:^0.4.0-alpha.2":
+  version: 0.4.0-alpha.2
+  resolution: "quadbin@npm:0.4.0-alpha.2"
+  dependencies:
+    "@mapbox/tile-cover": "npm:3.0.1"
+    "@math.gl/web-mercator": "npm:^4.1.0"
+  checksum: 10c0/3df09bce66a4e880174705669763bb332f19db6c4c6cc5882b9e091dbdb8db8538c62b9c09d4b07da5bc512abbb5a59103cc57658c10c072d5981e4de312a6fd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
In large part, widgets for raster datasources reuse the same code implemented for quadbin tilesets (https://github.com/CartoDB/carto-api-client/pull/50). To accomplish this, we pre-process each raster tile, creating a 'FeatureData' key/value object for each pixel in the raster, if not excluded by the spatial filter. Creating "an object per pixel" is far from ideal, and keeping a binary representation throughout widget calculations would greatly improve performance. However, I think it's better to keep the code aligned with quadbin tilesets right now — ideally any performance optimizations would benefit both. Use of web workers should prevent calculations from dragging down the web application, even if the calculations themselves are inefficient.

Changes:

- Add WidgetRasterSource class
- Add `tileFeaturesRaster()` function, doing the heavy lifting of extracting feature data for calculations from rasters
- Add raster example
- Minor changes to example widgets, making it easier to set category colors that match pixel colors for debugging

![screenshot](https://github.com/user-attachments/assets/14820ff7-cee8-4b2f-86a2-a776a08aea1f)
