### PR TITLE
feat(widgets): Add WidgetRemoteSource#setRequestHeaders

### DIFF
--- a/src/models/common.ts
+++ b/src/models/common.ts
@@ -3,6 +3,7 @@ import {InvalidColumnError} from '../utils.js';
 /** @internalRemarks Source: @carto/react-api */
 export interface ModelRequestOptions {
   method: 'GET' | 'POST';
+  headers?: Record<string, string>;
   abortController?: AbortController;
   otherOptions?: Record<string, unknown>;
   body?: string;
@@ -68,6 +69,7 @@ export async function makeCall({
       headers: {
         Authorization: `Bearer ${accessToken}`,
         ...(isPost && {'Content-Type': 'application/json'}),
+        ...opts.headers,
       },
       ...(isPost && {
         method: opts?.method,

--- a/src/widget-sources/widget-remote-source.ts
+++ b/src/widget-sources/widget-remote-source.ts
@@ -31,6 +31,13 @@ export type WidgetRemoteSourceProps = WidgetSourceProps;
 export abstract class WidgetRemoteSource<
   Props extends WidgetRemoteSourceProps,
 > extends WidgetSource<Props> {
+  protected _headers: Record<string, string> = {};
+
+  /** Assigns HTTP headers to be included on API requests from this source. */
+  setRequestHeaders(headers: Record<string, string>): void {
+    this._headers = headers;
+  }
+
   async getCategories(
     options: CategoryRequestOptions
   ): Promise<CategoryResponse> {
@@ -65,7 +72,7 @@ export abstract class WidgetRemoteSource<
         operation,
         operationColumn: operationColumn || column,
       },
-      opts: {abortController},
+      opts: {abortController, headers: this._headers},
     }).then((res: CategoriesModelResponse) => normalizeObjectKeys(res.rows));
   }
 
@@ -106,7 +113,7 @@ export abstract class WidgetRemoteSource<
         limit: limit || 1000,
         tileResolution: tileResolution || DEFAULT_TILE_RESOLUTION,
       },
-      opts: {abortController},
+      opts: {abortController, headers: this._headers},
       // Avoid `normalizeObjectKeys()`, which changes column names.
     }).then(({rows}: FeaturesModelResponse) => ({rows}));
   }
@@ -144,7 +151,7 @@ export abstract class WidgetRemoteSource<
         operation: operation ?? 'count',
         operationExp,
       },
-      opts: {abortController},
+      opts: {abortController, headers: this._headers},
     }).then((res: FormulaModelResponse) => normalizeObjectKeys(res.rows[0]));
   }
 
@@ -178,7 +185,7 @@ export abstract class WidgetRemoteSource<
         spatialFilter,
       },
       params: {column, operation, ticks},
-      opts: {abortController},
+      opts: {abortController, headers: this._headers},
     }).then((res: HistogramModelResponse) => normalizeObjectKeys(res.rows));
 
     if (data.length) {
@@ -222,7 +229,7 @@ export abstract class WidgetRemoteSource<
         spatialFilter,
       },
       params: {column},
-      opts: {abortController},
+      opts: {abortController, headers: this._headers},
     }).then((res: RangeModelResponse) => normalizeObjectKeys(res.rows[0]));
   }
 
@@ -265,7 +272,7 @@ export abstract class WidgetRemoteSource<
         yAxisJoinOperation,
         limit: HARD_LIMIT,
       },
-      opts: {abortController},
+      opts: {abortController, headers: this._headers},
     })
       .then((res: ScatterModelResponse) => normalizeObjectKeys(res.rows))
       .then((res) => res.map(({x, y}: {x: number; y: number}) => [x, y]));
@@ -308,7 +315,7 @@ export abstract class WidgetRemoteSource<
         limit,
         offset,
       },
-      opts: {abortController},
+      opts: {abortController, headers: this._headers},
     }).then((res: TableModelResponse) => ({
       // Avoid `normalizeObjectKeys()`, which changes column names.
       rows: res.rows ?? (res as any).ROWS,
@@ -370,7 +377,7 @@ export abstract class WidgetRemoteSource<
         splitByCategoryLimit,
         splitByCategoryValues,
       },
-      opts: {abortController},
+      opts: {abortController, headers: this._headers},
     }).then((res: TimeSeriesModelResponse) => ({
       rows: normalizeObjectKeys(res.rows),
       categories: res.metadata?.categories,

--- a/test/widget-sources/widget-remote-source.test.ts
+++ b/test/widget-sources/widget-remote-source.test.ts
@@ -42,6 +42,10 @@ test('constructor', () => {
   });
 });
 
+test('setRequestHeaders', () => {
+  expect(true).toBe(false); // TODO
+});
+
 /******************************************************************************
  * getCategories
  */

--- a/test/widget-sources/widget-remote-source.test.ts
+++ b/test/widget-sources/widget-remote-source.test.ts
@@ -42,8 +42,31 @@ test('constructor', () => {
   });
 });
 
-test('setRequestHeaders', () => {
-  expect(true).toBe(false); // TODO
+test('setRequestHeaders', async () => {
+  const mockResponse = createMockResponse({rows: []});
+  const mockFetch = vi.fn().mockResolvedValue(mockResponse);
+  vi.stubGlobal('fetch', mockFetch);
+
+  const widgetSource = new WidgetTestSource({
+    accessToken: '<token>',
+    connectionName: 'carto_dw',
+  });
+
+  await widgetSource.getFormula({column: 'store_name', operation: 'count'});
+
+  expect(mockFetch).toHaveBeenCalledOnce();
+  expect(mockFetch.mock.lastCall[1].headers).toEqual({
+    Authorization: 'Bearer <token>',
+  });
+
+  widgetSource.setRequestHeaders({'Cache-Control': 'public'});
+  await widgetSource.getFormula({column: 'store_name', operation: 'count'});
+
+  expect(mockFetch).toHaveBeenCalledTimes(2);
+  expect(mockFetch.mock.lastCall[1].headers).toEqual({
+    Authorization: 'Bearer <token>',
+    'Cache-Control': 'public',
+  });
 });
 
 /******************************************************************************


### PR DESCRIPTION
Provides a helper, for table and query widget sources, to assign HTTP request headers for calls to the Widget/Models API.

Example:

```javascript
widgetSource.setRequestHeaders({'Cache-Control': 'private'});

const result = await widgetSource.getFormula({
  column: 'store_name',
  operation: 'count'
});
```