### PR TITLE
feat(filters): Improve filter and spatialFilter APIs

### DIFF
--- a/examples/03-tileset/app.ts
+++ b/examples/03-tileset/app.ts
@@ -80,10 +80,7 @@ function updateLayers() {
     pointRadiusMinPixels: 4,
     getFillColor: [200, 0, 80],
     onViewportLoad: (tiles) => {
-      const viewport = new WebMercatorViewport(viewState);
-      const spatialFilter = createViewportSpatialFilter(viewport.getBounds())!;
       data.widgetSource.loadTiles(tiles);
-      data.widgetSource.extractTileFeatures({spatialFilter});
       updateWidgets();
     },
   });

--- a/examples/03-tileset/app.ts
+++ b/examples/03-tileset/app.ts
@@ -1,11 +1,10 @@
 import maplibregl from 'maplibre-gl';
-import {Deck, WebMercatorViewport} from '@deck.gl/core';
+import {Deck} from '@deck.gl/core';
 import {VectorTileLayer} from '@deck.gl/carto';
 import {
   TilejsonResult,
   WidgetTilesetSource,
   vectorTilesetSource,
-  createViewportSpatialFilter,
 } from '@carto/api-client';
 import '../components/index.js';
 import type {Widget} from '../components/index.js';

--- a/examples/04-tileset-h3/app.ts
+++ b/examples/04-tileset-h3/app.ts
@@ -1,10 +1,9 @@
 import maplibregl from 'maplibre-gl';
-import {Deck, WebMercatorViewport} from '@deck.gl/core';
+import {Deck} from '@deck.gl/core';
 import {H3TileLayer} from '@deck.gl/carto';
 import {
   TilejsonResult,
   WidgetTilesetSource,
-  createViewportSpatialFilter,
   h3TilesetSource,
 } from '@carto/api-client';
 import '../components/index.js';

--- a/examples/04-tileset-h3/app.ts
+++ b/examples/04-tileset-h3/app.ts
@@ -80,10 +80,7 @@ function updateLayers() {
     getFillColor: [200, 0, 80],
     extruded: false,
     onViewportLoad: (tiles) => {
-      const viewport = new WebMercatorViewport(viewState);
-      const spatialFilter = createViewportSpatialFilter(viewport.getBounds())!;
       data.widgetSource.loadTiles(tiles);
-      data.widgetSource.extractTileFeatures({spatialFilter});
       updateWidgets();
     },
   });

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "@loaders.gl/schema": "^4.3.3",
     "@turf/bbox-clip": "^7.2.0",
     "@turf/bbox-polygon": "^7.2.0",
+    "@turf/boolean-equal": "^7.2.0",
     "@turf/boolean-intersects": "^7.2.0",
     "@turf/boolean-within": "^7.2.0",
     "@turf/helpers": "^7.2.0",

--- a/src/widget-sources/types.ts
+++ b/src/widget-sources/types.ts
@@ -1,5 +1,6 @@
 import {SpatialFilterPolyfillMode, TileResolution} from '../sources/types.js';
 import {
+  Filters,
   GroupDateType,
   SortColumnType,
   SortDirection,
@@ -23,6 +24,8 @@ interface BaseRequestOptions {
   /** Required for table- and query-based spatial index sources (H3, Quadbin). */
   spatialIndexReferenceViewState?: ViewState;
   abortController?: AbortController;
+  /** Overrides source filters, if any. */
+  filters?: Filters;
   filterOwner?: string;
 }
 

--- a/src/widget-sources/widget-query-source.ts
+++ b/src/widget-sources/widget-query-source.ts
@@ -8,6 +8,7 @@ import {
   WidgetRemoteSourceProps,
 } from './widget-remote-source.js';
 import {ModelSource} from '../models/model.js';
+import {Filters} from '../types.js';
 
 type LayerQuerySourceOptions =
   | Omit<VectorQuerySourceOptions, 'filters'>
@@ -41,9 +42,12 @@ export type WidgetQuerySourceResult = {widgetSource: WidgetQuerySource};
 export class WidgetQuerySource extends WidgetRemoteSource<
   LayerQuerySourceOptions & WidgetRemoteSourceProps
 > {
-  protected override getModelSource(owner: string): ModelSource {
+  protected override getModelSource(
+    filters: Filters | undefined,
+    filterOwner?: string
+  ): ModelSource {
     return {
-      ...super._getModelSource(owner),
+      ...super._getModelSource(filters, filterOwner),
       type: 'query',
       data: this.props.sqlQuery,
       queryParameters: this.props.queryParameters,

--- a/src/widget-sources/widget-remote-source.ts
+++ b/src/widget-sources/widget-remote-source.ts
@@ -42,6 +42,7 @@ export abstract class WidgetRemoteSource<
     options: CategoryRequestOptions
   ): Promise<CategoryResponse> {
     const {
+      filters = this.props.filters,
       filterOwner,
       spatialFilter,
       spatialFiltersMode,
@@ -50,7 +51,7 @@ export abstract class WidgetRemoteSource<
       ...params
     } = options;
     const {column, operation, operationColumn} = params;
-    const source = this.getModelSource(filterOwner);
+    const source = this.getModelSource(filters, filterOwner);
     const spatialFiltersResolution = this._getSpatialFiltersResolution(
       source,
       spatialFilter,
@@ -80,6 +81,7 @@ export abstract class WidgetRemoteSource<
     options: FeaturesRequestOptions
   ): Promise<FeaturesResponse> {
     const {
+      filters = this.props.filters,
       filterOwner,
       spatialFilter,
       spatialFiltersMode,
@@ -88,7 +90,7 @@ export abstract class WidgetRemoteSource<
       ...params
     } = options;
     const {columns, dataType, featureIds, z, limit, tileResolution} = params;
-    const source = this.getModelSource(filterOwner);
+    const source = this.getModelSource(filters, filterOwner);
     const spatialFiltersResolution = this._getSpatialFiltersResolution(
       source,
       spatialFilter,
@@ -120,6 +122,7 @@ export abstract class WidgetRemoteSource<
 
   async getFormula(options: FormulaRequestOptions): Promise<FormulaResponse> {
     const {
+      filters = this.props.filters,
       filterOwner,
       spatialFilter,
       spatialFiltersMode,
@@ -129,7 +132,7 @@ export abstract class WidgetRemoteSource<
       ...params
     } = options;
     const {column, operation} = params;
-    const source = this.getModelSource(filterOwner);
+    const source = this.getModelSource(filters, filterOwner);
     const spatialFiltersResolution = this._getSpatialFiltersResolution(
       source,
       spatialFilter,
@@ -159,6 +162,7 @@ export abstract class WidgetRemoteSource<
     options: HistogramRequestOptions
   ): Promise<HistogramResponse> {
     const {
+      filters = this.props.filters,
       filterOwner,
       spatialFilter,
       spatialFiltersMode,
@@ -167,7 +171,7 @@ export abstract class WidgetRemoteSource<
       ...params
     } = options;
     const {column, operation, ticks} = params;
-    const source = this.getModelSource(filterOwner);
+    const source = this.getModelSource(filters, filterOwner);
     const spatialFiltersResolution = this._getSpatialFiltersResolution(
       source,
       spatialFilter,
@@ -203,6 +207,7 @@ export abstract class WidgetRemoteSource<
 
   async getRange(options: RangeRequestOptions): Promise<RangeResponse> {
     const {
+      filters = this.props.filters,
       filterOwner,
       spatialFilter,
       spatialFiltersMode,
@@ -211,7 +216,7 @@ export abstract class WidgetRemoteSource<
       ...params
     } = options;
     const {column} = params;
-    const source = this.getModelSource(filterOwner);
+    const source = this.getModelSource(filters, filterOwner);
     const spatialFiltersResolution = this._getSpatialFiltersResolution(
       source,
       spatialFilter,
@@ -235,6 +240,7 @@ export abstract class WidgetRemoteSource<
 
   async getScatter(options: ScatterRequestOptions): Promise<ScatterResponse> {
     const {
+      filters = this.props.filters,
       filterOwner,
       spatialFilter,
       spatialFiltersMode,
@@ -245,7 +251,7 @@ export abstract class WidgetRemoteSource<
     const {xAxisColumn, xAxisJoinOperation, yAxisColumn, yAxisJoinOperation} =
       params;
 
-    const source = this.getModelSource(filterOwner);
+    const source = this.getModelSource(filters, filterOwner);
     const spatialFiltersResolution = this._getSpatialFiltersResolution(
       source,
       spatialFilter,
@@ -280,6 +286,7 @@ export abstract class WidgetRemoteSource<
 
   async getTable(options: TableRequestOptions): Promise<TableResponse> {
     const {
+      filters = this.props.filters,
       filterOwner,
       spatialFilter,
       spatialFiltersMode,
@@ -288,7 +295,7 @@ export abstract class WidgetRemoteSource<
       ...params
     } = options;
     const {columns, sortBy, sortDirection, offset = 0, limit = 10} = params;
-    const source = this.getModelSource(filterOwner);
+    const source = this.getModelSource(filters, filterOwner);
     const spatialFiltersResolution = this._getSpatialFiltersResolution(
       source,
       spatialFilter,
@@ -327,6 +334,7 @@ export abstract class WidgetRemoteSource<
     options: TimeSeriesRequestOptions
   ): Promise<TimeSeriesResponse> {
     const {
+      filters = this.props.filters,
       filterOwner,
       abortController,
       spatialFilter,
@@ -346,7 +354,7 @@ export abstract class WidgetRemoteSource<
       splitByCategoryValues,
     } = params;
 
-    const source = this.getModelSource(filterOwner);
+    const source = this.getModelSource(filters, filterOwner);
     const spatialFiltersResolution = this._getSpatialFiltersResolution(
       source,
       spatialFilter,

--- a/src/widget-sources/widget-source.ts
+++ b/src/widget-sources/widget-source.ts
@@ -17,7 +17,12 @@ import {
   TimeSeriesResponse,
   ViewState,
 } from './types.js';
-import {FilterLogicalOperator, Filter, SpatialFilter} from '../types.js';
+import {
+  FilterLogicalOperator,
+  Filter,
+  SpatialFilter,
+  Filters,
+} from '../types.js';
 import {getApplicableFilters} from '../utils.js';
 import {getClient} from '../client.js';
 import {ModelSource} from '../models/model.js';
@@ -58,10 +63,14 @@ export abstract class WidgetSource<Props extends WidgetSourceProps> {
    * properties, and adding additional required properties including 'type' and
    * 'data'.
    */
-  protected abstract getModelSource(owner: string | undefined): ModelSource;
+  protected abstract getModelSource(
+    filters: Filters | undefined,
+    filterOwner?: string
+  ): ModelSource;
 
   protected _getModelSource(
-    owner?: string
+    filters: Filters | undefined,
+    filterOwner?: string
   ): Omit<ModelSource, 'type' | 'data'> {
     const props = this.props;
     return {
@@ -70,7 +79,7 @@ export abstract class WidgetSource<Props extends WidgetSourceProps> {
       clientId: props.clientId as string,
       accessToken: props.accessToken,
       connectionName: props.connectionName,
-      filters: getApplicableFilters(owner, props.filters),
+      filters: getApplicableFilters(filterOwner, filters || props.filters),
       filtersLogicalOperator: props.filtersLogicalOperator,
       spatialDataType: props.spatialDataType,
       spatialDataColumn: props.spatialDataColumn,

--- a/src/widget-sources/widget-table-source.ts
+++ b/src/widget-sources/widget-table-source.ts
@@ -8,6 +8,7 @@ import {
   WidgetRemoteSourceProps,
 } from './widget-remote-source.js';
 import {ModelSource} from '../models/model.js';
+import {Filters} from '../types.js';
 
 type LayerTableSourceOptions =
   | Omit<VectorTableSourceOptions, 'filters'>
@@ -41,9 +42,12 @@ export type WidgetTableSourceResult = {widgetSource: WidgetTableSource};
 export class WidgetTableSource extends WidgetRemoteSource<
   LayerTableSourceOptions & WidgetRemoteSourceProps
 > {
-  protected override getModelSource(owner: string): ModelSource {
+  protected override getModelSource(
+    filters: Filters | undefined,
+    filterOwner?: string
+  ): ModelSource {
     return {
-      ...super._getModelSource(owner),
+      ...super._getModelSource(filters, filterOwner),
       type: 'table',
       data: this.props.tableName,
     };

--- a/test/widget-sources/widget-tileset-source.test.ts
+++ b/test/widget-sources/widget-tileset-source.test.ts
@@ -33,6 +33,7 @@ describe('getFormula', () => {
         operation: 'count',
         column: undefined,
         joinOperation: undefined,
+        spatialFilter: MOCK_SPATIAL_FILTER,
       })
     ).toEqual({value: 6});
   });
@@ -60,6 +61,7 @@ describe('getFormula', () => {
         column: undefined,
         joinOperation: undefined,
         operation: 'count',
+        spatialFilter: MOCK_SPATIAL_FILTER,
       })
     ).toEqual({
       value: 3,
@@ -75,6 +77,7 @@ describe('getHistogram', () => {
         operation: 'count',
         ticks: [997472.3, 1716077, 2056468.7],
         joinOperation: undefined,
+        spatialFilter: MOCK_SPATIAL_FILTER,
       })
     ).toEqual([0, 4, 2, 0]);
   });
@@ -88,6 +91,7 @@ describe('getTable', () => {
         sortBy: undefined,
         sortDirection: undefined,
         sortByColumnType: undefined,
+        spatialFilter: MOCK_SPATIAL_FILTER,
       })
     ).toEqual({
       totalCount: 6,
@@ -102,6 +106,7 @@ describe('getTable', () => {
         sortBy: 'size_m2',
         sortDirection: 'desc',
         sortByColumnType: 'number',
+        spatialFilter: MOCK_SPATIAL_FILTER,
       })
     ).toEqual({
       totalCount: 6,
@@ -117,6 +122,7 @@ describe('getTable', () => {
         columns: MOCK_COLUMNS,
         searchFilterColumn: 'address',
         searchFilterText: null,
+        spatialFilter: MOCK_SPATIAL_FILTER,
       })
     ).toEqual({
       totalCount: 6,
@@ -130,6 +136,7 @@ describe('getTable', () => {
         columns: MOCK_COLUMNS,
         searchFilterColumn: null,
         searchFilterText: 'any-text',
+        spatialFilter: MOCK_SPATIAL_FILTER,
       })
     ).toEqual({
       totalCount: 6,
@@ -142,6 +149,7 @@ describe('getTable', () => {
       columns: MOCK_COLUMNS,
       searchFilterColumn: 'address',
       searchFilterText: '146 tremont st',
+      spatialFilter: MOCK_SPATIAL_FILTER,
     });
 
     expect(result).toEqual({

--- a/yarn.lock
+++ b/yarn.lock
@@ -1479,6 +1479,7 @@ __metadata:
     "@luma.gl/shadertools": "npm:~9.1.0"
     "@turf/bbox-clip": "npm:^7.2.0"
     "@turf/bbox-polygon": "npm:^7.2.0"
+    "@turf/boolean-equal": "npm:^7.2.0"
     "@turf/boolean-intersects": "npm:^7.2.0"
     "@turf/boolean-within": "npm:^7.2.0"
     "@turf/helpers": "npm:^7.2.0"
@@ -3030,6 +3031,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@turf/boolean-equal@npm:^7.2.0":
+  version: 7.2.0
+  resolution: "@turf/boolean-equal@npm:7.2.0"
+  dependencies:
+    "@turf/clean-coords": "npm:^7.2.0"
+    "@turf/helpers": "npm:^7.2.0"
+    "@turf/invariant": "npm:^7.2.0"
+    "@types/geojson": "npm:^7946.0.10"
+    geojson-equality-ts: "npm:^1.0.2"
+    tslib: "npm:^2.8.1"
+  checksum: 10c0/f0f8623620ad329535bbc610309c1f09348d73355fce39c22c72fa57d026ae2c1b65b5e443744156256055edd43d19611c4ad1f497af2e39ab7ade72ef074af7
+  languageName: node
+  linkType: hard
+
 "@turf/boolean-intersects@npm:^7.2.0":
   version: 7.2.0
   resolution: "@turf/boolean-intersects@npm:7.2.0"
@@ -3080,6 +3095,18 @@ __metadata:
     "@types/geojson": "npm:^7946.0.10"
     tslib: "npm:^2.8.1"
   checksum: 10c0/2aed21d55b820a19d1d7f22f521fdd9c780ba8ab036828ac2a316efea984d3c70c71190aeaa5766fce922b5dcd52987d86dc0fcb27a0d50306a9e7e270cf80ce
+  languageName: node
+  linkType: hard
+
+"@turf/clean-coords@npm:^7.2.0":
+  version: 7.2.0
+  resolution: "@turf/clean-coords@npm:7.2.0"
+  dependencies:
+    "@turf/helpers": "npm:^7.2.0"
+    "@turf/invariant": "npm:^7.2.0"
+    "@types/geojson": "npm:^7946.0.10"
+    tslib: "npm:^2.8.1"
+  checksum: 10c0/2ea92fa647ea0fabbf2b3f5ebe61b66e499754bde6d8b3259b13e2f5a4858e843e6419307f55fb3a193311906ef292f56430c368d06aded15eec616949e7dd20
   languageName: node
   linkType: hard
 
@@ -3294,7 +3321,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/geojson@npm:^7946.0.15, @types/geojson@npm:^7946.0.16":
+"@types/geojson@npm:^7946.0.14, @types/geojson@npm:^7946.0.15, @types/geojson@npm:^7946.0.16":
   version: 7946.0.16
   resolution: "@types/geojson@npm:7946.0.16"
   checksum: 10c0/1ff24a288bd5860b766b073ead337d31d73bdc715e5b50a2cee5cb0af57a1ed02cc04ef295f5fa68dc40fe3e4f104dd31282b2b818a5ba3231bc1001ba084e3c
@@ -5505,6 +5532,15 @@ __metadata:
   version: 1.0.0-beta.2
   resolution: "gensync@npm:1.0.0-beta.2"
   checksum: 10c0/782aba6cba65b1bb5af3b095d96249d20edbe8df32dbf4696fd49be2583faf676173bf4809386588828e4dd76a3354fcbeb577bab1c833ccd9fc4577f26103f8
+  languageName: node
+  linkType: hard
+
+"geojson-equality-ts@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "geojson-equality-ts@npm:1.0.2"
+  dependencies:
+    "@types/geojson": "npm:^7946.0.14"
+  checksum: 10c0/f582c6a549673f238b1eb450511e7be222ded8af039924fd21d03ab201de003a5b1769c44b35ca59406533322165520d7aea77e7e1011722259a1485edb30e24
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
For tilesets, filters cannot be specified in source functions like `vectorTilesetSource`. Both filters and spatial filters need to be applied in a pre-pass on the tile data, before computing widget results. In #50 this was originally set up similarly to C4R, with three distinct steps for (1) loading tiles, (2) extracting tile features, and (3) computing results. For simpler usage, we'd like to hide step (2), and in most cases users can simply do this:

```javascript
// (1)
widgetSource.loadTiles(tiles);

// (2)
const result = await widgetSource.getFormula({..., filters, spatialFilter});
```

For the less common cases where the storeGeometry or uniqueIdProperty options need to be specified, that can be done once, and doesnt need to be reconfigured when new tiles are loaded:

```javascript
// (optional)
widgetSource.setTileExtractOptions({
  uniqueIdProperty: 'my_custom_id',
  storeGeometry: true
});
```

Finally, this PR allows widget sources to accept a `filters` parameter in individual widget function calls like getCategories/getFormula/... this parameter will override _all_ filters specified on the datasource, if any. All widget sources (tileset, table, query) accept `filters` parameters in these function calls. Only remote widget sources (table, query) accept `filters` in the datasource constructor, since tilesets would not be able to apply filters to layers in that way.

```javascript
const { widgetSource } = vectorTableSource({
  ...
  filters: filtersA, // will be overridden below
});

// filtersB overrides filtersA!
const result = await widgetSource.getFormula({..., filters: filtersB});
```