### PR TITLE
chore(tsdoc): Clean up TSDoc for next release

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1,6 +1,6 @@
 /**
  * @internal
- * @internalRemarks Source: @carto/react-core, @carto/constants, @deck.gl/carto
+ * @privateRemarks Source: @carto/react-core, @carto/constants, @deck.gl/carto
  */
 let client = 'deck-gl-carto';
 
@@ -8,7 +8,7 @@ let client = 'deck-gl-carto';
  * Returns current client ID, used to categorize API requests. For internal use only.
  *
  * @internal
- * @internalRemarks Source: @carto/react-core
+ * @privateRemarks Source: @carto/react-core
  */
 export function getClient() {
   return client;
@@ -18,7 +18,7 @@ export function getClient() {
  * Sets current client ID, used to categorize API requests. For internal use only.
  *
  * @internal
- * @internalRemarks Source: @carto/react-core
+ * @privateRemarks Source: @carto/react-core
  */
 export function setClient(c: string) {
   client = c;

--- a/src/constants-internal.ts
+++ b/src/constants-internal.ts
@@ -7,26 +7,26 @@ export const API_CLIENT_VERSION = __CARTO_API_CLIENT_VERSION;
 /** @internal */
 export const V3_MINOR_VERSION = '3.4';
 
-/** @internalRemarks Source: @carto/constants, @deck.gl/carto */
+/** @privateRemarks Source: @carto/constants, @deck.gl/carto */
 export const DEFAULT_GEO_COLUMN = 'geom';
 
 /**
  * Fastly default limit is 8192; leave some padding.
- * @internalRemarks Source: @deck.gl/carto
+ * @privateRemarks Source: @deck.gl/carto
  */
 export const DEFAULT_MAX_LENGTH_URL = 7000;
 
-/** @internalRemarks Source: @deck.gl/carto */
+/** @privateRemarks Source: @deck.gl/carto */
 export const DEFAULT_TILE_RESOLUTION = 0.5;
 
 /**
- * @internalRemarks Source: @deck.gl/carto
+ * @privateRemarks Source: @deck.gl/carto
  * @internal
  */
 export const DEFAULT_AGGREGATION_RES_LEVEL_H3 = 4;
 
 /**
- * @internalRemarks Source: @deck.gl/carto
+ * @privateRemarks Source: @deck.gl/carto
  * @internal
  */
 export const DEFAULT_AGGREGATION_RES_LEVEL_QUADBIN = 6;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -10,7 +10,7 @@
  * };
  * ```
  *
- * @internalRemarks Source: @carto/react-api, @deck.gl/carto
+ * @privateRemarks Source: @carto/react-api, @deck.gl/carto
  */
 export enum FilterType {
   IN = 'in',
@@ -22,17 +22,17 @@ export enum FilterType {
   STRING_SEARCH = 'stringSearch',
 }
 
-/** @internalRemarks Source: @carto/constants */
+/** @privateRemarks Source: @carto/constants */
 export enum ApiVersion {
   V1 = 'v1',
   V2 = 'v2',
   V3 = 'v3',
 }
 
-/** @internalRemarks Source: @carto/constants, @deck.gl/carto */
+/** @privateRemarks Source: @carto/constants, @deck.gl/carto */
 export const DEFAULT_API_BASE_URL = 'https://gcp-us-east1.api.carto.com';
 
-/** @internalRemarks Source: @carto/react-core */
+/** @privateRemarks Source: @carto/react-core */
 export enum TileFormat {
   MVT = 'mvt',
   JSON = 'json',
@@ -40,14 +40,14 @@ export enum TileFormat {
   BINARY = 'binary',
 }
 
-/** @internalRemarks Source: @carto/react-core */
+/** @privateRemarks Source: @carto/react-core */
 export enum SpatialIndex {
   H3 = 'h3',
   S2 = 's2',
   QUADBIN = 'quadbin',
 }
 
-/** @internalRemarks Source: @carto/react-core */
+/** @privateRemarks Source: @carto/react-core */
 export enum Provider {
   BIGQUERY = 'bigquery',
   REDSHIFT = 'redshift',

--- a/src/filters/Filter.ts
+++ b/src/filters/Filter.ts
@@ -44,7 +44,11 @@ function passesFilter(
   });
 }
 
-export function buildFeatureFilter({
+/**
+ * @internal
+ * @privateRemarks Exported for use in @deck.gl/carto's getDataFilterExtensionProps.
+ */
+export function _buildFeatureFilter({
   filters = {},
   type = 'boolean',
   filtersLogicalOperator = 'and',
@@ -74,18 +78,24 @@ export function buildFeatureFilter({
   };
 }
 
-// Apply certain filters to a collection of features
+/**
+ * Apply certain filters to a collection of features.
+ * @internal
+ */
 export function applyFilters(
   features: FeatureData[],
   filters: Filters,
   filtersLogicalOperator: FilterLogicalOperator
 ) {
   return Object.keys(filters).length
-    ? features.filter(buildFeatureFilter({filters, filtersLogicalOperator}))
+    ? features.filter(_buildFeatureFilter({filters, filtersLogicalOperator}))
     : features;
 }
 
-// Binary
+/**
+ * Binary.
+ * @internal
+ */
 export function buildBinaryFeatureFilter({filters = {}}: {filters: Filters}) {
   const columns = Object.keys(filters);
 

--- a/src/filters/tileFeatures.ts
+++ b/src/filters/tileFeatures.ts
@@ -6,7 +6,7 @@ import {DEFAULT_GEO_COLUMN} from '../constants-internal';
 import {FeatureData} from '../types-internal';
 import {SpatialDataType} from '../sources/types';
 
-/** @internalRemarks Source: @carto/react-core */
+/** @privateRemarks Source: @carto/react-core */
 export type TileFeatures = {
   tiles: Tile[];
   tileFormat: TileFormat;
@@ -17,12 +17,12 @@ export type TileFeatures = {
   options?: TileFeatureExtractOptions;
 };
 
-/** @internalRemarks Source: @carto/react-core */
+/** @privateRemarks Source: @carto/react-core */
 export type TileFeatureExtractOptions = {
   storeGeometry?: boolean;
 };
 
-/** @internalRemarks Source: @carto/react-core */
+/** @privateRemarks Source: @carto/react-core */
 export function tileFeatures({
   tiles,
   spatialFilter,

--- a/src/geo.ts
+++ b/src/geo.ts
@@ -40,7 +40,7 @@ export function createPolygonSpatialFilter(
  * Check if a viewport is large enough to represent a global coverage.
  * In this case the spatial filter parameter for widget calculation is removed.
  *
- * @internalRemarks Source: @carto/react-core
+ * @privateRemarks Source: @carto/react-core
  */
 function _isGlobalViewport(viewport: BBox) {
   const [minx, miny, maxx, maxy] = viewport;
@@ -54,7 +54,7 @@ function _isGlobalViewport(viewport: BBox) {
  *
  * It results in a Polygon or MultiPolygon strictly inside the validity range.
  *
- * @internalRemarks Source: @carto/react-core
+ * @privateRemarks Source: @carto/react-core
  */
 function _normalizeGeometry(
   geometry: Polygon | MultiPolygon
@@ -100,19 +100,19 @@ function _normalizeGeometry(
   return result;
 }
 
-/** @internalRemarks Source: @carto/react-core */
+/** @privateRemarks Source: @carto/react-core */
 function _cleanPolygonCoords(cc: Position[][]) {
   const coords = cc.filter((c) => c.length > 0);
   return coords.length > 0 ? coords : null;
 }
 
-/** @internalRemarks Source: @carto/react-core */
+/** @privateRemarks Source: @carto/react-core */
 function _cleanMultiPolygonCoords(ccc: Position[][][]) {
   const coords = ccc.map(_cleanPolygonCoords).filter((cc) => cc);
   return coords.length > 0 ? coords : null;
 }
 
-/** @internalRemarks Source: @carto/react-core */
+/** @privateRemarks Source: @carto/react-core */
 function _clean(
   geometry: Polygon | MultiPolygon | null
 ): Polygon | MultiPolygon | null {
@@ -135,22 +135,22 @@ function _clean(
   return null;
 }
 
-/** @internalRemarks Source: @carto/react-core */
+/** @privateRemarks Source: @carto/react-core */
 function _txContourCoords(cc: Position[], distance: number) {
   return cc.map((c) => [c[0] + distance, c[1]]);
 }
 
-/** @internalRemarks Source: @carto/react-core */
+/** @privateRemarks Source: @carto/react-core */
 function _txPolygonCoords(ccc: Position[][], distance: number) {
   return ccc.map((cc) => _txContourCoords(cc, distance));
 }
 
-/** @internalRemarks Source: @carto/react-core */
+/** @privateRemarks Source: @carto/react-core */
 function _txMultiPolygonCoords(cccc: Position[][][], distance: number) {
   return cccc.map((ccc) => _txPolygonCoords(ccc, distance));
 }
 
-/** @internalRemarks Source: @carto/react-core */
+/** @privateRemarks Source: @carto/react-core */
 function _tx(geometry: Polygon | MultiPolygon, distance: number) {
   if (geometry && getType(geometry) === 'Polygon') {
     const coords = _txPolygonCoords(

--- a/src/models/common.ts
+++ b/src/models/common.ts
@@ -1,6 +1,6 @@
 import {InvalidColumnError} from '../utils.js';
 
-/** @internalRemarks Source: @carto/react-api */
+/** @privateRemarks Source: @carto/react-api */
 export interface ModelRequestOptions {
   method: 'GET' | 'POST';
   abortController?: AbortController;
@@ -16,7 +16,7 @@ interface ModelErrorResponse {
 
 /**
  * Return more descriptive error from API
- * @internalRemarks Source: @carto/react-api
+ * @privateRemarks Source: @carto/react-api
  */
 export function dealWithApiError({
   response,
@@ -50,7 +50,7 @@ export function dealWithApiError({
   }
 }
 
-/** @internalRemarks Source: @carto/react-api */
+/** @privateRemarks Source: @carto/react-api */
 export async function makeCall({
   url,
   accessToken,

--- a/src/models/model.ts
+++ b/src/models/model.ts
@@ -12,7 +12,7 @@ import {ModelRequestOptions, makeCall} from './common.js';
 import {ApiVersion} from '../constants.js';
 import {SpatialDataType, SpatialFilterPolyfillMode} from '../sources/types.js';
 
-/** @internalRemarks Source: @carto/react-api */
+/** @privateRemarks Source: @carto/react-api */
 const AVAILABLE_MODELS = [
   'category',
   'histogram',
@@ -51,7 +51,7 @@ const REQUEST_GET_MAX_URL_LENGTH = 2048;
 
 /**
  * Execute a SQL model request.
- * @internalRemarks Source: @carto/react-api
+ * @privateRemarks Source: @carto/react-api
  */
 export function executeModel(props: {
   model: Model;

--- a/src/operations/aggregation.ts
+++ b/src/operations/aggregation.ts
@@ -1,14 +1,14 @@
 import {AggregationType} from '../types';
 import {FeatureData} from '../types-internal';
 
-/** @internalRemarks Source: @carto/react-core */
+/** @privateRemarks Source: @carto/react-core */
 export type AggregationFunction = (
   values: unknown[] | FeatureData[],
   keys?: string[] | string,
   joinOperation?: AggregationType
 ) => number;
 
-/** @internalRemarks Source: @carto/react-core */
+/** @privateRemarks Source: @carto/react-core */
 export const aggregationFunctions: Record<
   Exclude<AggregationType, 'custom'>,
   AggregationFunction
@@ -20,7 +20,7 @@ export const aggregationFunctions: Record<
   avg: (...args) => applyAggregationFunction(avg, ...args),
 };
 
-/** @internalRemarks Source: @carto/react-core */
+/** @privateRemarks Source: @carto/react-core */
 export function aggregate(
   feature: FeatureData,
   keys?: string[],

--- a/src/operations/applySorting.ts
+++ b/src/operations/applySorting.ts
@@ -19,7 +19,7 @@ interface SortOptions {
  * @param [sortOptions.sortByDirection] - Direction by the columns will be sorted
  * @param [sortOptions.sortByColumnType] - Column type
  * @internal
- * @internalRemarks Source: @carto/react-core
+ * @privateRemarks Source: @carto/react-core
  */
 export function applySorting(
   features: FeatureData[],

--- a/src/operations/groupBy.ts
+++ b/src/operations/groupBy.ts
@@ -2,13 +2,13 @@ import {aggregationFunctions, aggregate} from './aggregation.js';
 import {AggregationType} from '../types';
 import {FeatureData} from '../types-internal';
 
-/** @internalRemarks Source: @carto/react-core */
+/** @privateRemarks Source: @carto/react-core */
 export type GroupByFeature = {
   name: string;
   value: number;
 }[];
 
-/** @internalRemarks Source: @carto/react-core */
+/** @privateRemarks Source: @carto/react-core */
 export function groupValuesByColumn({
   data,
   valuesColumns,

--- a/src/operations/groupByDate.ts
+++ b/src/operations/groupByDate.ts
@@ -35,7 +35,7 @@ const GROUP_KEY_FN_MAPPING: Record<GroupDateType, (date: Date) => number> = {
     ),
 };
 
-/** @internalRemarks Source: @carto/react-core */
+/** @privateRemarks Source: @carto/react-core */
 export function groupValuesByDateColumn({
   data,
   valuesColumns,

--- a/src/operations/histogram.ts
+++ b/src/operations/histogram.ts
@@ -4,7 +4,7 @@ import {FeatureData} from '../types-internal';
 
 /**
  * Histogram computation.
- * @internalRemarks Source: @carto/react-core
+ * @privateRemarks Source: @carto/react-core
  */
 export function histogram({
   data,

--- a/src/operations/scatterPlot.ts
+++ b/src/operations/scatterPlot.ts
@@ -6,7 +6,7 @@ export type ScatterPlotFeature = [number, number][];
 
 /**
  * Filters invalid features and formats  data.
- * @internalRemarks Source: @carto/react-core
+ * @privateRemarks Source: @carto/react-core
  */
 export function scatterPlot({
   data,

--- a/src/sources/types.ts
+++ b/src/sources/types.ts
@@ -208,7 +208,7 @@ export type SpatialDataType = 'geo' | 'h3' | 'quadbin';
  * Strategy used for covering spatial filter geometry with spatial indexes.
  * See https://docs.carto.com/data-and-analysis/analytics-toolbox-for-bigquery/sql-reference/quadbin#quadbin_polyfill_mode
  * or https://docs.carto.com/data-and-analysis/analytics-toolbox-for-bigquery/sql-reference/h3#h3_polyfill_mode for more information.
- * @internalRemarks Source: cloud-native maps-api
+ * @privateRemarks Source: cloud-native maps-api
  * */
 export type SpatialFilterPolyfillMode = 'center' | 'intersects' | 'contains';
 

--- a/src/types-internal.ts
+++ b/src/types-internal.ts
@@ -15,7 +15,7 @@ export type $IntentionalAny = any;
  */
 
 /**
- * @internalRemarks Source: @deck.gl/carto
+ * @privateRemarks Source: @deck.gl/carto
  * @internal
  */
 export enum SchemaFieldType {
@@ -31,7 +31,7 @@ export enum SchemaFieldType {
 }
 
 /**
- * @internalRemarks Source: @deck.gl/carto
+ * @privateRemarks Source: @deck.gl/carto
  * @internal
  */
 export interface SchemaField {
@@ -40,7 +40,7 @@ export interface SchemaField {
 }
 
 /**
- * @internalRemarks Source: @deck.gl/carto
+ * @privateRemarks Source: @deck.gl/carto
  * @internal
  */
 export interface MapInstantiation extends MapInstantiationFormats {
@@ -50,7 +50,7 @@ export interface MapInstantiation extends MapInstantiationFormats {
 }
 
 /**
- * @internalRemarks Source: @deck.gl/carto
+ * @privateRemarks Source: @deck.gl/carto
  * @internal
  */
 type MapInstantiationFormats = Record<

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,10 +6,10 @@ import type {BinaryFeature, BinaryFeatureCollection} from '@loaders.gl/schema';
  * MAPS AND TILES
  */
 
-/** @internalRemarks Source: @deck.gl/carto */
+/** @privateRemarks Source: @deck.gl/carto */
 export type Format = 'json' | 'geojson' | 'tilejson';
 
-/** @internalRemarks Source: @carto/constants, @deck.gl/carto */
+/** @privateRemarks Source: @carto/constants, @deck.gl/carto */
 export type MapType = 'boundary' | 'query' | 'table' | 'tileset' | 'raster';
 
 /**
@@ -23,7 +23,7 @@ export type Viewport = [number, number, number, number];
  * required for local widget calculations. Deeper dependencies on deck.gl
  * APIs should be minimized within this library: @deck.gl/carto depends
  * on the API client, not the other way around.
- * @internalRemarks Source: @deck.gl/geo-layers
+ * @privateRemarks Source: @deck.gl/geo-layers
  */
 export type Tile = {
   index: {x: number; y: number; z: number};
@@ -40,7 +40,7 @@ export type SpatialIndexTile = Tile & {
   data?: (Feature & {id: bigint})[];
 };
 
-/** @internalRemarks Source: @deck.gl/carto */
+/** @privateRemarks Source: @deck.gl/carto */
 export type Raster = {
   blockSize: number;
   cells: {
@@ -56,8 +56,8 @@ export type Raster = {
 /**
  * Enum for the different types of aggregations available for widgets.
  *
- * @internalRemarks Source: @carto/constants
- * @internalRemarks Converted from enum to type union, for improved declarative API.
+ * @privateRemarks Source: @carto/constants
+ * @privateRemarks Converted from enum to type union, for improved declarative API.
  */
 export type AggregationType =
   | 'count'
@@ -71,15 +71,15 @@ export type AggregationType =
  * FILTERS
  */
 
-/** @internalRemarks Source: @carto/react-api */
+/** @privateRemarks Source: @carto/react-api */
 export type SpatialFilter = Polygon | MultiPolygon;
 
-/** @internalRemarks Source: @deck.gl/carto */
+/** @privateRemarks Source: @deck.gl/carto */
 export interface Filters {
   [column: string]: Filter;
 }
 
-/** @internalRemarks Source: @carto/react-api, @deck.gl/carto */
+/** @privateRemarks Source: @carto/react-api, @deck.gl/carto */
 export interface Filter {
   [FilterType.IN]?: {owner?: string; values: number[] | string[]};
   /** [a, b] both are included. */
@@ -94,7 +94,7 @@ export interface Filter {
   };
 }
 
-/** @internalRemarks Source: @carto/react-core */
+/** @privateRemarks Source: @carto/react-core */
 export type FilterLogicalOperator = 'and' | 'or';
 
 /**
@@ -120,7 +120,7 @@ export type StringSearchOptions = {
 /**
  * Defines a step size increment for use with {@link TimeSeriesRequestOptions}.
  *
- * @internalRemarks Source: @carto/react-core
+ * @privateRemarks Source: @carto/react-core
  */
 export type GroupDateType =
   | 'year'
@@ -142,7 +142,7 @@ export type SortColumnType = 'number' | 'string' | 'date';
  * SQL QUERY PARAMETERS
  */
 
-/** @internalRemarks Source: @deck.gl/carto */
+/** @privateRemarks Source: @deck.gl/carto */
 export type QueryParameterValue =
   | string
   | number
@@ -150,11 +150,11 @@ export type QueryParameterValue =
   | Array<QueryParameterValue>
   | object;
 
-/** @internalRemarks Source: @deck.gl/carto */
+/** @privateRemarks Source: @deck.gl/carto */
 export type NamedQueryParameter = Record<string, QueryParameterValue>;
 
-/** @internalRemarks Source: @deck.gl/carto */
+/** @privateRemarks Source: @deck.gl/carto */
 export type PositionalQueryParameter = QueryParameterValue[];
 
-/** @internalRemarks Source: @deck.gl/carto */
+/** @privateRemarks Source: @deck.gl/carto */
 export type QueryParameters = NamedQueryParameter | PositionalQueryParameter;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -39,7 +39,7 @@ type Row<T> = Record<string, T> | Record<string, T>[] | T[] | T;
  * Due to each data warehouse having its own behavior with columns,
  * we need to normalize them and transform every key to lowercase.
  *
- * @internalRemarks Source: @carto/react-widgets
+ * @privateRemarks Source: @carto/react-widgets
  * @internal
  */
 export function normalizeObjectKeys<T, R extends Row<T>>(el: R): R {
@@ -59,7 +59,7 @@ export function normalizeObjectKeys<T, R extends Row<T>>(el: R): R {
   ) as R;
 }
 
-/** @internalRemarks Source: @carto/react-core */
+/** @privateRemarks Source: @carto/react-core */
 export function assert(condition: unknown, message: string): asserts condition {
   if (!condition) {
     throw new Error(message);
@@ -67,7 +67,7 @@ export function assert(condition: unknown, message: string): asserts condition {
 }
 
 /**
- * @internalRemarks Source: @carto/react-core
+ * @privateRemarks Source: @carto/react-core
  * @internal
  */
 export class InvalidColumnError extends Error {

--- a/test/filters/Filter.test.ts
+++ b/test/filters/Filter.test.ts
@@ -2,9 +2,8 @@ import {describe, expect, test} from 'vitest';
 import {POINTS_BINARY_DATA, POLYGONS_BINARY_DATA} from './__fixtures.js';
 import {
   buildBinaryFeatureFilter,
-  buildFeatureFilter,
+  _buildFeatureFilter,
   FilterLogicalOperator,
-  TileData,
 } from '@carto/api-client';
 
 const filters = {
@@ -53,13 +52,13 @@ describe('Filters', () => {
   test('should return 1 if no filters present', () => {
     const params = {filters: {}, type: 'number' as const};
     const feature = makeFeatureWithValueInColumn();
-    expect(buildFeatureFilter(params)(feature)).toBe(1);
+    expect(_buildFeatureFilter(params)(feature)).toBe(1);
   });
 
   test('should return true if no filters present', () => {
     const params = {filters: {}, type: 'boolean' as const};
     const feature = makeFeatureWithValueInColumn();
-    expect(buildFeatureFilter(params)(feature)).toBe(true);
+    expect(_buildFeatureFilter(params)(feature)).toBe(true);
   });
 
   describe('feature passes filter - boolean type', () => {
@@ -70,7 +69,7 @@ describe('Filters', () => {
       for (const value of columnValues) {
         test(`${value} - with geojson feature`, () => {
           const feature = makeFeatureWithValueInColumn(value as any);
-          const withProps = buildFeatureFilter(params)(feature);
+          const withProps = _buildFeatureFilter(params)(feature);
           expect(withProps).toBe(false);
         });
       }
@@ -78,7 +77,7 @@ describe('Filters', () => {
       for (const value of columnValues) {
         test(`${value} - with geojson feature properties`, () => {
           const obj = makeObjectWithValueInColumn(value as any);
-          const noProps = buildFeatureFilter(params)(obj);
+          const noProps = _buildFeatureFilter(params)(obj);
           expect(noProps).toBe(false);
         });
       }
@@ -96,7 +95,7 @@ describe('Filters', () => {
       };
 
       test('with geojson feature', () => {
-        const filter = buildFeatureFilter(
+        const filter = _buildFeatureFilter(
           paramsWithFilterFunctionNotImplemented as any
         );
         const feature = makeFeatureWithValueInColumn();
@@ -106,7 +105,7 @@ describe('Filters', () => {
       });
 
       test('with geojson feature properties', () => {
-        const filter = buildFeatureFilter(
+        const filter = _buildFeatureFilter(
           paramsWithFilterFunctionNotImplemented as any
         );
         const obj = makeObjectWithValueInColumn();
@@ -123,7 +122,7 @@ describe('Filters', () => {
           column4: 'Alcalá de Guadaíra',
         },
       };
-      const featureIsIncluded = buildFeatureFilter(params)(feature);
+      const featureIsIncluded = _buildFeatureFilter(params)(feature);
       expect(featureIsIncluded).toBe(true);
     });
 
@@ -136,7 +135,7 @@ describe('Filters', () => {
           column4: 'test',
         },
       };
-      const featureIsIncluded = buildFeatureFilter(params)(feature);
+      const featureIsIncluded = _buildFeatureFilter(params)(feature);
       expect(featureIsIncluded).toBe(false);
     });
   });
@@ -167,7 +166,7 @@ describe('Filters', () => {
 
       for (const feature of notIncludedFeatures) {
         test(`${feature.properties.column1} - with geojson feature`, () => {
-          const isFeatureIncluded = buildFeatureFilter(
+          const isFeatureIncluded = _buildFeatureFilter(
             nullOrUndefinedAreNotValid
           )(feature);
           expect(isFeatureIncluded).toBe(0);
@@ -177,7 +176,7 @@ describe('Filters', () => {
       const notIncludedObjects = [{column1: null}, {column1: undefined}];
       for (const obj of notIncludedObjects) {
         test(`${obj.column1} - with geojson feature properties`, () => {
-          const isFeatureIncluded = buildFeatureFilter(
+          const isFeatureIncluded = _buildFeatureFilter(
             nullOrUndefinedAreNotValid
           )(obj);
           expect(isFeatureIncluded).toBe(0);
@@ -195,7 +194,7 @@ describe('Filters', () => {
 
       test(`ZERO - with geojson feature`, () => {
         const feature = makeFeatureWithValueInColumn(0);
-        const isFeatureIncluded = buildFeatureFilter(zeroIsValidForThisFilter)(
+        const isFeatureIncluded = _buildFeatureFilter(zeroIsValidForThisFilter)(
           feature
         );
         expect(isFeatureIncluded).toBe(1);
@@ -203,7 +202,7 @@ describe('Filters', () => {
 
       test(`ZERO - with geojson feature properties`, () => {
         const obj = makeObjectWithValueInColumn(0);
-        const isFeatureIncluded = buildFeatureFilter(zeroIsValidForThisFilter)(
+        const isFeatureIncluded = _buildFeatureFilter(zeroIsValidForThisFilter)(
           obj
         );
         expect(isFeatureIncluded).toBe(1);
@@ -222,7 +221,7 @@ describe('Filters', () => {
       };
 
       test('with geojson feature', () => {
-        const filter = buildFeatureFilter(
+        const filter = _buildFeatureFilter(
           paramsWithFilterFunctionNotImplemented as any
         );
         const feature = makeFeatureWithValueInColumn();
@@ -232,7 +231,7 @@ describe('Filters', () => {
       });
 
       test('with geojson feature properties', () => {
-        const filter = buildFeatureFilter(
+        const filter = _buildFeatureFilter(
           paramsWithFilterFunctionNotImplemented as any
         );
         const obj = makeObjectWithValueInColumn();
@@ -249,7 +248,7 @@ describe('Filters', () => {
           column4: 'Alcalá de Guadaíra',
         },
       };
-      const featureIsIncluded = buildFeatureFilter(params)(feature);
+      const featureIsIncluded = _buildFeatureFilter(params)(feature);
       expect(featureIsIncluded).toBe(1);
     });
 
@@ -262,7 +261,7 @@ describe('Filters', () => {
           column4: 'test',
         },
       };
-      const featureIsIncluded = buildFeatureFilter(params)(feature);
+      const featureIsIncluded = _buildFeatureFilter(params)(feature);
       expect(featureIsIncluded).toBe(0);
     });
 
@@ -276,7 +275,7 @@ describe('Filters', () => {
 
       test(`left endpoint is ALWAYS included - with geojson feature`, () => {
         const feature = makeFeatureWithValueInColumn(10);
-        const isFeatureIncluded = buildFeatureFilter(zeroIsValidForThisFilter)(
+        const isFeatureIncluded = _buildFeatureFilter(zeroIsValidForThisFilter)(
           feature
         );
         expect(isFeatureIncluded).toBe(1);
@@ -284,7 +283,7 @@ describe('Filters', () => {
 
       test(`rigth endpoint is NEVER included - with geojson feature`, () => {
         const feature = makeFeatureWithValueInColumn(20);
-        const isFeatureIncluded = buildFeatureFilter(zeroIsValidForThisFilter)(
+        const isFeatureIncluded = _buildFeatureFilter(zeroIsValidForThisFilter)(
           feature
         );
         expect(isFeatureIncluded).toBe(0);
@@ -292,7 +291,7 @@ describe('Filters', () => {
 
       test(`left endpoint is ALWAYS included - with geojson feature properties`, () => {
         const obj = makeObjectWithValueInColumn(10);
-        const isFeatureIncluded = buildFeatureFilter(zeroIsValidForThisFilter)(
+        const isFeatureIncluded = _buildFeatureFilter(zeroIsValidForThisFilter)(
           obj
         );
         expect(isFeatureIncluded).toBe(1);
@@ -300,7 +299,7 @@ describe('Filters', () => {
 
       test(`rigth endpoint is NEVER included - with geojson feature properties`, () => {
         const obj = makeObjectWithValueInColumn(20);
-        const isFeatureIncluded = buildFeatureFilter(zeroIsValidForThisFilter)(
+        const isFeatureIncluded = _buildFeatureFilter(zeroIsValidForThisFilter)(
           obj
         );
         expect(isFeatureIncluded).toBe(0);
@@ -327,22 +326,22 @@ describe('Filters', () => {
 
     test('should pass if only first column passes', () => {
       const feature = {properties: {column1: 1, column2: null}};
-      const result = buildFeatureFilter(params)(feature);
+      const result = _buildFeatureFilter(params)(feature);
       expect(result).toBe(true);
     });
     test('should pass if only second column passes', () => {
       const feature = {properties: {column1: null, column2: 2}};
-      const result = buildFeatureFilter(params)(feature);
+      const result = _buildFeatureFilter(params)(feature);
       expect(result).toBe(true);
     });
     test('should pass if both columns pass', () => {
       const feature = {properties: {column1: 1, column2: 2}};
-      const result = buildFeatureFilter(params)(feature);
+      const result = _buildFeatureFilter(params)(feature);
       expect(result).toBe(true);
     });
     test('should not pass if none of the columns pass', () => {
       const feature = {properties: {column1: null, column2: null}};
-      const result = buildFeatureFilter(params)(feature);
+      const result = _buildFeatureFilter(params)(feature);
       expect(result).toBe(false);
     });
   });
@@ -359,8 +358,7 @@ describe('Filters', () => {
       const filterFn = buildBinaryFeatureFilter({filters: filterForBinaryData});
 
       const filterRes = POINTS_BINARY_DATA.featureIds.value.map(
-        (_, idx) =>
-          filterFn(idx, POINTS_BINARY_DATA as unknown as TileData) as number
+        (_, idx: number) => filterFn(idx, POINTS_BINARY_DATA) as number
       );
 
       expect(filterRes[0]).toBe(1);
@@ -379,8 +377,7 @@ describe('Filters', () => {
       const filterFn = buildBinaryFeatureFilter({filters: filterForBinaryData});
 
       const filterRes = POLYGONS_BINARY_DATA.featureIds.value.map(
-        (_, idx) =>
-          filterFn(idx, POLYGONS_BINARY_DATA as unknown as TileData) as number
+        (_, idx: number) => filterFn(idx, POLYGONS_BINARY_DATA) as number
       );
 
       expect(filterRes[0]).toBe(1);
@@ -400,9 +397,9 @@ describe('Filters', () => {
         filters: filterForBinaryData,
       } as any);
 
-      expect(() =>
-        filterFn(0, POLYGONS_BINARY_DATA as unknown as TileData)
-      ).toThrow('"pow" filter is not implemented');
+      expect(() => filterFn(0, POLYGONS_BINARY_DATA)).toThrow(
+        '"pow" filter is not implemented'
+      );
     });
 
     test('should returns always 0 when values is nullish', () => {
@@ -417,8 +414,7 @@ describe('Filters', () => {
       const filterFn = buildBinaryFeatureFilter({filters: filterForBinaryData});
 
       const filterRes = POLYGONS_BINARY_DATA.featureIds.value.map(
-        (_, idx) =>
-          filterFn(idx, POLYGONS_BINARY_DATA as unknown as TileData) as number
+        (_, idx: number) => filterFn(idx, POLYGONS_BINARY_DATA) as number
       );
 
       expect(filterRes.every((el) => el === 0)).toBe(true);

--- a/test/filters/__fixtures.ts
+++ b/test/filters/__fixtures.ts
@@ -1,4 +1,7 @@
-export const POINTS_BINARY_DATA = {
+import {BinaryPointFeature, BinaryPolygonFeature} from '@loaders.gl/schema';
+
+export const POINTS_BINARY_DATA: BinaryPointFeature = {
+  type: 'Point',
   positions: {
     value: Float32Array.of(
       0.672607421875,
@@ -414,7 +417,8 @@ export const POINTS_BINARY_DATA = {
   fields: [],
 };
 
-export const POLYGONS_BINARY_DATA = {
+export const POLYGONS_BINARY_DATA: BinaryPolygonFeature = {
+  type: 'Polygon',
   polygonIndices: {
     value: Uint16Array.of(0, 5, 10),
     size: 1,


### PR DESCRIPTION
Changes:

- find/replace `@internalRemarks` → `@privateRemarks` (https://tsdoc.org/pages/tags/privateremarks/)
- rename `buildFeatureFilter` → `_buildFeatureFilter`, to make clearer that this is an internal API, exported only for `@deck.gl/carto` and unit tests
    - related to https://github.com/visgl/deck.gl/pull/9448