### PR TITLE
feat(deck): Add getDataFilterExtensionProps

### DIFF
--- a/src/deck/get-data-filter-extension-props.ts
+++ b/src/deck/get-data-filter-extension-props.ts
@@ -1,0 +1,146 @@
+import {Feature} from 'geojson';
+import {FilterLogicalOperator, Filters} from '../types.js';
+import {FilterType} from '../constants.js';
+import {_buildFeatureFilter} from '../filters/index.js';
+import {FeatureData} from '../types-internal.js';
+
+type TimeFilter = Filters['string'][FilterType.TIME] & {
+  params?: {offsetBy?: number};
+};
+
+/** @experimental Prefer type definition from deck.gl. */
+export type _DataFilterExtensionProps = {
+  filterRange: number[][];
+  updateTriggers: Record<string, string>;
+  getFilterValue: (feature: Feature | FeatureData) => number[];
+};
+
+/**
+ * Creates props for DataFilterExtension, from `@deck.gl/extensions`, given
+ * a set of filters.
+ *
+ * @privateRemarks DataFilterExtension accepts up to 4 values to filter. This
+ *  implementation uses the 1st for all filters except the time filter, and the
+ *  2nd for the time filter.
+ */
+export function getDataFilterExtensionProps(
+  filters: Filters,
+  filtersLogicalOperator?: FilterLogicalOperator,
+  filterSize?: 0 | 1 | 2 | 3 | 4
+): _DataFilterExtensionProps {
+  filterSize ??= 4;
+  const {filtersWithoutTimeType, timeColumn, timeFilter} =
+    getFiltersByType(filters);
+  return {
+    filterRange: getFilterRange(timeFilter, filterSize),
+    updateTriggers: getUpdateTriggers(
+      filtersWithoutTimeType,
+      timeColumn,
+      timeFilter
+    ),
+    getFilterValue: getFilterValue(
+      filtersWithoutTimeType,
+      timeColumn,
+      timeFilter,
+      filterSize,
+      filtersLogicalOperator
+    ),
+  };
+}
+
+/** @internal */
+function getFiltersByType(filters: Filters) {
+  const filtersWithoutTimeType: Filters = {};
+
+  let timeColumn: string | null = null;
+  let timeFilter: TimeFilter | null = null;
+
+  for (const [column, columnData] of Object.entries(filters)) {
+    for (const [type, typeData] of Object.entries(columnData) as [
+      FilterType,
+      unknown,
+    ][]) {
+      if (type === FilterType.TIME) {
+        timeColumn = column;
+        timeFilter = typeData as TimeFilter;
+      } else {
+        filtersWithoutTimeType[column] = {[type]: typeData};
+      }
+    }
+  }
+
+  return {
+    filtersWithoutTimeType,
+    timeColumn,
+    timeFilter,
+  };
+}
+
+/** @internal */
+function getFilterRange(
+  timeFilter: TimeFilter | null,
+  filterSize: number
+): number[][] {
+  const result = Array(filterSize).fill([0, 0]);
+  // According to getFilterValue all filters are resolved as 0 or 1 in the first position of the array
+  // except the time filter value that is resolved with the real value of the feature in the second position of the array
+  result[0] = [1, 1];
+  if (timeFilter) {
+    const offsetBy = timeFilter.params?.offsetBy || 0;
+    result[1] = timeFilter.values[0].map((v) => v - offsetBy);
+  }
+  return result;
+}
+
+/** @internal */
+function getUpdateTriggers(
+  filtersWithoutTimeType: Filters,
+  timeColumn: string | null,
+  timeFilter: TimeFilter | null
+) {
+  const result: Record<string, object> = {...filtersWithoutTimeType};
+
+  // We don't want to change the layer UpdateTriggers every time that the time filter changes
+  // because this filter is changed by the time series widget during its animation
+  // so we remove the time filter value from the `updateTriggers`
+  if (timeColumn && timeFilter) {
+    result[timeColumn] = {
+      ...result[timeColumn],
+      offsetBy: timeFilter.params?.offsetBy,
+      [FilterType.TIME]: {}, // Allows working with other filters, without an impact on performance.
+    };
+  }
+  return {
+    getFilterValue: JSON.stringify(result),
+  };
+}
+
+/** @internal */
+function getFilterValue(
+  filtersWithoutTimeType: Filters,
+  timeColumn: string | null,
+  timeFilter: TimeFilter | null,
+  filterSize: number,
+  filtersLogicalOperator?: FilterLogicalOperator
+) {
+  const result = Array(filterSize).fill(0);
+  const featureFilter = _buildFeatureFilter({
+    filters: filtersWithoutTimeType,
+    type: 'number',
+    filtersLogicalOperator,
+  });
+
+  // We evaluate all filters except the time filter using _buildFeatureFilter function.
+  // For the time filter, we return the value of the feature and we will change the getFilterRange result
+  // every time this filter changes
+  return (feature: Feature | FeatureData) => {
+    result[0] = featureFilter(feature);
+
+    if (timeColumn && timeFilter) {
+      const offsetBy = timeFilter.params?.offsetBy || 0;
+      const f = (feature.properties || feature) as Record<string, unknown>;
+      result[1] = (f[timeColumn] as number) - offsetBy;
+    }
+    return result;
+  };
+}

--- a/src/deck/index.ts
+++ b/src/deck/index.ts
@@ -1,0 +1,1 @@
+export * from './get-data-filter-extension-props.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export * from './client.js';
 export * from './constants.js';
+export * from './deck/index.js';
 export * from './filters.js';
 export * from './geo.js';
 export * from './sources/index.js';

--- a/test/deck/get-data-filter-extension-props.test.ts
+++ b/test/deck/get-data-filter-extension-props.test.ts
@@ -1,0 +1,106 @@
+import {describe, test, expect} from 'vitest';
+import {getDataFilterExtensionProps} from '@carto/api-client';
+import {Feature} from 'geojson';
+
+describe('getDataFilterExtensionProps', () => {
+  test('filters', () => {
+    const filters = {
+      storetype: {
+        in: {
+          values: ['Supermarket'],
+          owner: 'revenueByStoreType',
+        },
+      },
+      revenue: {
+        closed_open: {
+          values: [[1400000, 1500000]],
+          owner: 'storesByRevenue',
+        },
+      },
+    };
+    const featurePassesFilter: Feature = {
+      type: 'Feature',
+      geometry: {type: 'Point', coordinates: [0, 0]},
+      properties: {
+        storetype: 'Supermarket',
+        revenue: 1400001,
+      },
+    };
+    const featureNotFilter: Feature = {
+      type: 'Feature',
+      geometry: {type: 'Point', coordinates: [0, 0]},
+      properties: {
+        storetype: 'Supermarket',
+        revenue: 100,
+      },
+    };
+    const {filterRange, updateTriggers, getFilterValue} =
+      getDataFilterExtensionProps(filters);
+
+    expect(filterRange.length).toBe(4);
+
+    filterRange.forEach((range, index) => {
+      expect(range).toStrictEqual(index === 0 ? [1, 1] : [0, 0]);
+    });
+
+    expect(updateTriggers.getFilterValue).toBe(JSON.stringify(filters));
+    expect(getFilterValue(featurePassesFilter)).toStrictEqual([1, 0, 0, 0]);
+    expect(getFilterValue(featureNotFilter)).toStrictEqual([0, 0, 0, 0]);
+  });
+});
+
+test('time', () => {
+  const offsetBy = 473380000000;
+  const filters = {
+    storetype: {
+      in: {
+        values: ['Supermarket'],
+        owner: 'revenueByStoreType',
+      },
+    },
+    dateTime: {
+      time: {
+        values: [[473385600000, 504921600000]],
+        owner: 'storesByRevenue',
+        params: {offsetBy},
+      },
+    },
+  };
+
+  const feature: Feature = {
+    type: 'Feature',
+    geometry: {type: 'Point', coordinates: [0, 0]},
+    properties: {
+      storetype: 'Supermarket',
+      dateTime: 473385600001,
+    },
+  };
+
+  const {filterRange, updateTriggers, getFilterValue} =
+    getDataFilterExtensionProps(filters);
+
+  expect(filterRange.length).toBe(4);
+
+  filterRange.forEach((range, index) => {
+    if (index === 0) {
+      expect(range).toStrictEqual([1, 1]);
+    } else if (index === 1) {
+      expect(range).toStrictEqual(
+        filters.dateTime.time.values[0].map((v) => v - offsetBy)
+      );
+    } else {
+      expect(range).toStrictEqual([0, 0]);
+    }
+  });
+
+  expect(updateTriggers.getFilterValue).toBe(
+    JSON.stringify({...filters, dateTime: {offsetBy, time: {}}})
+  );
+
+  expect(getFilterValue(feature)).toStrictEqual([
+    1,
+    feature.properties.dateTime - offsetBy,
+    0,
+    0,
+  ]);
+});


### PR DESCRIPTION
Migrates `getDataFilterExtensionProps(filters)` from `@carto/react-api` to `@cart/api-client`, for applications using deck.gl and CARTO, which may or may not be using React.

Changes, compared to [original implementation](https://github.com/CartoDB/carto-react/blob/72a07903f6bee93ea66808fe9fc7d09a5121522a/packages/react-api/src/hooks/dataFilterExtensionUtil.js#L4):

- replaced global constant MAX_GPU_FILTERS with optional `filterSize` parameter
- removed global singleton DataFilterExtension, user may define extension(s) as needed
- updated helper function signatures to use types from `@carto/api-client`

Example:

```javascript
import { DataFilterExtension } from '@deck.gl/extensions';
import { getDataFilterExtensionProps } from '@carto/api-client';

const layer = new VectorTileLayer({
  data,
  ...
  extensions: [new DataFilterExtension({ filterSize: 4 })],
  ...getDataFilterExtensionProps(filters),
});
```