### PR TITLE
chore(npm): Remove package.json#packageConfig

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,10 +10,6 @@
   "packageManager": "yarn@4.3.1",
   "version": "0.5.0-alpha.2",
   "license": "MIT",
-  "publishConfig": {
-    "access": "public",
-    "tag": "alpha"
-  },
   "type": "module",
   "sideEffects": false,
   "source": "src/index.ts",


### PR DESCRIPTION
This config was needed during initial development, but now that the package is published with stable releases, it can be removed.