### PR TITLE
feat(widgets): Accept HTTP headers from constructors

### DIFF
--- a/src/widget-sources/widget-remote-source.ts
+++ b/src/widget-sources/widget-remote-source.ts
@@ -31,13 +31,6 @@ export type WidgetRemoteSourceProps = WidgetSourceProps;
 export abstract class WidgetRemoteSource<
   Props extends WidgetRemoteSourceProps,
 > extends WidgetSource<Props> {
-  protected _headers: Record<string, string> = {};
-
-  /** Assigns HTTP headers to be included on API requests from this source. */
-  setRequestHeaders(headers: Record<string, string>): void {
-    this._headers = headers;
-  }
-
   async getCategories(
     options: CategoryRequestOptions
   ): Promise<CategoryResponse> {
@@ -73,7 +66,7 @@ export abstract class WidgetRemoteSource<
         operation,
         operationColumn: operationColumn || column,
       },
-      opts: {signal, headers: this._headers},
+      opts: {signal, headers: this.props.headers},
     }).then((res: CategoriesModelResponse) => normalizeObjectKeys(res.rows));
   }
 
@@ -115,7 +108,7 @@ export abstract class WidgetRemoteSource<
         limit: limit || 1000,
         tileResolution: tileResolution || DEFAULT_TILE_RESOLUTION,
       },
-      opts: {signal, headers: this._headers},
+      opts: {signal, headers: this.props.headers},
       // Avoid `normalizeObjectKeys()`, which changes column names.
     }).then(({rows}: FeaturesModelResponse) => ({rows}));
   }
@@ -154,7 +147,7 @@ export abstract class WidgetRemoteSource<
         operation: operation ?? 'count',
         operationExp,
       },
-      opts: {signal, headers: this._headers},
+      opts: {signal, headers: this.props.headers},
     }).then((res: FormulaModelResponse) => normalizeObjectKeys(res.rows[0]));
   }
 
@@ -189,7 +182,7 @@ export abstract class WidgetRemoteSource<
         spatialFilter,
       },
       params: {column, operation, ticks},
-      opts: {signal, headers: this._headers},
+      opts: {signal, headers: this.props.headers},
     }).then((res: HistogramModelResponse) => normalizeObjectKeys(res.rows));
 
     if (data.length) {
@@ -234,7 +227,7 @@ export abstract class WidgetRemoteSource<
         spatialFilter,
       },
       params: {column},
-      opts: {signal, headers: this._headers},
+      opts: {signal, headers: this.props.headers},
     }).then((res: RangeModelResponse) => normalizeObjectKeys(res.rows[0]));
   }
 
@@ -278,7 +271,7 @@ export abstract class WidgetRemoteSource<
         yAxisJoinOperation,
         limit: HARD_LIMIT,
       },
-      opts: {signal, headers: this._headers},
+      opts: {signal, headers: this.props.headers},
     })
       .then((res: ScatterModelResponse) => normalizeObjectKeys(res.rows))
       .then((res) => res.map(({x, y}: {x: number; y: number}) => [x, y]));
@@ -322,7 +315,7 @@ export abstract class WidgetRemoteSource<
         limit,
         offset,
       },
-      opts: {signal, headers: this._headers},
+      opts: {signal, headers: this.props.headers},
     }).then((res: TableModelResponse) => ({
       // Avoid `normalizeObjectKeys()`, which changes column names.
       rows: res.rows ?? (res as any).ROWS,
@@ -385,7 +378,7 @@ export abstract class WidgetRemoteSource<
         splitByCategoryLimit,
         splitByCategoryValues,
       },
-      opts: {signal, headers: this._headers},
+      opts: {signal, headers: this.props.headers},
     }).then((res: TimeSeriesModelResponse) => ({
       rows: normalizeObjectKeys(res.rows),
       categories: res.metadata?.categories,

--- a/test/widget-sources/widget-remote-source.test.ts
+++ b/test/widget-sources/widget-remote-source.test.ts
@@ -48,7 +48,7 @@ test('setRequestHeaders', async () => {
   const mockFetch = vi.fn().mockResolvedValue(mockResponse);
   vi.stubGlobal('fetch', mockFetch);
 
-  const widgetSource = new WidgetTestSource({
+  let widgetSource = new WidgetTestSource({
     accessToken: '<token>',
     connectionName: 'carto_dw',
   });
@@ -60,7 +60,12 @@ test('setRequestHeaders', async () => {
     Authorization: 'Bearer <token>',
   });
 
-  widgetSource.setRequestHeaders({'Cache-Control': 'public'});
+  widgetSource = new WidgetTestSource({
+    accessToken: '<token>',
+    connectionName: 'carto_dw',
+    headers: {'Cache-Control': 'public'},
+  });
+
   await widgetSource.getFormula({column: 'store_name', operation: 'count'});
 
   expect(mockFetch).toHaveBeenCalledTimes(2);


### PR DESCRIPTION
Simplifying the changes from #100 before making the stable release in v0.5. Removes the setRequestHeaders() method and just uses headers specified in the vectorTableSource / WidgetTableSource / ... constructors.

For example, either of these should be supported:

```javascript
const data = vectorTableSource({
  accessToken: '••••',
  connectionName: 'carto_dw',
  tableName: 'carto-demo-data.demo_tables.retail_stores',
  headers: {'Cache-Control': 'max-age=1234'},
});

const widgetSource = new WidgetTableSource({
  accessToken: '••••',
  connectionName: 'carto_dw',
  tableName: 'carto-demo-data.demo_tables.retail_stores',
  headers: {'Cache-Control': 'max-age=1234'},
});
```