### PR TITLE
Revert "chore(npm): Remove package.json#packageConfig"

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,10 @@
   "packageManager": "yarn@4.3.1",
   "version": "0.5.0-alpha.2",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public",
+    "tag": "alpha"
+  },
   "type": "module",
   "sideEffects": false,
   "source": "src/index.ts",

--- a/package.json
+++ b/package.json
@@ -11,8 +11,7 @@
   "version": "0.5.0-alpha.2",
   "license": "MIT",
   "publishConfig": {
-    "access": "public",
-    "tag": "alpha"
+    "access": "public"
   },
   "type": "module",
   "sideEffects": false,


### PR DESCRIPTION
Reverts CartoDB/carto-api-client#109, minus the 'alpha' tag, see:

https://github.com/CartoDB/carto-api-client/pull/109#issuecomment-2683203649