### PR TITLE
fix(widgets): Fix custom clientId in table and query widget calls

### DIFF
--- a/src/widget-sources/widget-source.ts
+++ b/src/widget-sources/widget-source.ts
@@ -54,7 +54,11 @@ export abstract class WidgetSource<Props extends WidgetSourceProps> {
   };
 
   constructor(props: Props) {
-    this.props = {...WidgetSource.defaultProps, ...props};
+    this.props = {
+      ...WidgetSource.defaultProps,
+      clientId: getClient(), // Refresh clientId, default may have changed.
+      ...props,
+    };
   }
 
   /**

--- a/test/widget-sources/widget-remote-source.test.ts
+++ b/test/widget-sources/widget-remote-source.test.ts
@@ -47,7 +47,8 @@ test('constructor', () => {
 
 test('clientId', () => {
   const clientId1 = getClient();
-  const clientId2 = 'testtesttest';
+  const clientId2 = 'new default';
+  const clientId3 = 'override default';
 
   const widgetSource1 = new WidgetTestSource({
     accessToken: '<token>',
@@ -61,8 +62,15 @@ test('clientId', () => {
     connectionName: 'carto_dw',
   });
 
+  const widgetSource3 = new WidgetTestSource({
+    accessToken: '<token>',
+    connectionName: 'carto_dw',
+    clientId: clientId3,
+  });
+
   expect(widgetSource1.props.clientId).toBe(clientId1);
   expect(widgetSource2.props.clientId).toBe(clientId2);
+  expect(widgetSource3.props.clientId).toBe(clientId3);
 });
 
 test('setRequestHeaders', async () => {

--- a/test/widget-sources/widget-remote-source.test.ts
+++ b/test/widget-sources/widget-remote-source.test.ts
@@ -2,6 +2,8 @@ import {afterEach, expect, test, vi} from 'vitest';
 import {
   Filters,
   FilterType,
+  getClient,
+  setClient,
   WidgetRemoteSource,
   WidgetRemoteSourceProps,
 } from '@carto/api-client';
@@ -41,6 +43,26 @@ test('constructor', () => {
     accessToken: '<token>',
     connectionName: 'carto_dw',
   });
+});
+
+test('clientId', () => {
+  const clientId1 = getClient();
+  const clientId2 = 'testtesttest';
+
+  const widgetSource1 = new WidgetTestSource({
+    accessToken: '<token>',
+    connectionName: 'carto_dw',
+  });
+
+  setClient(clientId2);
+
+  const widgetSource2 = new WidgetTestSource({
+    accessToken: '<token>',
+    connectionName: 'carto_dw',
+  });
+
+  expect(widgetSource1.props.clientId).toBe(clientId1);
+  expect(widgetSource2.props.clientId).toBe(clientId2);
 });
 
 test('setRequestHeaders', async () => {


### PR DESCRIPTION
The `WidgetSource.defaultProps` static property assigns `getClient()` when the class is defined, not instantiated. If `setClient()` is called by an application later, new instances of the class inherit the old clientId. This PR adds a fix so that `getClient()` is called each time a class is created, and each WidgetSource will have a clientId matching the default at the time it was created. A clientId passed to the WidgetSource constructor will override any defaults.