### PR TITLE
chore(release): v0.4.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,24 @@
 # CHANGELOG
 
-## Not released
+## 0.5 (Unreleased)
+
+### 0.5.0 (Unreleased)
+
+- BREAKING CHANGE: Replace 'abortController' with 'signal' parameter (#110)
+- feat: Add widget calculations for tileset sources (#50)
+- feat: Add widget calculations for raster sources (#119)
+- feat: Enable Web Workers for local tileset and raster widget calculations (#119)
 
 ## 0.4
+
+### 0.4.7
+
+- fix: Fix clientId customization in table and query widget calls (#120)
+- feat: Add getDataFilterExtensionProps (#105, #113)
+- feat: Add option to override HTTP headers in widget calls (#100, #111)
+- feat: Add filters parameter in widget calls (#103)
+- chore: Update to turf.js v7.2 (#98)
+- chore: Enable compatibility with moduleResolution=nodenext (#106)
 
 ### 0.4.6
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "homepage": "https://github.com/CartoDB/carto-api-client#readme",
   "author": "Don McCurdy <donmccurdy@carto.com>",
   "packageManager": "yarn@4.3.1",
-  "version": "0.5.0-alpha.2",
+  "version": "0.4.7",
   "license": "MIT",
   "publishConfig": {
     "access": "public"
@@ -111,6 +111,5 @@
   },
   "resolutions": {
     "rollup": "^4.20.0"
-  },
-  "stableVersion": "0.4.6"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "vitest": "3.0.7"
   },
   "resolutions": {
+    "@carto/api-client": "portal:./",
     "rollup": "^4.20.0"
   }
 }

--- a/src/sources/h3-tileset-source.ts
+++ b/src/sources/h3-tileset-source.ts
@@ -2,11 +2,6 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {getTileFormat} from '../utils/getTileFormat.js';
-import {
-  WidgetTilesetSource,
-  WidgetTilesetSourceResult,
-} from '../widget-sources/index.js';
 import {baseSource} from './base-source.js';
 import type {
   SourceOptions,
@@ -17,24 +12,17 @@ import type {
 export type H3TilesetSourceOptions = SourceOptions & TilesetSourceOptions;
 type UrlParameters = {name: string};
 
-export type H3TilesetSourceResponse = TilejsonResult &
-  WidgetTilesetSourceResult;
+export type H3TilesetSourceResponse = TilejsonResult;
 
 export const h3TilesetSource = async function (
   options: H3TilesetSourceOptions
 ): Promise<H3TilesetSourceResponse> {
-  const {tableName, spatialDataColumn = 'h3'} = options;
+  const {tableName} = options;
   const urlParameters: UrlParameters = {name: tableName};
 
-  return baseSource<UrlParameters>('tileset', options, urlParameters).then(
-    (result) => ({
-      ...(result as TilejsonResult),
-      widgetSource: new WidgetTilesetSource({
-        ...options,
-        tileFormat: getTileFormat(result as TilejsonResult),
-        spatialDataColumn,
-        spatialDataType: 'h3',
-      }),
-    })
+  return baseSource<UrlParameters>(
+    'tileset',
+    options,
+    urlParameters
   ) as Promise<H3TilesetSourceResponse>;
 };

--- a/src/sources/quadbin-tileset-source.ts
+++ b/src/sources/quadbin-tileset-source.ts
@@ -2,11 +2,6 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {getTileFormat} from '../utils/getTileFormat.js';
-import {
-  WidgetTilesetSource,
-  WidgetTilesetSourceResult,
-} from '../widget-sources/index.js';
 import {baseSource} from './base-source.js';
 import type {
   SourceOptions,
@@ -17,24 +12,17 @@ import type {
 export type QuadbinTilesetSourceOptions = SourceOptions & TilesetSourceOptions;
 type UrlParameters = {name: string};
 
-export type QuadbinTilesetSourceResponse = TilejsonResult &
-  WidgetTilesetSourceResult;
+export type QuadbinTilesetSourceResponse = TilejsonResult;
 
 export const quadbinTilesetSource = async function (
   options: QuadbinTilesetSourceOptions
 ): Promise<QuadbinTilesetSourceResponse> {
-  const {tableName, spatialDataColumn = 'quadbin'} = options;
+  const {tableName} = options;
   const urlParameters: UrlParameters = {name: tableName};
 
-  return baseSource<UrlParameters>('tileset', options, urlParameters).then(
-    (result) => ({
-      ...(result as TilejsonResult),
-      widgetSource: new WidgetTilesetSource({
-        ...options,
-        tileFormat: getTileFormat(result as TilejsonResult),
-        spatialDataColumn,
-        spatialDataType: 'quadbin',
-      }),
-    })
+  return baseSource<UrlParameters>(
+    'tileset',
+    options,
+    urlParameters
   ) as Promise<QuadbinTilesetSourceResponse>;
 };

--- a/src/sources/vector-tileset-source.ts
+++ b/src/sources/vector-tileset-source.ts
@@ -2,12 +2,6 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {DEFAULT_GEO_COLUMN} from '../constants-internal.js';
-import {getTileFormat} from '../utils/getTileFormat.js';
-import {
-  WidgetTilesetSource,
-  WidgetTilesetSourceResult,
-} from '../widget-sources/index.js';
 import {baseSource} from './base-source.js';
 import type {
   SourceOptions,
@@ -18,24 +12,17 @@ import type {
 export type VectorTilesetSourceOptions = SourceOptions & TilesetSourceOptions;
 type UrlParameters = {name: string};
 
-export type VectorTilesetSourceResponse = TilejsonResult &
-  WidgetTilesetSourceResult;
+export type VectorTilesetSourceResponse = TilejsonResult;
 
 export const vectorTilesetSource = async function (
   options: VectorTilesetSourceOptions
 ): Promise<VectorTilesetSourceResponse> {
-  const {tableName, spatialDataColumn = DEFAULT_GEO_COLUMN} = options;
+  const {tableName} = options;
   const urlParameters: UrlParameters = {name: tableName};
 
-  return baseSource<UrlParameters>('tileset', options, urlParameters).then(
-    (result) => ({
-      ...(result as TilejsonResult),
-      widgetSource: new WidgetTilesetSource({
-        ...options,
-        tileFormat: getTileFormat(result as TilejsonResult),
-        spatialDataColumn,
-        spatialDataType: 'geo',
-      }),
-    })
+  return baseSource<UrlParameters>(
+    'tileset',
+    options,
+    urlParameters
   ) as Promise<VectorTilesetSourceResponse>;
 };

--- a/src/widget-sources/types.ts
+++ b/src/widget-sources/types.ts
@@ -19,6 +19,8 @@ export interface ViewState {
 
 /** Common options for {@link WidgetRemoteSource} requests. */
 interface BaseRequestOptions {
+  /** @deprecated */
+  abortController?: AbortController;
   signal?: AbortSignal;
   spatialFilter?: SpatialFilter;
   spatialFiltersMode?: SpatialFilterPolyfillMode;

--- a/src/widget-sources/widget-remote-source.ts
+++ b/src/widget-sources/widget-remote-source.ts
@@ -74,7 +74,8 @@ export abstract class WidgetRemoteSource<
     options: FeaturesRequestOptions
   ): Promise<FeaturesResponse> {
     const {
-      signal,
+      abortController,
+      signal = abortController?.signal,
       filters = this.props.filters,
       filterOwner,
       spatialFilter,
@@ -115,7 +116,8 @@ export abstract class WidgetRemoteSource<
 
   async getFormula(options: FormulaRequestOptions): Promise<FormulaResponse> {
     const {
-      signal,
+      abortController,
+      signal = abortController?.signal,
       filters = this.props.filters,
       filterOwner,
       spatialFilter,
@@ -155,7 +157,8 @@ export abstract class WidgetRemoteSource<
     options: HistogramRequestOptions
   ): Promise<HistogramResponse> {
     const {
-      signal,
+      abortController,
+      signal = abortController?.signal,
       filters = this.props.filters,
       filterOwner,
       spatialFilter,
@@ -200,7 +203,8 @@ export abstract class WidgetRemoteSource<
 
   async getRange(options: RangeRequestOptions): Promise<RangeResponse> {
     const {
-      signal,
+      abortController,
+      signal = abortController?.signal,
       filters = this.props.filters,
       filterOwner,
       spatialFilter,
@@ -233,7 +237,8 @@ export abstract class WidgetRemoteSource<
 
   async getScatter(options: ScatterRequestOptions): Promise<ScatterResponse> {
     const {
-      signal,
+      abortController,
+      signal = abortController?.signal,
       filters = this.props.filters,
       filterOwner,
       spatialFilter,
@@ -279,7 +284,8 @@ export abstract class WidgetRemoteSource<
 
   async getTable(options: TableRequestOptions): Promise<TableResponse> {
     const {
-      signal,
+      abortController,
+      signal = abortController?.signal,
       filters = this.props.filters,
       filterOwner,
       spatialFilter,
@@ -327,7 +333,8 @@ export abstract class WidgetRemoteSource<
     options: TimeSeriesRequestOptions
   ): Promise<TimeSeriesResponse> {
     const {
-      signal,
+      abortController,
+      signal = abortController?.signal,
       filters = this.props.filters,
       filterOwner,
       spatialFilter,

--- a/src/widget-sources/widget-source.ts
+++ b/src/widget-sources/widget-source.ts
@@ -171,3 +171,15 @@ export abstract class WidgetSource<Props extends WidgetSourceProps> {
     options: TimeSeriesRequestOptions
   ): Promise<TimeSeriesResponse>;
 }
+
+/**
+ * @todo TODO(v0.5): Remove WidgetBaseSourceProps alias
+ * @deprecated Use WidgetSourceProps.
+ */
+export type WidgetBaseSourceProps = WidgetSourceProps;
+
+/**
+ * @todo TODO(v0.5): Remove WidgetBaseSource alias.
+ * @deprecated Use WidgetSourceP.
+ */
+export const WidgetBaseSource = WidgetSource;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1444,19 +1444,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@carto/api-client@npm:^0.4.4":
-  version: 0.4.6
-  resolution: "@carto/api-client@npm:0.4.6"
+"@carto/api-client@portal:./::locator=%40carto%2Fapi-client%40workspace%3A.":
+  version: 0.0.0-use.local
+  resolution: "@carto/api-client@portal:./::locator=%40carto%2Fapi-client%40workspace%3A."
   dependencies:
-    "@turf/bbox-clip": "npm:^7.1.0"
-    "@turf/bbox-polygon": "npm:^7.1.0"
-    "@turf/helpers": "npm:^7.1.0"
-    "@turf/invariant": "npm:^7.1.0"
-    "@turf/union": "npm:^7.1.0"
-    "@types/geojson": "npm:^7946.0.15"
-  checksum: 10c0/0fecabaa58226603c2f200d811db07ef620690e619d18bbd1c906b093a0fe8215c5ecf1a0571416830a3564fd9b3a5379d7b261504e17cbdc08f4de80443fe7e
+    "@loaders.gl/schema": "npm:^4.3.3"
+    "@turf/bbox-clip": "npm:^7.2.0"
+    "@turf/bbox-polygon": "npm:^7.2.0"
+    "@turf/boolean-equal": "npm:^7.2.0"
+    "@turf/boolean-intersects": "npm:^7.2.0"
+    "@turf/boolean-within": "npm:^7.2.0"
+    "@turf/helpers": "npm:^7.2.0"
+    "@turf/intersect": "npm:^7.2.0"
+    "@turf/invariant": "npm:^7.2.0"
+    "@turf/union": "npm:^7.2.0"
+    "@types/geojson": "npm:^7946.0.16"
+    h3-js: "npm:4.1.0"
   languageName: node
-  linkType: hard
+  linkType: soft
 
 "@carto/api-client@workspace:.":
   version: 0.0.0-use.local
@@ -2995,7 +3000,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@turf/bbox-clip@npm:^7.1.0, @turf/bbox-clip@npm:^7.2.0":
+"@turf/bbox-clip@npm:^7.2.0":
   version: 7.2.0
   resolution: "@turf/bbox-clip@npm:7.2.0"
   dependencies:
@@ -3007,7 +3012,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@turf/bbox-polygon@npm:^7.1.0, @turf/bbox-polygon@npm:^7.2.0":
+"@turf/bbox-polygon@npm:^7.2.0":
   version: 7.2.0
   resolution: "@turf/bbox-polygon@npm:7.2.0"
   dependencies:
@@ -3189,7 +3194,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@turf/helpers@npm:^7.1.0, @turf/helpers@npm:^7.2.0":
+"@turf/helpers@npm:^7.2.0":
   version: 7.2.0
   resolution: "@turf/helpers@npm:7.2.0"
   dependencies:
@@ -3221,7 +3226,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@turf/invariant@npm:^7.1.0, @turf/invariant@npm:^7.2.0":
+"@turf/invariant@npm:^7.2.0":
   version: 7.2.0
   resolution: "@turf/invariant@npm:7.2.0"
   dependencies:
@@ -3321,7 +3326,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@turf/union@npm:^7.1.0, @turf/union@npm:^7.2.0":
+"@turf/union@npm:^7.2.0":
   version: 7.2.0
   resolution: "@turf/union@npm:7.2.0"
   dependencies:
@@ -3417,7 +3422,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/geojson@npm:^7946.0.14, @types/geojson@npm:^7946.0.15, @types/geojson@npm:^7946.0.16":
+"@types/geojson@npm:^7946.0.14, @types/geojson@npm:^7946.0.16":
   version: 7946.0.16
   resolution: "@types/geojson@npm:7946.0.16"
   checksum: 10c0/1ff24a288bd5860b766b073ead337d31d73bdc715e5b50a2cee5cb0af57a1ed02cc04ef295f5fa68dc40fe3e4f104dd31282b2b818a5ba3231bc1001ba084e3c


### PR DESCRIPTION
Release for v0.4.7, and minor changes to keep backward compatibility with v0.4.6 until the v0.5 release. Changes:

- Removes .widgetSource property from tileset source responses. Tileset widgets will be officially supported in v0.5.
- Add fallback if users set `abortController` parameter, for backward compatibility with v0.4.6. Fallback can be removed with v0.5 or later.
    - See #110
- Add fallback alias for WidgetSource (renamed from WidgetBaseSource)