### PR TITLE
fix(query,sources): Ensure consistent setClient() support

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "homepage": "https://github.com/CartoDB/carto-api-client#readme",
   "author": "Don McCurdy <donmccurdy@carto.com>",
   "packageManager": "yarn@4.3.1",
-  "version": "0.4.7",
+  "version": "0.4.8-alpha.0",
   "license": "MIT",
   "publishConfig": {
     "access": "public"
@@ -112,5 +112,6 @@
   "resolutions": {
     "@carto/api-client": "portal:./",
     "rollup": "^4.20.0"
-  }
+  },
+  "stableVersion": "0.4.7"
 }

--- a/src/api/query.ts
+++ b/src/api/query.ts
@@ -11,6 +11,7 @@ import type {
 import {buildQueryUrl} from './endpoints.js';
 import {requestWithParameters} from './request-with-parameters.js';
 import {APIErrorContext} from './carto-api-error.js';
+import {getClient} from '../client.js';
 
 export type QueryOptions = SourceOptions & QuerySourceOptions;
 type UrlParameters = {q: string; queryParameters?: string};
@@ -20,8 +21,8 @@ export const query = async function (
 ): Promise<QueryResult> {
   const {
     apiBaseUrl = SOURCE_DEFAULTS.apiBaseUrl,
-    clientId = SOURCE_DEFAULTS.clientId,
     maxLengthURL = SOURCE_DEFAULTS.maxLengthURL,
+    clientId = getClient(),
     localCache,
     connectionName,
     sqlQuery,

--- a/src/sources/base-source.ts
+++ b/src/sources/base-source.ts
@@ -18,9 +18,8 @@ import {MapType} from '../types.js';
 import {APIErrorContext} from '../api/index.js';
 import {getClient} from '../client.js';
 
-export const SOURCE_DEFAULTS: SourceOptionalOptions = {
+export const SOURCE_DEFAULTS: Omit<SourceOptionalOptions, 'clientId'> = {
   apiBaseUrl: DEFAULT_API_BASE_URL,
-  clientId: getClient(),
   format: 'tilejson',
   headers: {},
   maxLengthURL: DEFAULT_MAX_LENGTH_URL,
@@ -34,6 +33,7 @@ export async function baseSource<UrlParameters extends Record<string, unknown>>(
   const {accessToken, connectionName, cache, ...optionalOptions} = options;
   const mergedOptions = {
     ...SOURCE_DEFAULTS,
+    clientId: getClient(),
     accessToken,
     connectionName,
     endpoint,
@@ -80,6 +80,7 @@ export async function baseSource<UrlParameters extends Record<string, unknown>>(
   if (format === 'tilejson') {
     const json = await requestWithParameters<TilejsonResult>({
       baseUrl: dataUrl,
+      parameters: {client: clientId},
       headers,
       errorContext,
       maxLengthURL,
@@ -93,6 +94,7 @@ export async function baseSource<UrlParameters extends Record<string, unknown>>(
 
   return await requestWithParameters<GeojsonResult | JsonResult>({
     baseUrl: dataUrl,
+    parameters: {client: clientId},
     headers,
     errorContext,
     maxLengthURL,

--- a/test/api/query.test.ts
+++ b/test/api/query.test.ts
@@ -1,5 +1,5 @@
 import {test, vi, expect, beforeEach, afterEach} from 'vitest';
-import {query} from '@carto/api-client';
+import {getClient, query, setClient} from '@carto/api-client';
 
 const QUERY_RESPONSE = [{id: 1, value: 'string'}];
 
@@ -20,7 +20,6 @@ test('query', async () => {
 
   const response = await query({
     connectionName: 'carto_dw',
-    clientId: 'CUSTOM_CLIENT',
     accessToken: '<token>',
     sqlQuery: 'SELECT * FROM a.b.h3_table',
   });
@@ -31,7 +30,30 @@ test('query', async () => {
 
   expect(queryCall[0]).toMatch(/v3\/sql\/carto_dw\/query/);
   expect(queryCall[0]).toMatch(/q=SELECT\+\*\+FROM\+a\.b\.h3_table/);
-  expect(queryCall[0]).toMatch(/client=CUSTOM_CLIENT/);
 
   expect(response).toEqual(QUERY_RESPONSE);
+});
+
+test('clientId', async () => {
+  const mockFetch = vi.mocked(fetch);
+
+  const clientIds = ['deck-gl-carto', 'new-default', 'override-default'];
+
+  const options = {
+    connectionName: 'carto_dw',
+    accessToken: '<token>',
+    sqlQuery: 'SELECT * FROM a.b.h3_table',
+  };
+
+  await query({...options, sqlQuery: 'SELECT 1'});
+  setClient(clientIds[1]);
+  await query({...options, sqlQuery: 'SELECT 2'});
+  await query({...options, sqlQuery: 'SELECT 2', clientId: clientIds[2]});
+
+  const calls = mockFetch.mock.calls;
+
+  expect(mockFetch).toHaveBeenCalledTimes(3);
+  expect(calls[0][0]).toMatch(`client=${clientIds[0]}`);
+  expect(calls[1][0]).toMatch(`client=${clientIds[1]}`);
+  expect(calls[2][0]).toMatch(`client=${clientIds[2]}`);
 });

--- a/test/api/query.test.ts
+++ b/test/api/query.test.ts
@@ -1,5 +1,5 @@
 import {test, vi, expect, beforeEach, afterEach} from 'vitest';
-import {getClient, query, setClient} from '@carto/api-client';
+import {query, setClient} from '@carto/api-client';
 
 const QUERY_RESPONSE = [{id: 1, value: 'string'}];
 

--- a/test/api/request-with-parameters.test.ts
+++ b/test/api/request-with-parameters.test.ts
@@ -1,12 +1,4 @@
-import {
-  describe,
-  test,
-  expect,
-  vi,
-  afterEach,
-  beforeEach,
-  assert,
-} from 'vitest';
+import {describe, test, expect, vi, beforeEach, assert} from 'vitest';
 import {
   APIRequestType,
   CartoAPIError,
@@ -26,7 +18,6 @@ describe('requestWithParameters', () => {
     vi.stubGlobal('fetch', mockFetch);
     vi.stubGlobal('deck', {VERSION: 'untranspiled source'});
   });
-  afterEach(() => void vi.restoreAllMocks());
 
   test('cache baseURL', async () => {
     const mockFetch = vi.mocked(fetch);

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -11,9 +11,6 @@ const DEFAULT_CLIENT_ID = getClient();
 
 afterEach(() => {
   setClient(DEFAULT_CLIENT_ID);
-});
-
-afterEach(() => {
   vi.restoreAllMocks();
   vi.unstubAllGlobals();
 });

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,5 +1,5 @@
 import {getClient, setClient} from '@carto/api-client';
-import {afterEach} from 'vitest';
+import {afterEach, vi} from 'vitest';
 
 // NOTE: By default Vitest runs each test file in isolation, but sometimes we
 // need to disable parallelism or isolation for debugging purposes. To confirm
@@ -11,4 +11,9 @@ const DEFAULT_CLIENT_ID = getClient();
 
 afterEach(() => {
   setClient(DEFAULT_CLIENT_ID);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
 });

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,0 +1,14 @@
+import {getClient, setClient} from '@carto/api-client';
+import {afterEach} from 'vitest';
+
+// NOTE: By default Vitest runs each test file in isolation, but sometimes we
+// need to disable parallelism or isolation for debugging purposes. To confirm
+// that all tests pass without parallism or isolation, use:
+//
+// yarn test --no-file-parallelism --no-isolate
+
+const DEFAULT_CLIENT_ID = getClient();
+
+afterEach(() => {
+  setClient(DEFAULT_CLIENT_ID);
+});

--- a/test/sources/base-source.test.ts
+++ b/test/sources/base-source.test.ts
@@ -1,5 +1,5 @@
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
-import {getClient, setClient, vectorTableSource} from '@carto/api-client';
+import {setClient, vectorTableSource} from '@carto/api-client';
 
 const CACHE = 'base-source-test';
 

--- a/test/sources/base-source.test.ts
+++ b/test/sources/base-source.test.ts
@@ -1,0 +1,46 @@
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
+import {getClient, setClient, vectorTableSource} from '@carto/api-client';
+
+const CACHE = 'base-source-test';
+
+const INIT_RESPONSE = {
+  tilejson: {url: [`https://xyz.com?format=tilejson&cache=${CACHE}`]},
+};
+
+describe('baseSource', () => {
+  beforeEach(() => {
+    const mockFetch = vi
+      .fn()
+      .mockReturnValue(
+        Promise.resolve({ok: true, json: () => Promise.resolve(INIT_RESPONSE)})
+      );
+
+    vi.stubGlobal('fetch', mockFetch);
+  });
+
+  afterEach(() => void vi.restoreAllMocks());
+
+  test('clientId', async () => {
+    const clientIds = ['deck-gl-carto', 'new-default', 'override-default'];
+    const options = {
+      connectionName: 'carto_dw',
+      accessToken: '<token>',
+      tableName: 'test',
+    };
+
+    // Using vectorTableSource as stand-in for baseSource, which is not exported.
+    await vectorTableSource({...options});
+    setClient(clientIds[1]);
+    await vectorTableSource({...options});
+    await vectorTableSource({...options, clientId: clientIds[2]});
+
+    const calls = vi.mocked(fetch).mock.calls;
+
+    expect(calls[0][0]).toMatch(`client=${clientIds[0]}`);
+    expect(calls[1][0]).toMatch(`client=${clientIds[0]}`);
+    expect(calls[2][0]).toMatch(`client=${clientIds[1]}`);
+    expect(calls[3][0]).toMatch(`client=${clientIds[1]}`);
+    expect(calls[4][0]).toMatch(`client=${clientIds[2]}`);
+    expect(calls[5][0]).toMatch(`client=${clientIds[2]}`);
+  });
+});

--- a/test/sources/boundary-query-source.test.ts
+++ b/test/sources/boundary-query-source.test.ts
@@ -1,5 +1,5 @@
 import {boundaryQuerySource} from '@carto/api-client';
-import {describe, afterEach, vi, test, expect, beforeEach} from 'vitest';
+import {describe, vi, test, expect, beforeEach} from 'vitest';
 
 const CACHE = 'boundary-query-source-test';
 
@@ -29,8 +29,6 @@ describe('boundaryQuerySource', () => {
 
     vi.stubGlobal('fetch', mockFetch);
   });
-
-  afterEach(() => void vi.restoreAllMocks());
 
   test('default', async () => {
     const tilejson = await boundaryQuerySource({

--- a/test/sources/boundary-table-source.test.ts
+++ b/test/sources/boundary-table-source.test.ts
@@ -1,5 +1,5 @@
 import {boundaryTableSource} from '@carto/api-client';
-import {describe, afterEach, vi, test, expect, beforeEach} from 'vitest';
+import {describe, vi, test, expect, beforeEach} from 'vitest';
 
 const CACHE = 'boundary-table-source-test';
 
@@ -29,8 +29,6 @@ describe('boundaryTableSource', () => {
 
     vi.stubGlobal('fetch', mockFetch);
   });
-
-  afterEach(() => void vi.restoreAllMocks());
 
   test('default', async () => {
     const tilejson = await boundaryTableSource({

--- a/test/sources/h3-query-source.test.ts
+++ b/test/sources/h3-query-source.test.ts
@@ -1,5 +1,5 @@
 import {WidgetQuerySource, h3QuerySource} from '@carto/api-client';
-import {describe, afterEach, vi, test, expect, beforeEach} from 'vitest';
+import {describe, vi, test, expect, beforeEach} from 'vitest';
 
 const CACHE = 'h3-query-source-test';
 
@@ -30,7 +30,6 @@ describe('h3QuerySource', () => {
     vi.stubGlobal('fetch', mockFetch);
   });
 
-  afterEach(() => void vi.restoreAllMocks());
   test('default', async () => {
     const tilejson = await h3QuerySource({
       connectionName: 'carto_dw',

--- a/test/sources/h3-table-source.test.ts
+++ b/test/sources/h3-table-source.test.ts
@@ -1,5 +1,5 @@
 import {WidgetTableSource, h3TableSource} from '@carto/api-client';
-import {describe, afterEach, vi, test, expect, beforeEach} from 'vitest';
+import {describe, vi, test, expect, beforeEach} from 'vitest';
 
 const CACHE = 'h3-table-source-test';
 
@@ -29,8 +29,6 @@ describe('h3TableSource', () => {
 
     vi.stubGlobal('fetch', mockFetch);
   });
-
-  afterEach(() => void vi.restoreAllMocks());
 
   test('default', async () => {
     const tilejson = await h3TableSource({

--- a/test/sources/h3-tileset-source.test.ts
+++ b/test/sources/h3-tileset-source.test.ts
@@ -1,5 +1,5 @@
 import {h3TilesetSource} from '@carto/api-client';
-import {describe, afterEach, vi, test, expect, beforeEach} from 'vitest';
+import {describe, vi, test, expect, beforeEach} from 'vitest';
 
 const CACHE = 'h3-tileset-source-test';
 
@@ -29,8 +29,6 @@ describe('h3TilesetSource', () => {
 
     vi.stubGlobal('fetch', mockFetch);
   });
-
-  afterEach(() => void vi.restoreAllMocks());
 
   test('default', async () => {
     const tilejson = await h3TilesetSource({

--- a/test/sources/quadbin-query-source.test.ts
+++ b/test/sources/quadbin-query-source.test.ts
@@ -1,5 +1,5 @@
 import {WidgetQuerySource, quadbinQuerySource} from '@carto/api-client';
-import {describe, afterEach, vi, test, expect, beforeEach} from 'vitest';
+import {describe, vi, test, expect, beforeEach} from 'vitest';
 
 const CACHE = 'quadbin-query-source-test';
 
@@ -29,8 +29,6 @@ describe('quadbinQuerySource', () => {
 
     vi.stubGlobal('fetch', mockFetch);
   });
-
-  afterEach(() => void vi.restoreAllMocks());
 
   test('default', async () => {
     const tilejson = await quadbinQuerySource({

--- a/test/sources/quadbin-table-source.test.ts
+++ b/test/sources/quadbin-table-source.test.ts
@@ -1,5 +1,5 @@
 import {WidgetTableSource, quadbinTableSource} from '@carto/api-client';
-import {describe, afterEach, vi, test, expect, beforeEach} from 'vitest';
+import {describe, vi, test, expect, beforeEach} from 'vitest';
 
 const CACHE = 'quadbin-table-source-test';
 
@@ -29,8 +29,6 @@ describe('quadbinTableSource', () => {
 
     vi.stubGlobal('fetch', mockFetch);
   });
-
-  afterEach(() => void vi.restoreAllMocks());
 
   test('default', async () => {
     const tilejson = await quadbinTableSource({

--- a/test/sources/quadbin-tileset-source.test.ts
+++ b/test/sources/quadbin-tileset-source.test.ts
@@ -1,5 +1,5 @@
 import {quadbinTilesetSource} from '@carto/api-client';
-import {describe, afterEach, vi, test, expect, beforeEach} from 'vitest';
+import {describe, vi, test, expect, beforeEach} from 'vitest';
 
 const CACHE = 'quadbin-tileset-source-test';
 
@@ -29,8 +29,6 @@ describe('quadbinTilesetSource', () => {
 
     vi.stubGlobal('fetch', mockFetch);
   });
-
-  afterEach(() => void vi.restoreAllMocks());
 
   test('default', async () => {
     const tilejson = await quadbinTilesetSource({

--- a/test/sources/raster-source.test.ts
+++ b/test/sources/raster-source.test.ts
@@ -1,7 +1,7 @@
 import {rasterSource} from '@carto/api-client';
 import {describe, afterEach, vi, test, expect, beforeEach} from 'vitest';
 
-const CACHE = 'vector-tileset-source-test';
+const CACHE = 'raster-source-test';
 
 const INIT_RESPONSE = {
   tilejson: {url: [`https://xyz.com?format=tilejson&cache=${CACHE}`]},

--- a/test/sources/vector-query-source.test.ts
+++ b/test/sources/vector-query-source.test.ts
@@ -1,5 +1,5 @@
 import {WidgetQuerySource, vectorQuerySource} from '@carto/api-client';
-import {describe, afterEach, vi, test, expect, beforeEach} from 'vitest';
+import {describe, vi, test, expect, beforeEach} from 'vitest';
 
 const CACHE = 'vector-query-source-test';
 
@@ -29,8 +29,6 @@ describe('vectorQuerySource', () => {
 
     vi.stubGlobal('fetch', mockFetch);
   });
-
-  afterEach(() => void vi.restoreAllMocks());
 
   test('default', async () => {
     const tilejson = await vectorQuerySource({

--- a/test/widget-sources/widget-query-source.test.ts
+++ b/test/widget-sources/widget-query-source.test.ts
@@ -1,13 +1,9 @@
-import {afterEach, expect, test, vi} from 'vitest';
+import {expect, test, vi} from 'vitest';
 import {WidgetQuerySource} from '@carto/api-client';
 
 const createMockResponse = (data: unknown) => ({
   ok: true,
   json: () => new Promise((resolve) => resolve(data)),
-});
-
-afterEach(() => {
-  vi.unstubAllGlobals();
 });
 
 test('exports', () => {

--- a/test/widget-sources/widget-remote-source.test.ts
+++ b/test/widget-sources/widget-remote-source.test.ts
@@ -2,7 +2,6 @@ import {afterEach, expect, test, vi} from 'vitest';
 import {
   Filters,
   FilterType,
-  getClient,
   setClient,
   WidgetRemoteSource,
   WidgetRemoteSourceProps,

--- a/test/widget-sources/widget-remote-source.test.ts
+++ b/test/widget-sources/widget-remote-source.test.ts
@@ -46,31 +46,29 @@ test('constructor', () => {
 });
 
 test('clientId', () => {
-  const clientId1 = getClient();
-  const clientId2 = 'new default';
-  const clientId3 = 'override default';
+  const clientIds = ['deck-gl-carto', 'new-default', 'override-default'];
+
+  const widgetSource0 = new WidgetTestSource({
+    accessToken: '<token>',
+    connectionName: 'carto_dw',
+  });
+
+  setClient(clientIds[1]);
 
   const widgetSource1 = new WidgetTestSource({
     accessToken: '<token>',
     connectionName: 'carto_dw',
   });
 
-  setClient(clientId2);
-
   const widgetSource2 = new WidgetTestSource({
     accessToken: '<token>',
     connectionName: 'carto_dw',
+    clientId: clientIds[2],
   });
 
-  const widgetSource3 = new WidgetTestSource({
-    accessToken: '<token>',
-    connectionName: 'carto_dw',
-    clientId: clientId3,
-  });
-
-  expect(widgetSource1.props.clientId).toBe(clientId1);
-  expect(widgetSource2.props.clientId).toBe(clientId2);
-  expect(widgetSource3.props.clientId).toBe(clientId3);
+  expect(widgetSource0.props.clientId).toBe(clientIds[0]);
+  expect(widgetSource1.props.clientId).toBe(clientIds[1]);
+  expect(widgetSource2.props.clientId).toBe(clientIds[2]);
 });
 
 test('setRequestHeaders', async () => {

--- a/test/widget-sources/widget-remote-source.test.ts
+++ b/test/widget-sources/widget-remote-source.test.ts
@@ -1,4 +1,4 @@
-import {afterEach, expect, test, vi} from 'vitest';
+import {expect, test, vi} from 'vitest';
 import {
   Filters,
   FilterType,
@@ -23,10 +23,6 @@ class WidgetTestSource extends WidgetRemoteSource<WidgetRemoteSourceProps> {
     >;
   }
 }
-
-afterEach(() => {
-  vi.unstubAllGlobals();
-});
 
 test('exports', () => {
   expect(WidgetRemoteSource).toBeDefined();

--- a/test/widget-sources/widget-table-source.test.ts
+++ b/test/widget-sources/widget-table-source.test.ts
@@ -1,13 +1,9 @@
-import {afterEach, expect, test, vi} from 'vitest';
+import {expect, test, vi} from 'vitest';
 import {WidgetTableSource} from '@carto/api-client';
 
 const createMockResponse = (data: unknown) => ({
   ok: true,
   json: () => new Promise((resolve) => resolve(data)),
-});
-
-afterEach(() => {
-  vi.unstubAllGlobals();
 });
 
 test('exports', () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,6 +6,7 @@ import {defineConfig} from 'vitest/config';
 // these dependencies to be temporary. See: https://github.com/vitest-dev/vitest/discussions/5964.
 export default defineConfig({
   test: {
+    setupFiles: ['test/setup.ts'],
     coverage: {
       provider: 'istanbul',
       include: ['src/**/*', 'build/**/*'],


### PR DESCRIPTION
Changes:

- Fix `setClient()` support in `query()`
- Fix `setClient()` support in TileJSON requests (was not propagated from user-specified params)
- Improve test coverage