### PR TITLE
fetchMap: Remove LayerProvider

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -16,8 +16,9 @@ const RESTRICTED_IMPORTS = {
       patterns: [
         {
           group: ['@deck.gl/*'],
-          message: 'Only type imports from @deck.gl/* are allowed.',
-          allowTypeImports: true,
+          message:
+            '@deck.gl/* imports are not allowed to avoid circular dependency.',
+          allowTypeImports: false,
         },
       ],
     },

--- a/examples/05-fetch-map/app.ts
+++ b/examples/05-fetch-map/app.ts
@@ -3,10 +3,10 @@ import {
   fetchMap,
   FetchMapOptions,
   GoogleBasemap,
-  LayerProvider,
+  LayerType,
   MapLibreBasemap,
 } from '@carto/api-client';
-import {Deck} from '@deck.gl/core';
+import {_ConstructorOf, Deck, Layer} from '@deck.gl/core';
 import maplibregl from 'maplibre-gl';
 import 'maplibre-gl/dist/maplibre-gl.css';
 import {Loader} from '@googlemaps/js-api-loader';
@@ -30,6 +30,29 @@ const GOOGLE_MAPS_API_KEY = '';
 const apiBaseUrl = 'https://gcp-us-east1.api.carto.com';
 // const apiBaseUrl = 'https://gcp-us-east1-05.dev.api.carto.com';
 
+// For now, define here. Eventually LayerFactory will be available in @deck.gl/carto
+const layerClasses: Record<LayerType, _ConstructorOf<Layer>> = {
+  clusterTile: ClusterTileLayer,
+  h3: H3TileLayer,
+  heatmapTile: HeatmapTileLayer,
+  mvt: VectorTileLayer,
+  quadbin: QuadbinTileLayer,
+  raster: RasterTileLayer,
+  tileset: VectorTileLayer,
+};
+function LayerFactory(layerProps: LayerProps[]) {
+  return layerProps
+    .map(({id, type, data, props}) => {
+      const LayerClass = layerClasses[type];
+      if (!LayerClass) {
+        console.error(`No layer class found for type: ${type}`);
+        return null;
+      }
+      return new LayerClass({id, data, ...props});
+    })
+    .filter(Boolean);
+}
+
 function createMapWithMapLibreOverlay(result: FetchMapResult) {
   document.getElementById('deck-canvas')!.style.display = 'none';
 
@@ -46,7 +69,7 @@ function createMapWithMapLibreOverlay(result: FetchMapResult) {
     })
   );
 
-  const overlay = new MapboxOverlay({layers: result.layers});
+  const overlay = new MapboxOverlay({layers: LayerFactory(result.layers)});
   map.addControl(overlay);
 
   return overlay;
@@ -64,22 +87,11 @@ async function createMapWithGoogleMapsOverlay(result: FetchMapResult) {
     disableDefaultUI: true,
   });
 
-  const overlay = new GoogleMapsOverlay({layers: result.layers});
+  const overlay = new GoogleMapsOverlay({layers: LayerFactory(result.layers)});
   overlay.setMap(map);
 
   return overlay;
 }
-
-// For testing define LayerProvider here for now
-const layerProvider: LayerProvider = {
-  clusterTile: ClusterTileLayer,
-  h3: H3TileLayer,
-  heatmapTile: HeatmapTileLayer,
-  mvt: VectorTileLayer,
-  quadbin: QuadbinTileLayer,
-  raster: RasterTileLayer,
-  tileset: VectorTileLayer,
-};
 
 async function createMap(cartoMapId: string) {
   const options: FetchMapOptions = {
@@ -95,13 +107,13 @@ async function createMap(cartoMapId: string) {
   if (autoRefresh) {
     // Autorefresh the data every 5 seconds
     options.autoRefresh = 5;
-    options.onNewData = ({layers}) => {
-      deck?.setProps({layers});
+    options.onNewData = (result) => {
+      deck?.setProps({layers: LayerFactory(result.layers)});
     };
   }
 
   // Get map info from CARTO and update deck
-  const result = await fetchMap(options, layerProvider);
+  const result = await fetchMap(options);
 
   if (GOOGLE_MAPS_API_KEY && result.basemap?.type === 'google-maps') {
     deck = await createMapWithGoogleMapsOverlay(result);

--- a/examples/05-fetch-map/app.ts
+++ b/examples/05-fetch-map/app.ts
@@ -3,6 +3,7 @@ import {
   fetchMap,
   FetchMapOptions,
   GoogleBasemap,
+  LayerDescriptor,
   LayerType,
   MapLibreBasemap,
 } from '@carto/api-client';
@@ -40,15 +41,15 @@ const layerClasses: Record<LayerType, _ConstructorOf<Layer>> = {
   raster: RasterTileLayer,
   tileset: VectorTileLayer,
 };
-function LayerFactory(layerProps: LayerProps[]) {
-  return layerProps
-    .map(({id, type, data, props}) => {
+function LayerFactory(layers: LayerDescriptor[]) {
+  return layers
+    .map(({type, props}) => {
       const LayerClass = layerClasses[type];
       if (!LayerClass) {
         console.error(`No layer class found for type: ${type}`);
         return null;
       }
-      return new LayerClass({id, data, ...props});
+      return new LayerClass(props);
     })
     .filter(Boolean);
 }

--- a/package.json
+++ b/package.json
@@ -117,9 +117,6 @@
     "vite": "^6.1.0",
     "vitest": "3.0.7"
   },
-  "peerDependencies": {
-    "@deck.gl/core": "~9.1.0"
-  },
   "resolutions": {
     "@carto/api-client": "portal:./",
     "rollup": "^4.20.0"

--- a/src/fetch-map/basemap.ts
+++ b/src/fetch-map/basemap.ts
@@ -1,4 +1,3 @@
-import type {MapViewState} from '@deck.gl/core';
 import {
   GOOGLE_BASEMAPS,
   CARTO_MAP_STYLES,
@@ -12,6 +11,20 @@ import {APIErrorContext} from '../api/index.js';
 
 const CUSTOM_STYLE_ID_PREFIX = 'custom:';
 const DEFAULT_CARTO_STYLE = 'positron';
+
+// Subset of type from @deck.gl/core to avoid adding dependency
+type MapViewState = {
+  /** Longitude of the map center */
+  longitude: number;
+  /** Latitude of the map center */
+  latitude: number;
+  /** Zoom level */
+  zoom: number;
+  /** Pitch (tilt) of the map, in degrees. `0` looks top down */
+  pitch?: number;
+  /** Bearing (rotation) of the map, in degrees. `0` is north up */
+  bearing?: number;
+};
 
 function mapLibreViewpros(
   config: KeplerMapConfig

--- a/src/fetch-map/fetch-map.ts
+++ b/src/fetch-map/fetch-map.ts
@@ -27,7 +27,6 @@ import {ParseMapResult, parseMap} from './parse-map.js';
 import {assert} from '../utils.js';
 import type {Basemap} from './types.js';
 import {fetchBasemapProps} from './basemap.js';
-import type {LayerProvider} from './layer-map.js';
 type Dataset = {
   id: string;
   type: MapType;
@@ -297,19 +296,16 @@ export type FetchMapResult = ParseMapResult & {
   stopAutoRefresh?: () => void;
 };
 
-export async function fetchMap(
-  {
-    accessToken,
-    apiBaseUrl = DEFAULT_API_BASE_URL,
-    cartoMapId,
-    clientId,
-    headers,
-    autoRefresh,
-    onNewData,
-    maxLengthURL,
-  }: FetchMapOptions,
-  layerProvider: LayerProvider
-): Promise<FetchMapResult> {
+export async function fetchMap({
+  accessToken,
+  apiBaseUrl = DEFAULT_API_BASE_URL,
+  cartoMapId,
+  clientId,
+  headers,
+  autoRefresh,
+  onNewData,
+  maxLengthURL,
+}: FetchMapOptions): Promise<FetchMapResult> {
   assert(
     cartoMapId,
     'Must define CARTO map id: fetchMap({cartoMapId: "XXXX-XXXX-XXXX"})'
@@ -351,7 +347,6 @@ export async function fetchMap(
   // will not update when a map is published.
   let stopAutoRefresh: (() => void) | undefined;
   if (autoRefresh) {
-    // eslint-disable-next-line @typescript-eslint/no-misused-promises
     const intervalId = setInterval(async () => {
       const changed = await fillInMapDatasets(map, {
         ...context,
@@ -361,7 +356,7 @@ export async function fetchMap(
         },
       });
       if (onNewData && changed.some((v) => v === true)) {
-        onNewData(parseMap(map, layerProvider));
+        onNewData(parseMap(map));
       }
     }, autoRefresh * 1000);
     stopAutoRefresh = () => {
@@ -398,10 +393,10 @@ export async function fetchMap(
   // Mutates attributes in visualChannels to contain tile stats
   await fillInTileStats(map, context);
 
-  const out = {...parseMap(map, layerProvider), basemap, ...{stopAutoRefresh}};
+  const out = {...parseMap(map), basemap, ...{stopAutoRefresh}};
 
   const textLayers = out.layers.filter((layer: any) => {
-    const pointType = layer.props.pointType || '';
+    const pointType = layer.props?.pointType || '';
     return pointType.includes('text');
   });
 

--- a/src/fetch-map/layer-map.ts
+++ b/src/fetch-map/layer-map.ts
@@ -27,7 +27,6 @@ import {
   CustomMarkersRange,
   MapDataset,
   MapLayerConfig,
-  MapTextSubLayerConfig,
   VisConfig,
   VisualChannelField,
   VisualChannels,

--- a/src/fetch-map/layer-map.ts
+++ b/src/fetch-map/layer-map.ts
@@ -26,6 +26,7 @@ import {createBinaryProxy, scaleIdentity} from './utils.js';
 import {
   CustomMarkersRange,
   MapDataset,
+  MapLayerConfig,
   MapTextSubLayerConfig,
   VisConfig,
   VisualChannelField,
@@ -146,9 +147,9 @@ const deprecatedLayerTypes = [
   'point',
 ];
 
-export function getLayer(
+export function getLayerProps(
   type: LayerType,
-  config: MapTextSubLayerConfig,
+  config: MapLayerConfig,
   dataset: MapDataset
 ): {propMap: any; defaultProps: any} {
   if (deprecatedLayerTypes.includes(type)) {

--- a/src/fetch-map/parse-map.ts
+++ b/src/fetch-map/parse-map.ts
@@ -1,7 +1,7 @@
 import type {ColorParameters} from '@luma.gl/core';
 import {
   AGGREGATION,
-  getLayer,
+  getLayerProps,
   getColorAccessor,
   getColorValueAccessor,
   getSizeAccessor,
@@ -78,7 +78,7 @@ export function parseMap(json: any) {
           const {data} = dataset;
           assert(data, `No data loaded for dataId: ${dataId}`);
 
-          const {propMap, defaultProps} = getLayer(type, config, dataset);
+          const {propMap, defaultProps} = getLayerProps(type, config, dataset);
 
           const styleProps = createStyleProps(config, propMap);
 

--- a/src/fetch-map/parse-map.ts
+++ b/src/fetch-map/parse-map.ts
@@ -24,10 +24,8 @@ import {
   MapConfigLayer,
 } from './types.js';
 
-export type LayerProps = {
-  id: string;
+export type LayerDescriptor = {
   type: LayerType;
-  data: any;
   props: Record<string, any>;
 };
 
@@ -48,7 +46,7 @@ export type ParseMapResult = {
   mapStyle: any;
   token: string;
 
-  layers: LayerProps[];
+  layers: LayerDescriptor[];
 };
 
 export function parseMap(json: any) {
@@ -80,21 +78,15 @@ export function parseMap(json: any) {
           const {data} = dataset;
           assert(data, `No data loaded for dataId: ${dataId}`);
 
-          const layerType = type as LayerType;
-          const {propMap, defaultProps} = getLayer(
-            layerType,
-            // @ts-ignore
-            config,
-            dataset
-          );
+          const {propMap, defaultProps} = getLayer(type, config, dataset);
 
           const styleProps = createStyleProps(config, propMap);
 
-          return {
-            id,
-            type: layerType,
-            data,
+          const layer: LayerDescriptor = {
+            type,
             props: {
+              id,
+              data,
               ...defaultProps,
               ...createInteractionProps(interactionConfig),
               ...styleProps,
@@ -106,6 +98,7 @@ export function parseMap(json: any) {
               ...createLoadOptions(token),
             },
           };
+          return layer;
         } catch (e: any) {
           console.error(e.message);
           return undefined;

--- a/src/fetch-map/types.ts
+++ b/src/fetch-map/types.ts
@@ -1,4 +1,3 @@
-import {Layer} from '../sources/types.js';
 import {LayerType, SCALE_TYPE} from './layer-map.js';
 
 export type VisualChannelField = {
@@ -93,10 +92,6 @@ export type MapLayerConfig = {
   dataId: string;
   textLabel: TextLabel[];
   visConfig: VisConfig;
-};
-
-export type MapTextSubLayerConfig = Omit<MapLayerConfig, 'textLabel'> & {
-  textLabel?: TextLabel;
 };
 
 export type MapConfigLayer = {

--- a/src/fetch-map/types.ts
+++ b/src/fetch-map/types.ts
@@ -1,4 +1,5 @@
-import {SCALE_TYPE} from './layer-map.js';
+import {Layer} from '../sources/types.js';
+import {LayerType, SCALE_TYPE} from './layer-map.js';
 
 export type VisualChannelField = {
   name: string;
@@ -99,7 +100,7 @@ export type MapTextSubLayerConfig = Omit<MapLayerConfig, 'textLabel'> & {
 };
 
 export type MapConfigLayer = {
-  type: string;
+  type: LayerType;
   id: string;
   config: MapLayerConfig;
   visualChannels: VisualChannels;

--- a/test/fetch-map/layer-map.spec.ts
+++ b/test/fetch-map/layer-map.spec.ts
@@ -2,7 +2,7 @@ import {describe, test, expect} from 'vitest';
 import {
   getColorAccessor,
   getTextAccessor,
-  getLayer,
+  getLayerProps,
   _domainFromValues,
 } from '@carto/api-client';
 
@@ -139,7 +139,7 @@ describe('layer-map', () => {
     ];
 
     deprecatedTypes.forEach((type) => {
-      expect(() => getLayer(type as any, {columns: {}}, {}, {})).toThrow(
+      expect(() => getLayerProps(type as any, {} as any, {} as any)).toThrow(
         `Outdated layer type: ${type}. Please open map in CARTO Builder to automatically migrate.`
       );
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1462,8 +1462,6 @@ __metadata:
     d3-format: "npm:^3.1.0"
     d3-scale: "npm:^4.0.2"
     h3-js: "npm:4.1.0"
-  peerDependencies:
-    "@deck.gl/core": ~9.1.0
   languageName: node
   linkType: soft
 
@@ -1528,8 +1526,6 @@ __metadata:
     typescript-eslint: "npm:^8.24.0"
     vite: "npm:^6.1.0"
     vitest: "npm:3.0.7"
-  peerDependencies:
-    "@deck.gl/core": ~9.1.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
For https://github.com/CartoDB/carto-api-client/issues/124 - minimal changes required to break deck.gl dependency

#### Change list

- Remove all deck.gl imports
- Tighten eslint rule
- Remove LayerProvider
- Fix up missing types