### PR TITLE
chore(types): Cleanup for Builder migration

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "homepage": "https://github.com/CartoDB/carto-api-client#readme",
   "author": "Don McCurdy <donmccurdy@carto.com>",
   "packageManager": "yarn@4.3.1",
-  "version": "0.5.1-alpha.1",
+  "version": "0.5.1-alpha.2",
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "homepage": "https://github.com/CartoDB/carto-api-client#readme",
   "author": "Don McCurdy <donmccurdy@carto.com>",
   "packageManager": "yarn@4.3.1",
-  "version": "0.5.1-alpha.0",
+  "version": "0.5.1-alpha.1",
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "homepage": "https://github.com/CartoDB/carto-api-client#readme",
   "author": "Don McCurdy <donmccurdy@carto.com>",
   "packageManager": "yarn@4.3.1",
-  "version": "0.5.0",
+  "version": "0.5.1-alpha.0",
   "license": "MIT",
   "publishConfig": {
     "access": "public"
@@ -127,5 +127,6 @@
   "resolutions": {
     "@carto/api-client": "portal:./",
     "rollup": "^4.20.0"
-  }
+  },
+  "stableVersion": "0.5.0"
 }

--- a/src/filters/tileFeatures.ts
+++ b/src/filters/tileFeatures.ts
@@ -23,6 +23,8 @@ export type TileFeatures = {
 /** @privateRemarks Source: @carto/react-core */
 export type TileFeatureExtractOptions = {
   storeGeometry?: boolean;
+  spatialDataType?: SpatialDataType;
+  spatialDataColumn?: string;
   uniqueIdProperty?: string;
 };
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -100,3 +100,30 @@ export const isObject: (x: unknown) => boolean = (x) =>
 /** @internal */
 export const isPureObject: (x: any) => boolean = (x) =>
   isObject(x) && x.constructor === {}.constructor;
+
+/**
+ * Merges one or more source objects into a target object. Unlike `Object.assign`, does not
+ * assign properties with undefined values. Null values will overwrite existing properties.
+ */
+export function assignOptional<T extends object, U, V>(
+  target: T,
+  source1: U,
+  source2: V
+): T & U & V;
+export function assignOptional<T extends object, U>(
+  target: T,
+  source: U
+): T & U;
+export function assignOptional<T extends object, U>(
+  target: T,
+  ...sources: any[]
+): any {
+  for (const source of sources) {
+    for (const key in source) {
+      if (source[key] !== undefined) {
+        (target as Record<string, unknown>)[key] = source[key];
+      }
+    }
+  }
+  return target as T & U;
+}

--- a/src/widget-sources/types.ts
+++ b/src/widget-sources/types.ts
@@ -18,7 +18,7 @@ export interface ViewState {
 }
 
 /** Common options for {@link WidgetRemoteSource} requests. */
-interface BaseRequestOptions {
+export interface BaseRequestOptions {
   signal?: AbortSignal;
   spatialFilter?: SpatialFilter;
   spatialFiltersMode?: SpatialFilterPolyfillMode;

--- a/src/widget-sources/types.ts
+++ b/src/widget-sources/types.ts
@@ -117,9 +117,9 @@ export interface TableRequestOptions extends BaseRequestOptions {
   sortByColumnType?: SortColumnType;
   offset?: number;
   limit?: number;
-  /** Local only. */
+  /** @deprecated Supported for tilesets only. Prefer `filters` (for all sources) instead. */
   searchFilterColumn?: string;
-  /** Local only. */
+  /** @deprecated Supported for tilesets only. Prefer `filters` (for all sources) instead. */
   searchFilterText?: string;
 }
 

--- a/src/widget-sources/widget-tileset-source-impl.ts
+++ b/src/widget-sources/widget-tileset-source-impl.ts
@@ -271,7 +271,11 @@ export class WidgetTilesetSourceImpl extends WidgetSource<WidgetTilesetSourcePro
     }
 
     // Search.
+    // TODO(v0.6): Remove "searchFilterText" and "searchFilterColumn".
     if (searchFilterColumn && searchFilterText) {
+      console.warn(
+        'WidgetTilesetSource: "searchFilterText" is deprecated, use "filters" and FilterType.STRING_SEARCH instead.'
+      );
       filteredFeatures = filteredFeatures.filter(
         (row) =>
           row[searchFilterColumn] &&

--- a/src/widget-sources/widget-tileset-source-impl.ts
+++ b/src/widget-sources/widget-tileset-source-impl.ts
@@ -16,7 +16,12 @@ import {
   TimeSeriesRequestOptions,
   TimeSeriesResponse,
 } from './types.js';
-import {InvalidColumnError, assert, getApplicableFilters} from '../utils.js';
+import {
+  InvalidColumnError,
+  assert,
+  assignOptional,
+  getApplicableFilters,
+} from '../utils.js';
 import {Filter, SpatialFilter, Tile} from '../types.js';
 import {
   TileFeatureExtractOptions,
@@ -84,8 +89,7 @@ export class WidgetTilesetSourceImpl extends WidgetSource<WidgetTilesetSourcePro
     }
 
     this._features = tileFeatures({
-      ...this.props,
-      ...this._tileFeatureExtractOptions,
+      ...assignOptional({}, this.props, this._tileFeatureExtractOptions),
       tiles: this._tiles,
       spatialFilter,
     });

--- a/src/widget-sources/widget-tileset-source-impl.ts
+++ b/src/widget-sources/widget-tileset-source-impl.ts
@@ -387,15 +387,15 @@ function assertColumn(
   features: FeatureData[],
   ...columnArgs: string[] | string[][]
 ) {
-  // TODO(cleanup): Can drop support for multiple column shapes here?
-
   // Due to the multiple column shape, we normalise it as an array with normalizeColumns
   const columns = Array.from(new Set(columnArgs.map(normalizeColumns).flat()));
 
   const featureKeys = Object.keys(features[0]);
 
+  // For backward compatibility, '' should pass column validation. For example,
+  // operation='count',operationColumn='' is accepted.
   const invalidColumns = columns.filter(
-    (column) => !featureKeys.includes(column)
+    (column) => column && !featureKeys.includes(column)
   );
 
   if (invalidColumns.length) {

--- a/test/widget-sources/widget-tileset-source.test.ts
+++ b/test/widget-sources/widget-tileset-source.test.ts
@@ -30,15 +30,48 @@ describe('getCategories', () => {
   it('counts features in categories', async () => {
     expect(
       await source.getCategories({
-        operation: 'count',
         column: 'storetype',
-        joinOperation: undefined,
+        operation: 'count',
         spatialFilter: MOCK_SPATIAL_FILTER,
       })
     ).toEqual([
       {
         name: 'Drugstore',
         value: 6,
+      },
+    ]);
+  });
+
+  it('counts features in categories - operationColumn=""', async () => {
+    expect(
+      await source.getCategories({
+        column: 'storetype',
+        operation: 'count',
+        // For backward compatibility, '' should pass column validation. For
+        // operations other than 'count', its behavior is undefined.
+        operationColumn: '',
+        spatialFilter: MOCK_SPATIAL_FILTER,
+      })
+    ).toEqual([
+      {
+        name: 'Drugstore',
+        value: 6,
+      },
+    ]);
+  });
+
+  it('computes max in categories', async () => {
+    expect(
+      await source.getCategories({
+        column: 'storetype',
+        operation: 'max',
+        operationColumn: 'revenue',
+        spatialFilter: MOCK_SPATIAL_FILTER,
+      })
+    ).toEqual([
+      {
+        name: 'Drugstore',
+        value: 1876776,
       },
     ]);
   });


### PR DESCRIPTION
#### Changes

- Support `spatialDataType?: SpatialDataType` and `spatialDataColumn?: string` in configuration for `widgetSource.setTileFeatureExtractOptions({...})`, overriding defaults in the layer source. For H3 and Quadbin sources in Builder, tileset spatial data types may not be known at source creation time.
- Fix a bug when computing indices for point tilesets
- Export `BaseRequestOptions` for type hints
- Allow `operationColumn=""` (empty string) for backward compatibility
- Deprecate `searchFilterText` and `searchFilterString` in favor of `filters` and `FilterType.STRING_SEARCH`
    - Fixes #30

#### PR Dependency Tree


* **PR #150** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)