### PR TITLE
Legend example PoC

### DIFF
--- a/examples/06-fetch-map/app.ts
+++ b/examples/06-fetch-map/app.ts
@@ -13,8 +13,6 @@ import {DataFilterExtension} from '@deck.gl/extensions';
 import maplibregl from 'maplibre-gl';
 import 'maplibre-gl/dist/maplibre-gl.css';
 import {Loader} from '@googlemaps/js-api-loader';
-
-type FetchMapResult = any; // TODO: fix type
 import {GoogleMapsOverlay} from '@deck.gl/google-maps';
 import {MapboxOverlay} from '@deck.gl/mapbox';
 import {
@@ -25,6 +23,9 @@ import {
   QuadbinTileLayer,
   RasterTileLayer,
 } from '@deck.gl/carto';
+import {createLegend} from './legend.js';
+
+type FetchMapResult = any; // TODO: fix type
 
 // Get proper API key to be able to render Google basemaps, otherwise we
 // render on maplibre/positron style
@@ -121,6 +122,10 @@ async function createMap(cartoMapId: string) {
 
   // Get map info from CARTO and update deck
   const result = await fetchMap(options);
+
+  // Add legend to the page
+  const legend = createLegend(result.layers);
+  document.getElementById('container')!.appendChild(legend);
 
   if (GOOGLE_MAPS_API_KEY && result.basemap?.type === 'google-maps') {
     deck = await createMapWithGoogleMapsOverlay(result);

--- a/examples/06-fetch-map/legend.css
+++ b/examples/06-fetch-map/legend.css
@@ -1,0 +1,87 @@
+.legend-wrapper {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  pointer-events: none;
+  display: flex;
+  justify-content: flex-end;
+  align-items: flex-start;
+}
+
+.legend-container {
+  margin: 10px;
+  width: 200px;
+  max-height: calc(100% - 20px);
+  overflow-y: auto;
+  background: white;
+  padding: 16px;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+  z-index: 1000;
+  font-family: Inter, sans-serif;
+  box-sizing: border-box;
+  pointer-events: auto;
+}
+
+.legend-layer {
+  margin-bottom: 10px;
+}
+
+.legend-title {
+  margin: 0;
+  font-family: Inter, sans-serif;
+  font-weight: 400;
+  font-size: 0.8125rem;
+  line-height: 1.538;
+  letter-spacing: 0;
+  color: rgb(44, 48, 50);
+  margin-bottom: 12px;
+}
+
+.legend-header {
+  color: #6c757d;
+  font-size: 10px;
+  margin-bottom: 4px;
+}
+
+.legend-column {
+  margin: 0;
+  font-family: Inter, sans-serif;
+  font-weight: 400;
+  font-size: 0.75rem;
+  line-height: 1.538;
+  letter-spacing: 0;
+  color: rgb(44, 48, 50);
+  margin-bottom: 12px;
+}
+
+.legend-range {
+  display: flex;
+  align-items: center;
+  margin-bottom: 6px;
+}
+
+.legend-color-swatch {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  margin-right: 6px;
+  flex-shrink: 0;
+}
+
+.legend-range-label {
+  margin: 0;
+  font-family: Inter, sans-serif;
+  font-weight: 400;
+  font-size: 0.75rem;
+  line-height: 1.538;
+  letter-spacing: 0;
+  color: rgb(44, 48, 50);
+  white-space: nowrap;
+}
+
+.legend-categories {
+  font-size: 0.75rem;
+} 

--- a/examples/06-fetch-map/legend.ts
+++ b/examples/06-fetch-map/legend.ts
@@ -29,7 +29,7 @@ export function createLegend(layers: LayerDescriptor[]): HTMLElement {
     layerDiv.appendChild(nameDiv);
 
     const columnDiv = document.createElement('div');
-    columnDiv.textContent = `Data column: ${dataColumn}`;
+    columnDiv.textContent = `Color based on: ${dataColumn}`;
     layerDiv.appendChild(columnDiv);
 
     // Add min/max values from tilestats
@@ -38,8 +38,52 @@ export function createLegend(layers: LayerDescriptor[]): HTMLElement {
     );
     if (tilestats) {
       const rangeDiv = document.createElement('div');
-      rangeDiv.textContent = `Range: ${tilestats.min} - ${tilestats.max}`;
-      layerDiv.appendChild(rangeDiv);
+      if (tilestats.type === 'Number' && tilestats.min !== undefined) {
+        rangeDiv.textContent = `Range: ${tilestats.min} - ${tilestats.max}`;
+        layerDiv.appendChild(rangeDiv);
+
+        // Create color bar
+        const colorBar = document.createElement('div');
+        colorBar.style.display = 'flex';
+        colorBar.style.marginTop = '5px';
+        colorBar.style.height = '20px';
+        colorBar.style.width = '100%';
+        colorBar.style.borderRadius = '4px';
+        colorBar.style.overflow = 'hidden';
+
+        // Create 5 color stops
+        const numStops = 5;
+        for (let i = 0; i < numStops; i++) {
+          const value = tilestats.min + (tilestats.max - tilestats.min) * (i / (numStops - 1));
+          const color = typeof layer.props.getFillColor !== 'function' ? layer.props.getFillColor : layer.props.getFillColor({properties: {[dataColumn]: value}});
+          const stop = document.createElement('div');
+          stop.style.flex = '1';
+          stop.style.backgroundColor = `rgb(${color[0]}, ${color[1]}, ${color[2]})`;
+          colorBar.appendChild(stop);
+        }
+
+        layerDiv.appendChild(colorBar);
+
+        // Add labels
+        const labels = document.createElement('div');
+        labels.style.display = 'flex';
+        labels.style.justifyContent = 'space-between';
+        labels.style.fontSize = '10px';
+        labels.style.marginTop = '2px';
+        
+        const minLabel = document.createElement('div');
+        minLabel.textContent = tilestats.min.toFixed(0);
+        labels.appendChild(minLabel);
+        
+        const maxLabel = document.createElement('div');
+        maxLabel.textContent = tilestats.max.toFixed(0);
+        labels.appendChild(maxLabel);
+        
+        layerDiv.appendChild(labels);
+      } else if (tilestats.type === 'String' && tilestats.categories) {
+        rangeDiv.textContent = `Categories: ${tilestats.categories.length}`;
+        layerDiv.appendChild(rangeDiv);
+      }
     }
 
     container.appendChild(layerDiv);

--- a/examples/06-fetch-map/legend.ts
+++ b/examples/06-fetch-map/legend.ts
@@ -1,0 +1,38 @@
+import {LayerDescriptor} from '@carto/api-client';
+
+export function createLegend(layers: LayerDescriptor[]): HTMLElement {
+  const container = document.createElement('div');
+  container.style.position = 'absolute';
+  container.style.top = '10px';
+  container.style.right = '10px';
+  container.style.background = 'white';
+  container.style.padding = '10px';
+  container.style.borderRadius = '4px';
+  container.style.boxShadow = '0 2px 4px rgba(0,0,0,0.2)';
+  container.style.zIndex = '1000';
+
+  layers.forEach((layer, index) => {
+    const widgetSource = layer.props.data?.widgetSource?.props;
+    if (!widgetSource) return;
+    
+    const {columns, spatialDataColumn} = widgetSource;
+    const dataColumn = columns?.find((col: string) => col !== spatialDataColumn);
+    if (!dataColumn) return;
+
+    const layerDiv = document.createElement('div');
+    layerDiv.style.marginBottom = '10px';
+
+    const nameDiv = document.createElement('div');
+    nameDiv.style.fontWeight = 'bold';
+    nameDiv.textContent = layer.props.cartoLabel;
+    layerDiv.appendChild(nameDiv);
+
+    const columnDiv = document.createElement('div');
+    columnDiv.textContent = `Data column: ${dataColumn}`;
+    layerDiv.appendChild(columnDiv);
+
+    container.appendChild(layerDiv);
+  });
+
+  return container;
+} 

--- a/examples/06-fetch-map/legend.ts
+++ b/examples/06-fetch-map/legend.ts
@@ -13,6 +13,7 @@ export function createLegend(layers: LayerDescriptor[]): HTMLElement {
   container.style.borderRadius = '8px';
   container.style.boxShadow = '0 2px 4px rgba(0,0,0,0.2)';
   container.style.zIndex = '1000';
+  container.style.fontFamily = 'Inter, sans-serif';
 
   layers.forEach((layer, index) => {
     const widgetSource = layer.props.data?.widgetSource?.props;
@@ -26,29 +27,73 @@ export function createLegend(layers: LayerDescriptor[]): HTMLElement {
     layerDiv.style.marginBottom = '10px';
 
     const nameDiv = document.createElement('div');
-    nameDiv.style.fontWeight = 'bold';
+    nameDiv.style.margin = '0px';
+    nameDiv.style.fontFamily = 'Inter, sans-serif';
+    nameDiv.style.fontWeight = '400';
+    nameDiv.style.fontSize = '0.8125rem';
+    nameDiv.style.lineHeight = '1.538';
+    nameDiv.style.letterSpacing = '0px';
+    nameDiv.style.color = 'rgb(44, 48, 50)';
     nameDiv.style.marginBottom = '12px';
     nameDiv.textContent = layer.props.cartoLabel;
     layerDiv.appendChild(nameDiv);
 
     const columnDiv = document.createElement('div');
     columnDiv.style.color = '#6c757d';
-    columnDiv.style.fontSize = '12px';
-    columnDiv.style.marginBottom = '8px';
+    columnDiv.style.fontSize = '10px';
+    columnDiv.style.marginBottom = '4px';
     columnDiv.textContent = `COLOR BASED ON`;
     layerDiv.appendChild(columnDiv);
 
     const dataColumnDiv = document.createElement('div');
-    dataColumnDiv.style.marginBottom = '16px';
+    dataColumnDiv.style.margin = '0px';
+    dataColumnDiv.style.fontFamily = 'Inter, sans-serif';
+    dataColumnDiv.style.fontWeight = '400';
+    dataColumnDiv.style.fontSize = '0.75rem';
+    dataColumnDiv.style.lineHeight = '1.538';
+    dataColumnDiv.style.letterSpacing = '0px';
+    dataColumnDiv.style.color = 'rgb(44, 48, 50)';
+    dataColumnDiv.style.marginBottom = '12px';
     dataColumnDiv.textContent = dataColumn;
     layerDiv.appendChild(dataColumnDiv);
 
-    // Add color ranges
     const tilestats = layer.props.data?.tilestats?.layers[0]?.attributes?.find(
       (a: any) => a.attribute === dataColumn
     );
-    if (tilestats && tilestats.type === 'Number' && tilestats.min !== undefined) {
-      // Create 6 ranges like in the screenshot
+    
+    const isConstantColor = typeof layer.props.getFillColor !== 'function';
+    
+    if (isConstantColor) {
+      const rangeDiv = document.createElement('div');
+      rangeDiv.style.display = 'flex';
+      rangeDiv.style.alignItems = 'center';
+      rangeDiv.style.marginBottom = '6px';
+      
+      const colorSwatch = document.createElement('div');
+      colorSwatch.style.width = '12px';
+      colorSwatch.style.height = '12px';
+      colorSwatch.style.borderRadius = '50%';
+      colorSwatch.style.marginRight = '6px';
+      colorSwatch.style.flexShrink = '0';
+      
+      const color = layer.props.getFillColor;
+      colorSwatch.style.backgroundColor = `rgb(${color[0]}, ${color[1]}, ${color[2]})`;
+      
+      const rangeLabel = document.createElement('div');
+      rangeLabel.style.margin = '0px';
+      rangeLabel.style.fontFamily = 'Inter, sans-serif';
+      rangeLabel.style.fontWeight = '400';
+      rangeLabel.style.fontSize = '0.75rem';
+      rangeLabel.style.lineHeight = '1.538';
+      rangeLabel.style.letterSpacing = '0px';
+      rangeLabel.style.color = 'rgb(44, 48, 50)';
+      rangeLabel.style.whiteSpace = 'nowrap';
+      rangeLabel.textContent = 'All values';
+      
+      rangeDiv.appendChild(colorSwatch);
+      rangeDiv.appendChild(rangeLabel);
+      layerDiv.appendChild(rangeDiv);
+    } else if (tilestats && tilestats.type === 'Number' && tilestats.min !== undefined) {
       const numRanges = 6;
       const min = tilestats.min;
       const max = tilestats.max;
@@ -61,23 +106,27 @@ export function createLegend(layers: LayerDescriptor[]): HTMLElement {
         const rangeDiv = document.createElement('div');
         rangeDiv.style.display = 'flex';
         rangeDiv.style.alignItems = 'center';
-        rangeDiv.style.marginBottom = '8px';
+        rangeDiv.style.marginBottom = '6px';
         
         const colorSwatch = document.createElement('div');
-        colorSwatch.style.width = '20px';
-        colorSwatch.style.height = '20px';
+        colorSwatch.style.width = '12px';
+        colorSwatch.style.height = '12px';
         colorSwatch.style.borderRadius = '50%';
-        colorSwatch.style.marginRight = '8px';
+        colorSwatch.style.marginRight = '6px';
         colorSwatch.style.flexShrink = '0';
         
         const value = (rangeStart + rangeEnd) / 2;
-        const color = typeof layer.props.getFillColor !== 'function' ? 
-          layer.props.getFillColor : 
-          layer.props.getFillColor({properties: {[dataColumn]: value}});
+        const color = layer.props.getFillColor({properties: {[dataColumn]: value}});
         colorSwatch.style.backgroundColor = `rgb(${color[0]}, ${color[1]}, ${color[2]})`;
         
         const rangeLabel = document.createElement('div');
-        rangeLabel.style.fontSize = '12px';
+        rangeLabel.style.margin = '0px';
+        rangeLabel.style.fontFamily = 'Inter, sans-serif';
+        rangeLabel.style.fontWeight = '400';
+        rangeLabel.style.fontSize = '0.75rem';
+        rangeLabel.style.lineHeight = '1.538';
+        rangeLabel.style.letterSpacing = '0px';
+        rangeLabel.style.color = 'rgb(44, 48, 50)';
         rangeLabel.style.whiteSpace = 'nowrap';
         rangeLabel.textContent = `${rangeStart.toFixed(2)} – ${rangeEnd.toFixed(2)}`;
         
@@ -87,6 +136,7 @@ export function createLegend(layers: LayerDescriptor[]): HTMLElement {
       }
     } else if (tilestats?.type === 'String' && tilestats.categories) {
       const categoriesDiv = document.createElement('div');
+      categoriesDiv.style.fontSize = '0.75rem';
       categoriesDiv.textContent = `Categories: ${tilestats.categories.length}`;
       layerDiv.appendChild(categoriesDiv);
     }

--- a/examples/06-fetch-map/legend.ts
+++ b/examples/06-fetch-map/legend.ts
@@ -8,12 +8,14 @@ export function createLegend(layers: LayerDescriptor[]): HTMLElement {
   const container = document.createElement('div');
   container.className = 'legend-container';
 
-  layers.forEach((layer, index) => {
+  layers.forEach((layer) => {
     const widgetSource = layer.props.data?.widgetSource?.props;
     if (!widgetSource) return;
-    
+
     const {columns, spatialDataColumn} = widgetSource;
-    const dataColumn = columns?.find((col: string) => col !== spatialDataColumn);
+    const dataColumn = columns?.find(
+      (col: string) => col !== spatialDataColumn
+    );
     if (!dataColumn) return;
 
     const layerDiv = document.createElement('div');
@@ -37,49 +39,55 @@ export function createLegend(layers: LayerDescriptor[]): HTMLElement {
     const tilestats = layer.props.data?.tilestats?.layers[0]?.attributes?.find(
       (a: any) => a.attribute === dataColumn
     );
-    
+
     const isConstantColor = typeof layer.props.getFillColor !== 'function';
-    
+
     if (isConstantColor) {
       const rangeDiv = document.createElement('div');
       rangeDiv.className = 'legend-range';
-      
+
       const colorSwatch = document.createElement('div');
       colorSwatch.className = 'legend-color-swatch';
       const color = layer.props.getFillColor;
       colorSwatch.style.backgroundColor = `rgb(${color[0]}, ${color[1]}, ${color[2]})`;
-      
+
       const rangeLabel = document.createElement('div');
       rangeLabel.className = 'legend-range-label';
       rangeLabel.textContent = 'All values';
-      
+
       rangeDiv.appendChild(colorSwatch);
       rangeDiv.appendChild(rangeLabel);
       layerDiv.appendChild(rangeDiv);
-    } else if (tilestats && tilestats.type === 'Number' && tilestats.min !== undefined) {
+    } else if (
+      tilestats &&
+      tilestats.type === 'Number' &&
+      tilestats.min !== undefined
+    ) {
       const numRanges = 6;
       const min = tilestats.min;
       const max = tilestats.max;
       const step = (max - min) / numRanges;
 
       for (let i = 0; i < numRanges; i++) {
-        const rangeStart = min + (step * i);
-        const rangeEnd = i === numRanges - 1 ? max : min + (step * (i + 1));
-        
+        const rangeStart = min + step * i;
+        const rangeEnd = i === numRanges - 1 ? max : min + step * (i + 1);
+
         const rangeDiv = document.createElement('div');
         rangeDiv.className = 'legend-range';
-        
+
         const colorSwatch = document.createElement('div');
         colorSwatch.className = 'legend-color-swatch';
-        
+
         const value = (rangeStart + rangeEnd) / 2;
-        const color = layer.props.getFillColor({properties: {[dataColumn]: value}});
+        const color = layer.props.getFillColor({
+          properties: {[dataColumn]: value},
+        });
         colorSwatch.style.backgroundColor = `rgb(${color[0]}, ${color[1]}, ${color[2]})`;
-        
+
         const rangeLabel = document.createElement('div');
         rangeLabel.className = 'legend-range-label';
         rangeLabel.textContent = `${rangeStart.toFixed(2)} – ${rangeEnd.toFixed(2)}`;
-        
+
         rangeDiv.appendChild(colorSwatch);
         rangeDiv.appendChild(rangeLabel);
         layerDiv.appendChild(rangeDiv);
@@ -96,4 +104,4 @@ export function createLegend(layers: LayerDescriptor[]): HTMLElement {
 
   wrapper.appendChild(container);
   return wrapper;
-} 
+}

--- a/examples/06-fetch-map/legend.ts
+++ b/examples/06-fetch-map/legend.ts
@@ -5,6 +5,7 @@ export function createLegend(layers: LayerDescriptor[]): HTMLElement {
   container.style.position = 'absolute';
   container.style.top = '10px';
   container.style.right = '10px';
+  container.style.width = '200px';
   container.style.background = 'white';
   container.style.padding = '10px';
   container.style.borderRadius = '4px';
@@ -30,6 +31,16 @@ export function createLegend(layers: LayerDescriptor[]): HTMLElement {
     const columnDiv = document.createElement('div');
     columnDiv.textContent = `Data column: ${dataColumn}`;
     layerDiv.appendChild(columnDiv);
+
+    // Add min/max values from tilestats
+    const tilestats = layer.props.data?.tilestats?.layers[0]?.attributes?.find(
+      (a: any) => a.attribute === dataColumn
+    );
+    if (tilestats) {
+      const rangeDiv = document.createElement('div');
+      rangeDiv.textContent = `Range: ${tilestats.min} - ${tilestats.max}`;
+      layerDiv.appendChild(rangeDiv);
+    }
 
     container.appendChild(layerDiv);
   });

--- a/examples/06-fetch-map/legend.ts
+++ b/examples/06-fetch-map/legend.ts
@@ -1,19 +1,12 @@
 import {LayerDescriptor} from '@carto/api-client';
+import './legend.css';
 
 export function createLegend(layers: LayerDescriptor[]): HTMLElement {
+  const wrapper = document.createElement('div');
+  wrapper.className = 'legend-wrapper';
+
   const container = document.createElement('div');
-  container.style.position = 'absolute';
-  container.style.top = '10px';
-  container.style.right = '10px';
-  container.style.width = '200px';
-  container.style.maxHeight = '400px';
-  container.style.overflowY = 'auto';
-  container.style.background = 'white';
-  container.style.padding = '16px';
-  container.style.borderRadius = '8px';
-  container.style.boxShadow = '0 2px 4px rgba(0,0,0,0.2)';
-  container.style.zIndex = '1000';
-  container.style.fontFamily = 'Inter, sans-serif';
+  container.className = 'legend-container';
 
   layers.forEach((layer, index) => {
     const widgetSource = layer.props.data?.widgetSource?.props;
@@ -24,36 +17,20 @@ export function createLegend(layers: LayerDescriptor[]): HTMLElement {
     if (!dataColumn) return;
 
     const layerDiv = document.createElement('div');
-    layerDiv.style.marginBottom = '10px';
+    layerDiv.className = 'legend-layer';
 
     const nameDiv = document.createElement('div');
-    nameDiv.style.margin = '0px';
-    nameDiv.style.fontFamily = 'Inter, sans-serif';
-    nameDiv.style.fontWeight = '400';
-    nameDiv.style.fontSize = '0.8125rem';
-    nameDiv.style.lineHeight = '1.538';
-    nameDiv.style.letterSpacing = '0px';
-    nameDiv.style.color = 'rgb(44, 48, 50)';
-    nameDiv.style.marginBottom = '12px';
+    nameDiv.className = 'legend-title';
     nameDiv.textContent = layer.props.cartoLabel;
     layerDiv.appendChild(nameDiv);
 
     const columnDiv = document.createElement('div');
-    columnDiv.style.color = '#6c757d';
-    columnDiv.style.fontSize = '10px';
-    columnDiv.style.marginBottom = '4px';
+    columnDiv.className = 'legend-header';
     columnDiv.textContent = `COLOR BASED ON`;
     layerDiv.appendChild(columnDiv);
 
     const dataColumnDiv = document.createElement('div');
-    dataColumnDiv.style.margin = '0px';
-    dataColumnDiv.style.fontFamily = 'Inter, sans-serif';
-    dataColumnDiv.style.fontWeight = '400';
-    dataColumnDiv.style.fontSize = '0.75rem';
-    dataColumnDiv.style.lineHeight = '1.538';
-    dataColumnDiv.style.letterSpacing = '0px';
-    dataColumnDiv.style.color = 'rgb(44, 48, 50)';
-    dataColumnDiv.style.marginBottom = '12px';
+    dataColumnDiv.className = 'legend-column';
     dataColumnDiv.textContent = dataColumn;
     layerDiv.appendChild(dataColumnDiv);
 
@@ -65,29 +42,15 @@ export function createLegend(layers: LayerDescriptor[]): HTMLElement {
     
     if (isConstantColor) {
       const rangeDiv = document.createElement('div');
-      rangeDiv.style.display = 'flex';
-      rangeDiv.style.alignItems = 'center';
-      rangeDiv.style.marginBottom = '6px';
+      rangeDiv.className = 'legend-range';
       
       const colorSwatch = document.createElement('div');
-      colorSwatch.style.width = '12px';
-      colorSwatch.style.height = '12px';
-      colorSwatch.style.borderRadius = '50%';
-      colorSwatch.style.marginRight = '6px';
-      colorSwatch.style.flexShrink = '0';
-      
+      colorSwatch.className = 'legend-color-swatch';
       const color = layer.props.getFillColor;
       colorSwatch.style.backgroundColor = `rgb(${color[0]}, ${color[1]}, ${color[2]})`;
       
       const rangeLabel = document.createElement('div');
-      rangeLabel.style.margin = '0px';
-      rangeLabel.style.fontFamily = 'Inter, sans-serif';
-      rangeLabel.style.fontWeight = '400';
-      rangeLabel.style.fontSize = '0.75rem';
-      rangeLabel.style.lineHeight = '1.538';
-      rangeLabel.style.letterSpacing = '0px';
-      rangeLabel.style.color = 'rgb(44, 48, 50)';
-      rangeLabel.style.whiteSpace = 'nowrap';
+      rangeLabel.className = 'legend-range-label';
       rangeLabel.textContent = 'All values';
       
       rangeDiv.appendChild(colorSwatch);
@@ -104,30 +67,17 @@ export function createLegend(layers: LayerDescriptor[]): HTMLElement {
         const rangeEnd = i === numRanges - 1 ? max : min + (step * (i + 1));
         
         const rangeDiv = document.createElement('div');
-        rangeDiv.style.display = 'flex';
-        rangeDiv.style.alignItems = 'center';
-        rangeDiv.style.marginBottom = '6px';
+        rangeDiv.className = 'legend-range';
         
         const colorSwatch = document.createElement('div');
-        colorSwatch.style.width = '12px';
-        colorSwatch.style.height = '12px';
-        colorSwatch.style.borderRadius = '50%';
-        colorSwatch.style.marginRight = '6px';
-        colorSwatch.style.flexShrink = '0';
+        colorSwatch.className = 'legend-color-swatch';
         
         const value = (rangeStart + rangeEnd) / 2;
         const color = layer.props.getFillColor({properties: {[dataColumn]: value}});
         colorSwatch.style.backgroundColor = `rgb(${color[0]}, ${color[1]}, ${color[2]})`;
         
         const rangeLabel = document.createElement('div');
-        rangeLabel.style.margin = '0px';
-        rangeLabel.style.fontFamily = 'Inter, sans-serif';
-        rangeLabel.style.fontWeight = '400';
-        rangeLabel.style.fontSize = '0.75rem';
-        rangeLabel.style.lineHeight = '1.538';
-        rangeLabel.style.letterSpacing = '0px';
-        rangeLabel.style.color = 'rgb(44, 48, 50)';
-        rangeLabel.style.whiteSpace = 'nowrap';
+        rangeLabel.className = 'legend-range-label';
         rangeLabel.textContent = `${rangeStart.toFixed(2)} – ${rangeEnd.toFixed(2)}`;
         
         rangeDiv.appendChild(colorSwatch);
@@ -136,7 +86,7 @@ export function createLegend(layers: LayerDescriptor[]): HTMLElement {
       }
     } else if (tilestats?.type === 'String' && tilestats.categories) {
       const categoriesDiv = document.createElement('div');
-      categoriesDiv.style.fontSize = '0.75rem';
+      categoriesDiv.className = 'legend-categories';
       categoriesDiv.textContent = `Categories: ${tilestats.categories.length}`;
       layerDiv.appendChild(categoriesDiv);
     }
@@ -144,5 +94,6 @@ export function createLegend(layers: LayerDescriptor[]): HTMLElement {
     container.appendChild(layerDiv);
   });
 
-  return container;
+  wrapper.appendChild(container);
+  return wrapper;
 } 

--- a/src/fetch-map/parse-map.ts
+++ b/src/fetch-map/parse-map.ts
@@ -57,7 +57,7 @@ export function parseMap(json: any) {
   const {keplerMapConfig, datasets, token} = json;
   assert(keplerMapConfig.version === 'v1', 'Only support Kepler v1');
   const config = keplerMapConfig.config as KeplerMapConfig;
-  const {filters, mapState, mapStyle, popupSettings} = config;
+  const {filters, mapState, mapStyle, popupSettings, legendSettings} = config;
   const {layers, layerBlending, interactionConfig} = config.visState;
 
   return {
@@ -70,6 +70,7 @@ export function parseMap(json: any) {
     /** @deprecated Use `basemap`. */
     mapStyle,
     popupSettings,
+    legendSettings,
     token,
     layers: layers
       .reverse()

--- a/src/fetch-map/types.ts
+++ b/src/fetch-map/types.ts
@@ -117,6 +117,7 @@ export type KeplerMapConfig = {
     styleType: string;
     visibleLayerGroups: Record<string, boolean>;
   };
+  legendSettings?: any;
   popupSettings: any;
   visState: {
     layers: MapConfigLayer[];

--- a/test/fetch-map/parse-map.spec.ts
+++ b/test/fetch-map/parse-map.spec.ts
@@ -159,28 +159,28 @@ describe('parseMap', () => {
         mapStyle: {},
         legendSettings: {
           layers: {
-            'abcd1234': {
+            abcd1234: {
               active: true,
               entries: [],
-              shouldDisplayEntries: true
+              shouldDisplayEntries: true,
             },
-            'wxyz5678': {
+            wxyz5678: {
               active: true,
               entries: [
                 {
                   hash: '041fefde86682c870543f0be4637fc81',
                   visualChannel: 'color',
-                  customColorLabels: ['Meteorites']
-                }
+                  customColorLabels: ['Meteorites'],
+                },
               ],
-              shouldDisplayEntries: true
-            }
+              shouldDisplayEntries: true,
+            },
           },
           expanded: {
             '0': true,
-            '1': false
+            '1': false,
           },
-          baseMapSelector: false
+          baseMapSelector: false,
         },
         popupSettings: {
           enabled: true,

--- a/test/fetch-map/parse-map.spec.ts
+++ b/test/fetch-map/parse-map.spec.ts
@@ -148,37 +148,62 @@ describe('parseMap', () => {
     );
   });
 
-  test('popupSettings are exported', () => {
-    // Mock input with popupSettings
-    const mockInput = {
-      id: 'test-map',
-      title: 'Test Map',
-      keplerMapConfig: {
-        version: 'v1',
-        config: {
-          mapState: {},
-          mapStyle: {},
-          popupSettings: {
-            enabled: true,
-            fields: ['field1', 'field2'],
+  // Mock input with popupSettings and legendSettings
+  const mockInput = {
+    id: 'test-map',
+    title: 'Test Map',
+    keplerMapConfig: {
+      version: 'v1',
+      config: {
+        mapState: {},
+        mapStyle: {},
+        legendSettings: {
+          layers: {
+            'abcd1234': {
+              active: true,
+              entries: [],
+              shouldDisplayEntries: true
+            },
+            'wxyz5678': {
+              active: true,
+              entries: [
+                {
+                  hash: '041fefde86682c870543f0be4637fc81',
+                  visualChannel: 'color',
+                  customColorLabels: ['Meteorites']
+                }
+              ],
+              shouldDisplayEntries: true
+            }
           },
-          visState: {
-            layers: [],
-            layerBlending: 'normal',
-            interactionConfig: {},
+          expanded: {
+            '0': true,
+            '1': false
           },
+          baseMapSelector: false
+        },
+        popupSettings: {
+          enabled: true,
+          fields: ['field1', 'field2'],
+        },
+        visState: {
+          layers: [],
+          layerBlending: 'normal',
+          interactionConfig: {},
         },
       },
-      datasets: [],
-      token: 'test-token',
-    };
-
+    },
+    datasets: [],
+    token: 'test-token',
+  };
+  test('popupSettings and legendSettings are exported', () => {
     const result = parseMap(mockInput);
+    const config = mockInput.keplerMapConfig.config;
 
     expect(result.popupSettings).toBeDefined();
-    expect(result.popupSettings).toEqual({
-      enabled: true,
-      fields: ['field1', 'field2'],
-    });
+    expect(result.popupSettings).toEqual(config.popupSettings);
+
+    expect(result.legendSettings).toBeDefined();
+    expect(result.legendSettings).toEqual(config.legendSettings);
   });
 });


### PR DESCRIPTION
For https://github.com/CartoDB/carto-api-client/issues/124

### Background

For discussion, regarding API for legends. I've marked as merging into https://github.com/CartoDB/carto-api-client/pull/153, but it doesn't actually need the top-level `legendSettings`.

### Demo

https://github.com/user-attachments/assets/49b0c08d-9a14-4d26-83ad-b4aa9e785acc

Example of how to use use the existing `props` that the `Layer` has to build a simple legend. On one hand, it is nice to be able to reuse the existing APIs, on the other I'm not sure if reaching deep into `props.data` to retrieve `widgetSource` and `tilestats` is very clean. Maybe we could wrap this better in some sort of `Widget`