### PR TITLE
chore: make package compatible

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,16 +14,7 @@
     "access": "public"
   },
   "main": "./build/api-client.cjs",
-  "module": "./build/api-client.js",
-  "types": "./build/api-client.d.ts",
   "type": "module",
-  "typesVersions": {
-    "*": {
-      "*": [
-        "./build/api-client.d.ts"
-      ]
-    }
-  },
   "sideEffects": false,
   "exports": {
     ".": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,17 @@
   "publishConfig": {
     "access": "public"
   },
+  "main": "./build/api-client.cjs",
+  "module": "./build/api-client.js",
+  "types": "./build/api-client.d.ts",
   "type": "module",
+  "typesVersions": {
+    "*": {
+      "*": [
+        "./build/api-client.d.ts"
+      ]
+    }
+  },
   "sideEffects": false,
   "exports": {
     ".": {


### PR DESCRIPTION
### Background

When importing `@carto/api-client` in deck.gl, the types do not resolve correctly, unless `modules/carto/package.json` includes `"moduleResolution": "bundler"`. In order to avoid having to do this, we should support the default `"moduleResolution": "node"` as it will otherwise be an issue other consumers of the library will face

### Changes

- Add configuration to `package.json` to avoid the need for `"moduleResolution": "bundler"` in downstream projects