### PR TITLE
fetchMap: do not throw in findAccessorKey

### DIFF
--- a/src/fetch-map/layer-map.ts
+++ b/src/fetch-map/layer-map.ts
@@ -272,9 +272,9 @@ function findAccessorKey(keys: string[], properties: any): string[] {
     }
   }
 
-  throw new Error(
-    `Could not find property for any accessor key: ${keys.join(', ')}`
-  );
+  // If data doesn't contain any valid keys, return all keys to run search
+  // on next feature
+  return keys;
 }
 
 export function getColorValueAccessor(

--- a/src/fetch-map/layer-map.ts
+++ b/src/fetch-map/layer-map.ts
@@ -118,7 +118,8 @@ const customMarkersPropsMap = {
 const heatmapTilePropsMap = {
   visConfig: {
     colorRange: (x: any) => ({colorRange: x.colors.map(hexToRGBA)}),
-    radius: 'radiusPixels',
+    radius: (radius: number) => ({radiusPixels: 20 + radius}),
+    opacity: 'opacity',
   },
 };
 


### PR DESCRIPTION
For https://github.com/CartoDB/carto-api-client/issues/124

See test map `194f11fb-a04d-425b-8ecf-d98049f183bb` for repro

#### Change list

- Instead of throwing return list of accessor keys, to support cases where a feature is missing data