### PR TITLE
feat(filters): Export getApplicableFilters

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "homepage": "https://github.com/CartoDB/carto-api-client#readme",
   "author": "Don McCurdy <donmccurdy@carto.com>",
   "packageManager": "yarn@4.3.1",
-  "version": "0.5.1",
+  "version": "0.5.2-alpha.0",
   "license": "MIT",
   "publishConfig": {
     "access": "public"
@@ -127,5 +127,6 @@
   "resolutions": {
     "@carto/api-client": "portal:./",
     "rollup": "^4.20.0"
-  }
+  },
+  "stableVersion": "0.5.1"
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,38 +1,3 @@
-import {Filter} from './types.js';
-import {FilterType} from './constants.js';
-
-const FILTER_TYPES = new Set(Object.values(FilterType));
-const isFilterType = (type: string): type is FilterType =>
-  FILTER_TYPES.has(type as FilterType);
-
-/**
- * @privateRemarks Source: @carto/react-widgets
- * @internal
- */
-export function getApplicableFilters(
-  owner?: string,
-  filters?: Record<string, Filter>
-): Record<string, Filter> {
-  if (!filters) return {};
-
-  const applicableFilters: Record<string, Filter> = {};
-
-  for (const column in filters) {
-    for (const type in filters[column]) {
-      if (!isFilterType(type)) continue;
-
-      const filter = filters[column][type];
-      const isApplicable = !owner || !filter?.owner || filter?.owner !== owner;
-      if (filter && isApplicable) {
-        applicableFilters[column] ||= {};
-        (applicableFilters[column][type] as typeof filter) = filter;
-      }
-    }
-  }
-
-  return applicableFilters;
-}
-
 type Row<T> = Record<string, T> | Record<string, T>[] | T[] | T;
 
 /**

--- a/src/widget-sources/widget-remote-source.ts
+++ b/src/widget-sources/widget-remote-source.ts
@@ -17,11 +17,12 @@ import {
   TimeSeriesRequestOptions,
   TimeSeriesResponse,
 } from './types.js';
-import {getApplicableFilters, normalizeObjectKeys} from '../utils.js';
+import {normalizeObjectKeys} from '../utils.js';
 import {DEFAULT_TILE_RESOLUTION} from '../constants-internal.js';
 import {WidgetSource, WidgetSourceProps} from './widget-source.js';
 import {Filters} from '../types.js';
 import {ApiVersion} from '../constants.js';
+import {getApplicableFilters} from '../filters.js';
 
 export type WidgetRemoteSourceProps = WidgetSourceProps;
 

--- a/src/widget-sources/widget-tileset-source-impl.ts
+++ b/src/widget-sources/widget-tileset-source-impl.ts
@@ -16,12 +16,7 @@ import {
   TimeSeriesRequestOptions,
   TimeSeriesResponse,
 } from './types.js';
-import {
-  InvalidColumnError,
-  assert,
-  assignOptional,
-  getApplicableFilters,
-} from '../utils.js';
+import {InvalidColumnError, assert, assignOptional} from '../utils.js';
 import {Filter, SpatialFilter, Tile} from '../types.js';
 import {
   TileFeatureExtractOptions,
@@ -42,6 +37,7 @@ import {FeatureCollection} from 'geojson';
 import {WidgetSource} from './widget-source.js';
 import {booleanEqual} from '@turf/boolean-equal';
 import type {WidgetTilesetSourceProps} from './widget-tileset-source.js';
+import {getApplicableFilters} from '../filters.js';
 
 // TODO(cleanup): Parameter defaults in source functions and widget API calls are
 // currently duplicated and possibly inconsistent. Consider consolidating and

--- a/test/filters.test.ts
+++ b/test/filters.test.ts
@@ -6,6 +6,8 @@ import {
   removeFilter,
   getFilter,
   hasFilter,
+  getApplicableFilters,
+  Filters,
 } from '@carto/api-client';
 
 test('addFilter', () => {
@@ -230,4 +232,22 @@ test('hasFilter', () => {
 
   expect(hasFilter(filters, {column: 'column_b', owner: 'owner-3'})).toBe(true);
   expect(hasFilter(filters, {column: 'column_b', owner: 'owner-2'})).toBe(true);
+});
+
+test('getApplicableFilters', () => {
+  const filters: Filters = {
+    column_a: {
+      [FilterType.IN]: {values: [1, 2]},
+    },
+    column_b: {
+      [FilterType.IN]: {values: ['a', 'b'], owner: 'owner-3'},
+      [FilterType.BETWEEN]: {values: [[3, 4]], owner: 'owner-2'},
+    },
+  };
+
+  expect(getApplicableFilters('', filters)).toMatchObject(filters);
+  expect(getApplicableFilters('owner-2', filters)).toMatchObject({
+    column_a: {[FilterType.IN]: {values: [1, 2]}},
+    column_b: {[FilterType.IN]: {values: ['a', 'b'], owner: 'owner-3'}},
+  });
 });


### PR DESCRIPTION
Exports `getApplicableFilters`. I've kept the same name and function signature as C4R, but would be fine with changing this (/cc @srtena). This function isn't strictly necessary when building filterable widgets — it's used _internally_ to make sure a widget doesn't filter itself — but can be helpful if you need to detect whether or not the filters affecting a particular widget have changed, without making a widget query.

#### PR Dependency Tree


* **PR #162** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)