### PR TITLE
perf(fetchMap): Remove moment-timezone dependency

### DIFF
--- a/src/fetch-map/layer-map.ts
+++ b/src/fetch-map/layer-map.ts
@@ -11,7 +11,6 @@ import {
   scaleThreshold,
 } from 'd3-scale';
 import {format as d3Format} from 'd3-format';
-import moment from 'moment-timezone';
 
 export type LayerType =
   | 'clusterTile'
@@ -22,7 +21,12 @@ export type LayerType =
   | 'raster'
   | 'tileset';
 
-import {createBinaryProxy, scaleIdentity} from './utils.js';
+import {
+  createBinaryProxy,
+  formatDate,
+  formatTimestamp,
+  scaleIdentity,
+} from './utils.js';
 import type {
   CustomMarkersRange,
   Dataset,
@@ -457,10 +461,10 @@ export function getSizeAccessor(
 }
 
 const FORMATS: Record<string, (value: any) => string> = {
-  date: (s) => moment.utc(s).format('MM/DD/YY HH:mm:ssa'),
+  date: formatDate,
   integer: d3Format('i'),
   float: d3Format('.5f'),
-  timestamp: (s) => moment.utc(s).format('X'),
+  timestamp: formatTimestamp,
   default: String,
 };
 

--- a/src/fetch-map/utils.ts
+++ b/src/fetch-map/utils.ts
@@ -67,3 +67,21 @@ export function isRemoteCalculationSupported(dataset: Dataset) {
 
   return true;
 }
+
+const DATE_FORMATTER = new Intl.DateTimeFormat('en-US', {
+  year: '2-digit',
+  month: 'numeric',
+  day: 'numeric',
+  hour: 'numeric',
+  minute: 'numeric',
+  second: 'numeric',
+  timeZone: 'UTC',
+});
+
+export function formatDate(value: string | number | Date): string {
+  return DATE_FORMATTER.format(new Date(value));
+}
+
+export function formatTimestamp(value: string | number | Date): string {
+  return String(Math.floor(new Date(value).getTime() / 1000));
+}

--- a/test/bundle-size.test.ts
+++ b/test/bundle-size.test.ts
@@ -1,0 +1,16 @@
+import {expect, test} from 'vitest';
+import {readFile} from 'node:fs/promises';
+
+// Confirm bundle size is non-trivial (not a barrel file), but also not larger
+// than the allocated bundle size budget.
+const BUNDLE_SIZE_MIN = 10_000;
+const BUNDLE_SIZE_MAX = 400_000;
+
+test('bundle size', async () => {
+  const pkg = JSON.parse(await readFile('package.json', 'utf8'));
+  const entryPath = pkg.exports['.']['default']['default'];
+  const entry = await readFile(entryPath, 'utf8');
+
+  expect(entry.length).toBeGreaterThan(BUNDLE_SIZE_MIN);
+  expect(entry.length).toBeLessThan(BUNDLE_SIZE_MAX);
+});

--- a/test/fetch-map/layer-map.spec.ts
+++ b/test/fetch-map/layer-map.spec.ts
@@ -98,7 +98,7 @@ describe('layer-map', () => {
       {
         textLabelField: {name: 'date', type: 'date'},
         data: {date: '2021-10-29T13:25:01.067Z'},
-        expected: '10/29/21 13:25:01pm',
+        expected: '10/29/21, 1:25:01 PM',
       },
       {
         textLabelField: {name: 'field', type: 'integer'},


### PR DESCRIPTION
Bundle size of `@carto/api-client` accidentally increased to >1 MB because of the large `moment-timezone` dependency. The dependency is in [legacy mode and discouraged](https://www.npmjs.com/package/moment-timezone) anyway, I've replaced it with the web's [`Intl.DateTimeFormat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat) utility. This creates a small change in date formatting, but I think that's acceptable for our purposes.

I've also added a very basic regression test for the bundle size. Currently this detects if the inline bundle crosses a threshold — it doesn't check external dependencies! — but it would be enough to catch this case at least.

#### PR Dependency Tree


* **PR #165** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)