### PR TITLE
fix(fetchMap): Fix cluster layer default aggregation expression column

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "homepage": "https://github.com/CartoDB/carto-api-client#readme",
   "author": "Don McCurdy <donmccurdy@carto.com>",
   "packageManager": "yarn@4.3.1",
-  "version": "0.5.2-alpha.1",
+  "version": "0.5.2-alpha.2",
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/src/fetch-map/layer-map.ts
+++ b/src/fetch-map/layer-map.ts
@@ -33,6 +33,7 @@ import type {
 } from './types.js';
 import type {ProviderType} from '../types.js';
 import {DEFAULT_AGGREGATION_EXP_ALIAS} from '../constants-internal.js';
+import type {SchemaField} from '../types-internal.js';
 
 const SCALE_FUNCS: Record<string, () => any> = {
   linear: scaleLinear,
@@ -495,11 +496,11 @@ export function calculateClusterRadius(
 export function getDefaultAggregationExpColumnAliasForLayerType(
   layerType: LayerType,
   provider: ProviderType,
-  columns: string[]
+  schema: SchemaField[]
 ): string {
-  if (columns && layerType === 'clusterTile') {
+  if (schema && layerType === 'clusterTile') {
     return getColumnAliasForAggregationExp(
-      getDefaultColumnFromSchemaForAggregationExp(columns),
+      getDefaultColumnFromSchemaForAggregationExp(schema),
       'count',
       provider
     );
@@ -520,9 +521,9 @@ function getColumnAliasForAggregationExp(
 
 /** @privateRemarks Source: Builder */
 function getDefaultColumnFromSchemaForAggregationExp(
-  columns: string[]
+  schema: SchemaField[]
 ): string {
-  return columns ? columns[0] : '';
+  return schema ? schema[0].name : '';
 }
 
 /** @privateRemarks Source: Builder */

--- a/src/fetch-map/parse-map.ts
+++ b/src/fetch-map/parse-map.ts
@@ -279,7 +279,7 @@ function createChannelProps(
     const aggregationExpAlias = getDefaultAggregationExpColumnAliasForLayerType(
       type,
       dataset.providerId,
-      dataset.columns
+      data.schema
     );
 
     result.pointType = visConfig.isTextVisible ? 'circle+text' : 'circle';

--- a/src/sources/base-source.ts
+++ b/src/sources/base-source.ts
@@ -55,7 +55,7 @@ export async function baseSource<UrlParameters extends Record<string, unknown>>(
     type: endpoint,
     source: JSON.stringify(parameters, undefined, 2),
   };
-  const mapInstantiation =
+  const {tilejson, schema} =
     await requestWithParameters<TilejsonMapInstantiation>({
       baseUrl,
       parameters,
@@ -65,7 +65,7 @@ export async function baseSource<UrlParameters extends Record<string, unknown>>(
       localCache,
     });
 
-  const dataUrl = mapInstantiation.tilejson.url[0];
+  const dataUrl = tilejson.url[0];
   if (cache) {
     cache.value = parseInt(
       new URL(dataUrl).searchParams.get('cache') || '',
@@ -84,6 +84,9 @@ export async function baseSource<UrlParameters extends Record<string, unknown>>(
   });
   if (accessToken) {
     json.accessToken = accessToken;
+  }
+  if (schema) {
+    json.schema = schema;
   }
   return json;
 }

--- a/src/sources/types.ts
+++ b/src/sources/types.ts
@@ -414,7 +414,11 @@ export type RasterMetadata = {
   pixel_resolution: number;
 };
 
-export type TilejsonResult = Tilejson & {accessToken: string};
+export type TilejsonResult = Tilejson & {
+  accessToken: string;
+  schema: SchemaField[];
+};
+
 export type QueryResult = {
   meta: {cacheHit: boolean; location: string; totalBytesProcessed: string};
   rows: Record<string, any>[];


### PR DESCRIPTION
Follow-up for #163. I'd thought that using the first entry in `dataset.columns` would be the same thing as the first entry from `mapInstantiation.schema`, and preferred that because the API client didn't previously expose the schema, but it looks like those are not necessarily the same fields/order, leading to issues where the cluster layer defaults to the wrong field for its aggregation expression column.

Fixes cluster layer fetchMap rendering.

![CleanShot 2025-05-01 at 12 27 38@2x](https://github.com/user-attachments/assets/2c88f4c4-150e-4f1e-aa09-16440ed19177)


#### PR Dependency Tree


* **PR #173** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)