### PR TITLE
WidgetRemoteSource: custom aggregations for category, timeseries models

### DIFF
--- a/src/widget-sources/types.ts
+++ b/src/widget-sources/types.ts
@@ -33,7 +33,8 @@ export interface BaseRequestOptions {
 /** Options for {@link WidgetRemoteSource#getCategories}. */
 export interface CategoryRequestOptions extends BaseRequestOptions {
   column: string;
-  operation?: 'count' | 'avg' | 'min' | 'max' | 'sum';
+  operation?: 'count' | 'avg' | 'min' | 'max' | 'sum' | 'custom';
+  operationExp?: string;
   operationColumn?: string;
   /** Local only. */
   joinOperation?: 'count' | 'avg' | 'min' | 'max' | 'sum';
@@ -131,7 +132,8 @@ export interface TimeSeriesRequestOptions extends BaseRequestOptions {
   column: string;
   stepSize: GroupDateType;
   stepMultiplier?: number;
-  operation?: 'count' | 'avg' | 'min' | 'max' | 'sum';
+  operation?: 'count' | 'avg' | 'min' | 'max' | 'sum' | 'custom';
+  operationExp?: string;
   operationColumn?: string;
   joinOperation?: 'count' | 'avg' | 'min' | 'max' | 'sum';
   splitByCategory?: string;

--- a/src/widget-sources/types.ts
+++ b/src/widget-sources/types.ts
@@ -3,6 +3,7 @@ import type {
   TileResolution,
 } from '../sources/types.js';
 import type {
+  AggregationType,
   Filters,
   GroupDateType,
   SortColumnType,
@@ -33,7 +34,8 @@ export interface BaseRequestOptions {
 /** Options for {@link WidgetRemoteSource#getCategories}. */
 export interface CategoryRequestOptions extends BaseRequestOptions {
   column: string;
-  operation?: 'count' | 'avg' | 'min' | 'max' | 'sum' | 'custom';
+  operation?: AggregationType
+  /** Remote only. Only valid if operation is 'custom' */
   operationExp?: string;
   operationColumn?: string;
   /** Local only. */
@@ -86,7 +88,8 @@ export interface FeaturesRequestOptions extends BaseRequestOptions {
 /** Options for {@link WidgetRemoteSource#getFormula}. */
 export interface FormulaRequestOptions extends BaseRequestOptions {
   column: string;
-  operation?: 'count' | 'avg' | 'min' | 'max' | 'sum' | 'custom';
+  operation?: AggregationType
+  /** Remote only. Only valid if operation is 'custom' */
   operationExp?: string;
   joinOperation?: 'count' | 'avg' | 'min' | 'max' | 'sum';
 }
@@ -132,7 +135,8 @@ export interface TimeSeriesRequestOptions extends BaseRequestOptions {
   column: string;
   stepSize: GroupDateType;
   stepMultiplier?: number;
-  operation?: 'count' | 'avg' | 'min' | 'max' | 'sum' | 'custom';
+  operation?: AggregationType
+  /** Remote only. Only valid if operation is 'custom' */
   operationExp?: string;
   operationColumn?: string;
   joinOperation?: 'count' | 'avg' | 'min' | 'max' | 'sum';

--- a/src/widget-sources/types.ts
+++ b/src/widget-sources/types.ts
@@ -31,12 +31,31 @@ export interface BaseRequestOptions {
   filterOwner?: string;
 }
 
-/** Options for {@link WidgetRemoteSource#getCategories}. */
+/**
+ * Examples:
+ *   * population by state
+ *      * column: 'state'
+ *      * operation: 'sum'
+ *      * operationColumn: 'population'
+ *   * average salary by department
+ *      * column: 'department'
+ *      * operation: 'avg'
+ *      * operationColumn: 'salary'
+ *   * custom aggregation by storetype
+ *      * column: 'storetype'
+ *      * operation: 'custom'
+ *      * operationExp: 'sum(sales)/sum(area)'
+ *
+ * Options for {@link WidgetRemoteSource#getCategories}.
+ */
 export interface CategoryRequestOptions extends BaseRequestOptions {
+  /** The column that to categorize by. */
   column: string;
-  operation?: AggregationType
+  /** The type of aggregation to apply on data in scope of each category. */
+  operation: AggregationType;
   /** Remote only. Only valid if operation is 'custom' */
   operationExp?: string;
+  /** The aggregated column per each category. */
   operationColumn?: string;
   /** Local only. */
   joinOperation?: 'count' | 'avg' | 'min' | 'max' | 'sum';
@@ -85,12 +104,28 @@ export interface FeaturesRequestOptions extends BaseRequestOptions {
   tileResolution?: TileResolution;
 }
 
-/** Options for {@link WidgetRemoteSource#getFormula}. */
+/**
+ * Examples:
+ *   * sum of all sales
+ *      * column: 'sales'
+ *      * operation: 'sum'
+ *   * average salary
+ *      * column: 'salary'
+ *      * operation: 'avg'
+ *   * custom aggregation over all rows
+ *      * operation: 'custom'
+ *      * operationExp: 'sum(sales)/sum(area)'
+ *
+ * Options for {@link WidgetRemoteSource#getFormula}.
+ */
 export interface FormulaRequestOptions extends BaseRequestOptions {
-  column: string;
-  operation?: AggregationType
+  /** The column to apply the aggregation operation on. Not needed for 'custom' operation. */
+  column?: string;
+  /** The type of aggregation to apply on data. */
+  operation: AggregationType;
   /** Remote only. Only valid if operation is 'custom' */
   operationExp?: string;
+  /** Local only. */
   joinOperation?: 'count' | 'avg' | 'min' | 'max' | 'sum';
 }
 
@@ -130,12 +165,23 @@ export interface TableRequestOptions extends BaseRequestOptions {
   searchFilterText?: string;
 }
 
-/** Options for {@link WidgetRemoteSource#getTimeSeries}. */
+/**
+ * Examples:
+ *   * sum of all sales by month
+ *      * column: 'sales'
+ *      * stepSize: 'month'
+ *      * operation: 'sum'
+ *   * average salary by year
+ *      * column: 'salary'
+ *      * stepSize: 'year'
+ *      * operation: 'avg'
+ * Options for {@link WidgetRemoteSource#getTimeSeries}.
+ */
 export interface TimeSeriesRequestOptions extends BaseRequestOptions {
   column: string;
   stepSize: GroupDateType;
   stepMultiplier?: number;
-  operation?: AggregationType
+  operation: AggregationType;
   /** Remote only. Only valid if operation is 'custom' */
   operationExp?: string;
   operationColumn?: string;

--- a/src/widget-sources/widget-remote-source.ts
+++ b/src/widget-sources/widget-remote-source.ts
@@ -17,7 +17,7 @@ import type {
   TimeSeriesRequestOptions,
   TimeSeriesResponse,
 } from './types.js';
-import {normalizeObjectKeys} from '../utils.js';
+import {assert, normalizeObjectKeys} from '../utils.js';
 import {DEFAULT_TILE_RESOLUTION} from '../constants-internal.js';
 import {WidgetSource, type WidgetSourceProps} from './widget-source.js';
 import type {Filters} from '../types.js';
@@ -74,7 +74,11 @@ export abstract class WidgetRemoteSource<
       spatialFiltersMode,
       ...params
     } = options;
-    const {column, operation, operationColumn} = params;
+    const {column, operation, operationColumn, operationExp} = params;
+
+    if (operation === 'custom') {
+      assert(operationExp, 'operationExp is required for custom operation');
+    }
 
     type CategoriesModelResponse = {rows: {name: string; value: number}[]};
 
@@ -88,6 +92,7 @@ export abstract class WidgetRemoteSource<
       params: {
         column,
         operation,
+        operationExp,
         operationColumn: operationColumn || column,
       },
       opts: {signal, headers: this.props.headers},
@@ -142,6 +147,10 @@ export abstract class WidgetRemoteSource<
     const {column, operation} = params;
 
     type FormulaModelResponse = {rows: {value: number}[]};
+
+    if (operation === 'custom') {
+      assert(operationExp, 'operationExp is required for custom operation');
+    }
 
     return executeModel({
       model: 'formula',
@@ -314,12 +323,17 @@ export abstract class WidgetRemoteSource<
       operationColumn,
       joinOperation,
       operation,
+      operationExp,
       stepSize,
       stepMultiplier,
       splitByCategory,
       splitByCategoryLimit,
       splitByCategoryValues,
     } = params;
+
+    if (operation === 'custom') {
+      assert(operationExp, 'operationExp is required for custom operation');
+    }
 
     type TimeSeriesModelResponse = {
       rows: {name: string; value: number}[];
@@ -340,6 +354,7 @@ export abstract class WidgetRemoteSource<
         operationColumn: operationColumn || column,
         joinOperation,
         operation,
+        operationExp,
         splitByCategory,
         splitByCategoryLimit,
         splitByCategoryValues,

--- a/src/widget-sources/widget-tileset-source-impl.ts
+++ b/src/widget-sources/widget-tileset-source-impl.ts
@@ -329,6 +329,10 @@ export class WidgetTilesetSourceImpl extends WidgetSource<WidgetTilesetSourcePro
     }
 
     assertColumn(this._features, column, operationColumn as string);
+    assert(
+      operation !== 'custom',
+      'Custom operation not supported for tilesets'
+    );
 
     const rows =
       groupValuesByDateColumn({

--- a/test/widget-sources/widget-remote-source.test.ts
+++ b/test/widget-sources/widget-remote-source.test.ts
@@ -121,7 +121,8 @@ test('getCategories', async () => {
 
   const actualCategories = await widgetSource.getCategories({
     column: 'store_type',
-    operation: 'count',
+    operation: 'custom',
+    operationExp: 'count(store_type) / 2',
   });
 
   expect(mockFetch).toHaveBeenCalledOnce();
@@ -133,7 +134,8 @@ test('getCategories', async () => {
     source: 'test-data',
     params: JSON.stringify({
       column: 'store_type',
-      operation: 'count',
+      operation: 'custom',
+      operationExp: 'count(store_type) / 2',
       operationColumn: 'store_type',
     }),
     queryParameters: '',
@@ -623,7 +625,8 @@ test('getTimeSeries', async () => {
   const actualTimeSeries = await widgetSource.getTimeSeries({
     column: 'date',
     stepSize: 'month',
-    operation: 'count',
+    operation: 'custom',
+    operationExp: 'count(purchases) * 2',
     operationColumn: 'purchases',
   });
 
@@ -638,7 +641,8 @@ test('getTimeSeries', async () => {
       column: 'date',
       stepSize: 'month',
       operationColumn: 'purchases',
-      operation: 'count',
+      operation: 'custom',
+      operationExp: 'count(purchases) * 2',
     }),
     queryParameters: '',
     filters: JSON.stringify({}),


### PR DESCRIPTION
Story: https://app.shortcut.com/cartoteam/story/486261

Just pass new parameters and update typings for `WidgetSource`s `getCategories` and `getTimeSeries`
 * `operation` can be also `custom`
 * `operationExp` needed if operation is `custom`