### PR TITLE
fix(widgets): Infer correct spatialDataType for widgets on dynamic point aggregation layer sources

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "homepage": "https://github.com/CartoDB/carto-api-client#readme",
   "author": "Don McCurdy <donmccurdy@carto.com>",
   "packageManager": "yarn@4.3.1",
-  "version": "0.5.3",
+  "version": "0.5.4-alpha.0",
   "license": "MIT",
   "publishConfig": {
     "access": "public"
@@ -128,5 +128,6 @@
   "resolutions": {
     "@carto/api-client": "portal:./",
     "rollup": "^4.20.0"
-  }
+  },
+  "stableVersion": "0.5.3"
 }

--- a/src/sources/h3-query-source.ts
+++ b/src/sources/h3-query-source.ts
@@ -3,6 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import {DEFAULT_AGGREGATION_RES_LEVEL_H3} from '../constants-internal.js';
+import {getWidgetSpatialDataType} from '../utils.js';
 import {
   WidgetQuerySource,
   type WidgetQuerySourceResult,
@@ -72,7 +73,11 @@ export const h3QuerySource = async function (
         ...options,
         // NOTE: Parameters with default values above must be explicitly passed here.
         spatialDataColumn,
-        spatialDataType,
+        spatialDataType: getWidgetSpatialDataType(
+          spatialDataType,
+          spatialDataColumn,
+          result.schema
+        ),
       }),
     })
   );

--- a/src/sources/h3-table-source.ts
+++ b/src/sources/h3-table-source.ts
@@ -3,6 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import {DEFAULT_AGGREGATION_RES_LEVEL_H3} from '../constants-internal.js';
+import {getWidgetSpatialDataType} from '../utils.js';
 import {
   WidgetTableSource,
   type WidgetTableSourceResult,
@@ -67,7 +68,11 @@ export const h3TableSource = async function (
         ...options,
         // NOTE: Parameters with default values above must be explicitly passed here.
         spatialDataColumn,
-        spatialDataType,
+        spatialDataType: getWidgetSpatialDataType(
+          spatialDataType,
+          spatialDataColumn,
+          result.schema
+        ),
       }),
     })
   );

--- a/src/sources/quadbin-query-source.ts
+++ b/src/sources/quadbin-query-source.ts
@@ -3,6 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import {DEFAULT_AGGREGATION_RES_LEVEL_QUADBIN} from '../constants-internal.js';
+import {getWidgetSpatialDataType} from '../utils.js';
 import {
   WidgetQuerySource,
   type WidgetQuerySourceResult,
@@ -73,7 +74,11 @@ export const quadbinQuerySource = async function (
         ...options,
         // NOTE: Parameters with default values above must be explicitly passed here.
         spatialDataColumn,
-        spatialDataType,
+        spatialDataType: getWidgetSpatialDataType(
+          spatialDataType,
+          spatialDataColumn,
+          result.schema
+        ),
       }),
     })
   );

--- a/src/sources/quadbin-table-source.ts
+++ b/src/sources/quadbin-table-source.ts
@@ -3,6 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import {DEFAULT_AGGREGATION_RES_LEVEL_QUADBIN} from '../constants-internal.js';
+import {getWidgetSpatialDataType} from '../utils.js';
 import {
   WidgetTableSource,
   type WidgetTableSourceResult,
@@ -68,7 +69,11 @@ export const quadbinTableSource = async function (
         ...options,
         // NOTE: Parameters with default values above must be explicitly passed here.
         spatialDataColumn,
-        spatialDataType,
+        spatialDataType: getWidgetSpatialDataType(
+          spatialDataType,
+          spatialDataColumn,
+          result.schema
+        ),
       }),
     })
   );

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,6 @@
-import type {Filter} from './types.js';
+import {SchemaFieldType, type Filter, type SchemaField} from './types.js';
 import {FilterType} from './constants.js';
+import type {SpatialDataType} from './sources/types.js';
 
 const FILTER_TYPES = new Set(Object.values(FilterType));
 const isFilterType = (type: string): type is FilterType =>
@@ -126,4 +127,22 @@ export function assignOptional<T extends object, U>(
     }
   }
   return target as T & U;
+}
+
+/**
+ * Returns the spatialDataType expected for widget operations, given layer source props. The
+ * spatialDataType used in widget operations may be different from that of the layer. For
+ * dynamically aggregated point datasets, widgets use type 'geo', not the aggregation type.
+ */
+export function getWidgetSpatialDataType(
+  spatialDataType: SpatialDataType,
+  spatialDataColumn: string,
+  schema: SchemaField[]
+): SpatialDataType {
+  const field = schema.find((field) => field.name === spatialDataColumn);
+  if (field && field.type === SchemaFieldType.Geometry) {
+    return 'geo';
+  }
+
+  return spatialDataType;
 }

--- a/test/sources/h3-query-source.test.ts
+++ b/test/sources/h3-query-source.test.ts
@@ -11,6 +11,7 @@ const TILESET_RESPONSE = {
   tilejson: '2.2.0',
   tiles: ['https://xyz.com/{z}/{x}/{y}?formatTiles=binary'],
   tilestats: {layers: []},
+  schema: [],
 };
 
 describe('h3QuerySource', () => {

--- a/test/sources/h3-table-source.test.ts
+++ b/test/sources/h3-table-source.test.ts
@@ -11,6 +11,7 @@ const TILESET_RESPONSE = {
   tilejson: '2.2.0',
   tiles: ['https://xyz.com/{z}/{x}/{y}?formatTiles=binary'],
   tilestats: {layers: []},
+  schema: [],
 };
 
 describe('h3TableSource', () => {

--- a/test/sources/quadbin-query-source.test.ts
+++ b/test/sources/quadbin-query-source.test.ts
@@ -11,6 +11,7 @@ const TILESET_RESPONSE = {
   tilejson: '2.2.0',
   tiles: ['https://xyz.com/{z}/{x}/{y}?formatTiles=binary'],
   tilestats: {layers: []},
+  schema: [],
 };
 
 describe('quadbinQuerySource', () => {

--- a/test/sources/quadbin-table-source.test.ts
+++ b/test/sources/quadbin-table-source.test.ts
@@ -11,6 +11,7 @@ const TILESET_RESPONSE = {
   tilejson: '2.2.0',
   tiles: ['https://xyz.com/{z}/{x}/{y}?formatTiles=binary'],
   tilestats: {layers: []},
+  schema: [],
 };
 
 describe('quadbinTableSource', () => {


### PR DESCRIPTION
Returns the spatialDataType expected for widget operations, given layer source props. The spatialDataType used in widget operations may be different from that of the layer. For dynamically aggregated point datasets, widgets use type 'geo', not the aggregation type.

[sc-484666]