### PR TITLE
chore(test): Improve testing of source functions and dynamic point aggregation

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -11,4 +11,7 @@ export {
 export {buildPublicMapUrl, buildStatsUrl} from './endpoints.js';
 export {query} from './query.js';
 export type {QueryOptions} from './query.js';
-export {requestWithParameters} from './request-with-parameters.js';
+export {
+  requestWithParameters,
+  clearDefaultRequestCache,
+} from './request-with-parameters.js';

--- a/src/api/request-with-parameters.ts
+++ b/src/api/request-with-parameters.ts
@@ -164,3 +164,11 @@ function excludeURLParameters(baseUrlString: string, parameters: string[]) {
   }
   return baseUrl.toString();
 }
+
+/**
+ * Clears the HTTP response cache for all requests using the default cache.
+ * @internal
+ */
+export function clearDefaultRequestCache() {
+  DEFAULT_REQUEST_CACHE.clear();
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ export {
   buildStatsUrl, // Internal, but required for fetchMap().
   query,
   requestWithParameters,
+  clearDefaultRequestCache, // Internal, for unit testing.
 } from './api/index.js';
 
 export {_getHexagonResolution} from './spatial-index.js';

--- a/test/__mock-fetch.ts
+++ b/test/__mock-fetch.ts
@@ -2,11 +2,14 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
+import {Mock, vi} from 'vitest';
+
 /* global Headers */
 
 const BINARY_TILE = new Uint8Array().buffer;
 
 const fetch = globalThis.fetch;
+
 type MockFetchCall = {
   url: string;
   headers: Record<string, unknown>;
@@ -141,4 +144,33 @@ export async function withMockFetchMapsV3(
   } finally {
     teardownMockFetchMaps();
   }
+}
+
+export const MOCK_INIT_RESPONSE = {
+  tilejson: {url: [`https://xyz.com?format=tilejson`]},
+};
+
+export const MOCK_TILESET_RESPONSE = {
+  tilejson: '2.2.0',
+  tiles: ['https://xyz.com/{z}/{x}/{y}?formatTiles=binary'],
+  tilestats: {layers: []},
+  schema: [],
+};
+
+export function stubGlobalFetchForSource(
+  initResponse = MOCK_INIT_RESPONSE,
+  tilesetResponse = MOCK_TILESET_RESPONSE
+) {
+  const mockFetch = vi
+    .fn()
+    .mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(initResponse),
+    })
+    .mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(tilesetResponse),
+    });
+  vi.stubGlobal('fetch', mockFetch);
+  return mockFetch;
 }

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,4 +1,8 @@
-import {getClient, setClient} from '@carto/api-client';
+import {
+  getClient,
+  setClient,
+  clearDefaultRequestCache,
+} from '@carto/api-client';
 import {afterEach, vi} from 'vitest';
 
 // NOTE: By default Vitest runs each test file in isolation, but sometimes we
@@ -11,6 +15,7 @@ const DEFAULT_CLIENT_ID = getClient();
 
 afterEach(() => {
   setClient(DEFAULT_CLIENT_ID);
+  clearDefaultRequestCache();
   vi.restoreAllMocks();
   vi.unstubAllGlobals();
 });

--- a/test/sources/base-source.test.ts
+++ b/test/sources/base-source.test.ts
@@ -1,19 +1,15 @@
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 import {setClient, vectorTableSource} from '@carto/api-client';
-
-const CACHE = 'base-source-test';
-
-const INIT_RESPONSE = {
-  tilejson: {url: [`https://xyz.com?format=tilejson&cache=${CACHE}`]},
-};
+import {MOCK_INIT_RESPONSE} from '../__mock-fetch.js';
 
 describe('baseSource', () => {
   beforeEach(() => {
     const mockFetch = vi
       .fn()
-      .mockReturnValue(
-        Promise.resolve({ok: true, json: () => Promise.resolve(INIT_RESPONSE)})
-      );
+      .mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(MOCK_INIT_RESPONSE),
+      });
 
     vi.stubGlobal('fetch', mockFetch);
   });

--- a/test/sources/base-source.test.ts
+++ b/test/sources/base-source.test.ts
@@ -4,12 +4,10 @@ import {MOCK_INIT_RESPONSE} from '../__mock-fetch.js';
 
 describe('baseSource', () => {
   beforeEach(() => {
-    const mockFetch = vi
-      .fn()
-      .mockResolvedValue({
-        ok: true,
-        json: () => Promise.resolve(MOCK_INIT_RESPONSE),
-      });
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(MOCK_INIT_RESPONSE),
+    });
 
     vi.stubGlobal('fetch', mockFetch);
   });

--- a/test/sources/boundary-query-source.test.ts
+++ b/test/sources/boundary-query-source.test.ts
@@ -1,36 +1,11 @@
 import {boundaryQuerySource} from '@carto/api-client';
-import {describe, vi, test, expect, beforeEach} from 'vitest';
-
-const CACHE = 'boundary-query-source-test';
-
-const INIT_RESPONSE = {
-  tilejson: {url: [`https://xyz.com?format=tilejson&cache=${CACHE}`]},
-};
-
-const TILESET_RESPONSE = {
-  tilejson: '2.2.0',
-  tiles: ['https://xyz.com/{z}/{x}/{y}?formatTiles=binary'],
-  tilestats: {layers: []},
-};
+import {describe, vi, test, expect} from 'vitest';
+import {stubGlobalFetchForSource} from '../__mock-fetch.js';
 
 describe('boundaryQuerySource', () => {
-  beforeEach(() => {
-    const mockFetch = vi
-      .fn()
-      .mockReturnValueOnce(
-        Promise.resolve({ok: true, json: () => Promise.resolve(INIT_RESPONSE)})
-      )
-      .mockReturnValueOnce(
-        Promise.resolve({
-          ok: true,
-          json: () => Promise.resolve(TILESET_RESPONSE),
-        })
-      );
-
-    vi.stubGlobal('fetch', mockFetch);
-  });
-
   test('default', async () => {
+    stubGlobalFetchForSource();
+
     const tilejson = await boundaryQuerySource({
       connectionName: 'carto_dw',
       accessToken: '<token>',
@@ -50,7 +25,7 @@ describe('boundaryQuerySource', () => {
     );
     expect(initURL).toMatch(/columns=column1%2Ccolumn2/);
 
-    expect(tilesetURL).toMatch(/^https:\/\/xyz\.com\/\?format=tilejson&cache=/);
+    expect(tilesetURL).toMatch(/^https:\/\/xyz\.com\/\?format=tilejson/);
 
     expect(tilejson).toBeTruthy();
     expect(tilejson.tiles).toEqual([

--- a/test/sources/boundary-table-source.test.ts
+++ b/test/sources/boundary-table-source.test.ts
@@ -1,36 +1,11 @@
 import {boundaryTableSource} from '@carto/api-client';
-import {describe, vi, test, expect, beforeEach} from 'vitest';
-
-const CACHE = 'boundary-table-source-test';
-
-const INIT_RESPONSE = {
-  tilejson: {url: [`https://xyz.com?format=tilejson&cache=${CACHE}`]},
-};
-
-const TILESET_RESPONSE = {
-  tilejson: '2.2.0',
-  tiles: ['https://xyz.com/{z}/{x}/{y}?formatTiles=binary'],
-  tilestats: {layers: []},
-};
+import {describe, vi, test, expect} from 'vitest';
+import {stubGlobalFetchForSource} from '../__mock-fetch.js';
 
 describe('boundaryTableSource', () => {
-  beforeEach(() => {
-    const mockFetch = vi
-      .fn()
-      .mockReturnValueOnce(
-        Promise.resolve({ok: true, json: () => Promise.resolve(INIT_RESPONSE)})
-      )
-      .mockReturnValueOnce(
-        Promise.resolve({
-          ok: true,
-          json: () => Promise.resolve(TILESET_RESPONSE),
-        })
-      );
-
-    vi.stubGlobal('fetch', mockFetch);
-  });
-
   test('default', async () => {
+    stubGlobalFetchForSource();
+
     const tilejson = await boundaryTableSource({
       connectionName: 'carto_dw',
       accessToken: '<token>',
@@ -48,7 +23,7 @@ describe('boundaryTableSource', () => {
     expect(initURL).toMatch(/propertiesTableName=a.b.properties_table/);
     expect(initURL).toMatch(/columns=column1%2Ccolumn2/);
 
-    expect(tilesetURL).toMatch(/^https:\/\/xyz\.com\/\?format=tilejson&cache=/);
+    expect(tilesetURL).toMatch(/^https:\/\/xyz\.com\/\?format=tilejson/);
 
     expect(tilejson).toBeTruthy();
     expect(tilejson.tiles).toEqual([

--- a/test/sources/h3-query-source.test.ts
+++ b/test/sources/h3-query-source.test.ts
@@ -1,37 +1,15 @@
 import {WidgetQuerySource, h3QuerySource} from '@carto/api-client';
-import {describe, vi, test, expect, beforeEach} from 'vitest';
-
-const CACHE = 'h3-query-source-test';
-
-const INIT_RESPONSE = {
-  tilejson: {url: [`https://xyz.com?format=tilejson&cache=${CACHE}`]},
-};
-
-const TILESET_RESPONSE = {
-  tilejson: '2.2.0',
-  tiles: ['https://xyz.com/{z}/{x}/{y}?formatTiles=binary'],
-  tilestats: {layers: []},
-  schema: [],
-};
+import {describe, vi, test, expect} from 'vitest';
+import {
+  MOCK_INIT_RESPONSE,
+  MOCK_TILESET_RESPONSE,
+  stubGlobalFetchForSource,
+} from '../__mock-fetch.js';
 
 describe('h3QuerySource', () => {
-  beforeEach(() => {
-    const mockFetch = vi
-      .fn()
-      .mockReturnValueOnce(
-        Promise.resolve({ok: true, json: () => Promise.resolve(INIT_RESPONSE)})
-      )
-      .mockReturnValueOnce(
-        Promise.resolve({
-          ok: true,
-          json: () => Promise.resolve(TILESET_RESPONSE),
-        })
-      );
-
-    vi.stubGlobal('fetch', mockFetch);
-  });
-
   test('default', async () => {
+    stubGlobalFetchForSource();
+
     const tilejson = await h3QuerySource({
       connectionName: 'carto_dw',
       clientId: 'CUSTOM_CLIENT',
@@ -51,7 +29,7 @@ describe('h3QuerySource', () => {
     expect(initURL).toMatch(/q=SELECT\+\*\+FROM\+a\.b\.h3_table/);
     expect(initURL).toMatch(/client=CUSTOM_CLIENT/);
 
-    expect(tilesetURL).toMatch(/^https:\/\/xyz\.com\/\?format=tilejson&cache=/);
+    expect(tilesetURL).toMatch(/^https:\/\/xyz\.com\/\?format=tilejson/);
 
     expect(tilejson).toBeTruthy();
     expect(tilejson.tiles).toEqual([
@@ -61,6 +39,8 @@ describe('h3QuerySource', () => {
   });
 
   test('widgetSource', async () => {
+    stubGlobalFetchForSource();
+
     const {widgetSource} = await h3QuerySource({
       accessToken: '<token>',
       connectionName: 'carto_dw',
@@ -69,5 +49,24 @@ describe('h3QuerySource', () => {
     });
 
     expect(widgetSource).toBeInstanceOf(WidgetQuerySource);
+  });
+
+  test('widgetSource + dynamic point aggregation', async () => {
+    stubGlobalFetchForSource(MOCK_INIT_RESPONSE, {
+      ...MOCK_TILESET_RESPONSE,
+      schema: [{name: 'geom', type: 'geometry'}],
+    });
+
+    const {widgetSource} = await h3QuerySource({
+      localCache: {cacheControl: ['no-cache']}, // prevent caching schema
+      accessToken: '<token>',
+      connectionName: 'carto_dw',
+      sqlQuery: 'SELECT *',
+      aggregationExp: 'COUNT (*)',
+      spatialDataColumn: 'geom',
+    });
+
+    expect(widgetSource).toBeInstanceOf(WidgetQuerySource);
+    expect(widgetSource.props.spatialDataType).toBe('geo'); // not 'h3'
   });
 });

--- a/test/sources/h3-query-source.test.ts
+++ b/test/sources/h3-query-source.test.ts
@@ -58,7 +58,6 @@ describe('h3QuerySource', () => {
     });
 
     const {widgetSource} = await h3QuerySource({
-      localCache: {cacheControl: ['no-cache']}, // prevent caching schema
       accessToken: '<token>',
       connectionName: 'carto_dw',
       sqlQuery: 'SELECT *',

--- a/test/sources/h3-table-source.test.ts
+++ b/test/sources/h3-table-source.test.ts
@@ -58,7 +58,6 @@ describe('h3TableSource', () => {
     });
 
     const {widgetSource} = await h3TableSource({
-      localCache: {cacheControl: ['no-cache']}, // prevent caching schema
       accessToken: '<token>',
       connectionName: 'carto_dw',
       tableName: 'my-table',

--- a/test/sources/quadbin-query-source.test.ts
+++ b/test/sources/quadbin-query-source.test.ts
@@ -56,7 +56,6 @@ describe('quadbinQuerySource', () => {
     });
 
     const {widgetSource} = await quadbinQuerySource({
-      localCache: {cacheControl: ['no-cache']}, // prevent caching schema
       accessToken: '<token>',
       connectionName: 'carto_dw',
       sqlQuery: 'SELECT *',

--- a/test/sources/quadbin-table-source.test.ts
+++ b/test/sources/quadbin-table-source.test.ts
@@ -56,7 +56,6 @@ describe('quadbinTableSource', () => {
     });
 
     const {widgetSource} = await quadbinTableSource({
-      localCache: {cacheControl: ['no-cache']}, // prevent caching schema
       accessToken: '<token>',
       connectionName: 'carto_dw',
       tableName: 'my-table',

--- a/test/sources/quadbin-table-source.test.ts
+++ b/test/sources/quadbin-table-source.test.ts
@@ -1,37 +1,15 @@
 import {WidgetTableSource, quadbinTableSource} from '@carto/api-client';
-import {describe, vi, test, expect, beforeEach} from 'vitest';
-
-const CACHE = 'quadbin-table-source-test';
-
-const INIT_RESPONSE = {
-  tilejson: {url: [`https://xyz.com?format=tilejson&cache=${CACHE}`]},
-};
-
-const TILESET_RESPONSE = {
-  tilejson: '2.2.0',
-  tiles: ['https://xyz.com/{z}/{x}/{y}?formatTiles=binary'],
-  tilestats: {layers: []},
-  schema: [],
-};
+import {describe, vi, test, expect} from 'vitest';
+import {
+  MOCK_INIT_RESPONSE,
+  MOCK_TILESET_RESPONSE,
+  stubGlobalFetchForSource,
+} from '../__mock-fetch.js';
 
 describe('quadbinTableSource', () => {
-  beforeEach(() => {
-    const mockFetch = vi
-      .fn()
-      .mockReturnValueOnce(
-        Promise.resolve({ok: true, json: () => Promise.resolve(INIT_RESPONSE)})
-      )
-      .mockReturnValueOnce(
-        Promise.resolve({
-          ok: true,
-          json: () => Promise.resolve(TILESET_RESPONSE),
-        })
-      );
-
-    vi.stubGlobal('fetch', mockFetch);
-  });
-
   test('default', async () => {
+    stubGlobalFetchForSource();
+
     const tilejson = await quadbinTableSource({
       connectionName: 'carto_dw',
       accessToken: '<token>',
@@ -49,7 +27,7 @@ describe('quadbinTableSource', () => {
     expect(initURL).toMatch(/spatialDataType=quadbin/);
     expect(initURL).toMatch(/name=a.b.quadbin_table/);
 
-    expect(tilesetURL).toMatch(/^https:\/\/xyz\.com\/\?format=tilejson&cache=/);
+    expect(tilesetURL).toMatch(/^https:\/\/xyz\.com\/\?format=tilejson/);
 
     expect(tilejson).toBeTruthy();
     expect(tilejson.tiles).toEqual([
@@ -59,6 +37,8 @@ describe('quadbinTableSource', () => {
   });
 
   test('widgetSource', async () => {
+    stubGlobalFetchForSource();
+
     const {widgetSource} = await quadbinTableSource({
       accessToken: '<token>',
       connectionName: 'carto_dw',
@@ -67,5 +47,24 @@ describe('quadbinTableSource', () => {
     });
 
     expect(widgetSource).toBeInstanceOf(WidgetTableSource);
+  });
+
+  test('widgetSource + dynamic point aggregation', async () => {
+    stubGlobalFetchForSource(MOCK_INIT_RESPONSE, {
+      ...MOCK_TILESET_RESPONSE,
+      schema: [{name: 'geom', type: 'geometry'}],
+    });
+
+    const {widgetSource} = await quadbinTableSource({
+      localCache: {cacheControl: ['no-cache']}, // prevent caching schema
+      accessToken: '<token>',
+      connectionName: 'carto_dw',
+      tableName: 'my-table',
+      aggregationExp: 'COUNT (*)',
+      spatialDataColumn: 'geom',
+    });
+
+    expect(widgetSource).toBeInstanceOf(WidgetTableSource);
+    expect(widgetSource.props.spatialDataType).toBe('geo'); // not 'quadbin'
   });
 });

--- a/test/sources/quadbin-tileset-source.test.ts
+++ b/test/sources/quadbin-tileset-source.test.ts
@@ -1,36 +1,11 @@
-import {quadbinTilesetSource} from '@carto/api-client';
-import {describe, vi, test, expect, beforeEach} from 'vitest';
-
-const CACHE = 'quadbin-tileset-source-test';
-
-const INIT_RESPONSE = {
-  tilejson: {url: [`https://xyz.com?format=tilejson&cache=${CACHE}`]},
-};
-
-const TILESET_RESPONSE = {
-  tilejson: '2.2.0',
-  tiles: ['https://xyz.com/{z}/{x}/{y}?formatTiles=binary'],
-  tilestats: {layers: []},
-};
+import {quadbinTilesetSource, WidgetTilesetSource} from '@carto/api-client';
+import {describe, vi, test, expect} from 'vitest';
+import {stubGlobalFetchForSource} from '../__mock-fetch.js';
 
 describe('quadbinTilesetSource', () => {
-  beforeEach(() => {
-    const mockFetch = vi
-      .fn()
-      .mockReturnValueOnce(
-        Promise.resolve({ok: true, json: () => Promise.resolve(INIT_RESPONSE)})
-      )
-      .mockReturnValueOnce(
-        Promise.resolve({
-          ok: true,
-          json: () => Promise.resolve(TILESET_RESPONSE),
-        })
-      );
-
-    vi.stubGlobal('fetch', mockFetch);
-  });
-
   test('default', async () => {
+    stubGlobalFetchForSource();
+
     const tilejson = await quadbinTilesetSource({
       connectionName: 'carto_dw',
       accessToken: '<token>',
@@ -44,12 +19,24 @@ describe('quadbinTilesetSource', () => {
     expect(initURL).toMatch(/v3\/maps\/carto_dw\/tileset/);
     expect(initURL).toMatch(/name=a.b.quadbin_tileset/);
 
-    expect(tilesetURL).toMatch(/^https:\/\/xyz\.com\/\?format=tilejson&cache=/);
+    expect(tilesetURL).toMatch(/^https:\/\/xyz\.com\/\?format=tilejson/);
 
     expect(tilejson).toBeTruthy();
     expect(tilejson.tiles).toEqual([
       'https://xyz.com/{z}/{x}/{y}?formatTiles=binary',
     ]);
     expect(tilejson.accessToken).toBe('<token>');
+  });
+
+  test('widgetSource', async () => {
+    stubGlobalFetchForSource();
+
+    const {widgetSource} = await quadbinTilesetSource({
+      accessToken: '<token>',
+      connectionName: 'carto_dw',
+      tableName: 'a.b.quadbin_tileset',
+    });
+
+    expect(widgetSource).toBeInstanceOf(WidgetTilesetSource);
   });
 });

--- a/test/sources/raster-source.test.ts
+++ b/test/sources/raster-source.test.ts
@@ -1,38 +1,11 @@
 import {rasterSource} from '@carto/api-client';
-import {describe, afterEach, vi, test, expect, beforeEach} from 'vitest';
-
-const CACHE = 'raster-source-test';
-
-const INIT_RESPONSE = {
-  tilejson: {url: [`https://xyz.com?format=tilejson&cache=${CACHE}`]},
-};
-
-const TILESET_RESPONSE = {
-  tilejson: '2.2.0',
-  tiles: ['https://xyz.com/{z}/{x}/{y}?formatTiles=binary'],
-  tilestats: {layers: []},
-};
+import {describe, vi, test, expect} from 'vitest';
+import {stubGlobalFetchForSource} from '../__mock-fetch.js';
 
 describe('rasterSource', () => {
-  beforeEach(() => {
-    const mockFetch = vi
-      .fn()
-      .mockReturnValueOnce(
-        Promise.resolve({ok: true, json: () => Promise.resolve(INIT_RESPONSE)})
-      )
-      .mockReturnValueOnce(
-        Promise.resolve({
-          ok: true,
-          json: () => Promise.resolve(TILESET_RESPONSE),
-        })
-      );
-
-    vi.stubGlobal('fetch', mockFetch);
-  });
-
-  afterEach(() => void vi.restoreAllMocks());
-
   test('default', async () => {
+    stubGlobalFetchForSource();
+
     const tilejson = await rasterSource({
       connectionName: 'carto_dw',
       accessToken: '<token>',
@@ -46,7 +19,7 @@ describe('rasterSource', () => {
     expect(initURL).toMatch(/v3\/maps\/carto_dw\/raster/);
     expect(initURL).toMatch(/name=a\.b\.raster_table/);
 
-    expect(tilesetURL).toMatch(/^https:\/\/xyz\.com\/\?format=tilejson&cache=/);
+    expect(tilesetURL).toMatch(/^https:\/\/xyz\.com\/\?format=tilejson/);
 
     expect(tilejson).toBeTruthy();
     expect(tilejson.tiles).toEqual([

--- a/test/sources/vector-query-source.test.ts
+++ b/test/sources/vector-query-source.test.ts
@@ -1,36 +1,11 @@
 import {WidgetQuerySource, vectorQuerySource} from '@carto/api-client';
-import {describe, vi, test, expect, beforeEach} from 'vitest';
-
-const CACHE = 'vector-query-source-test';
-
-const INIT_RESPONSE = {
-  tilejson: {url: [`https://xyz.com?format=tilejson&cache=${CACHE}`]},
-};
-
-const TILESET_RESPONSE = {
-  tilejson: '2.2.0',
-  tiles: ['https://xyz.com/{z}/{x}/{y}?formatTiles=binary'],
-  tilestats: {layers: []},
-};
+import {describe, vi, test, expect} from 'vitest';
+import {stubGlobalFetchForSource} from '../__mock-fetch.js';
 
 describe('vectorQuerySource', () => {
-  beforeEach(() => {
-    const mockFetch = vi
-      .fn()
-      .mockReturnValueOnce(
-        Promise.resolve({ok: true, json: () => Promise.resolve(INIT_RESPONSE)})
-      )
-      .mockReturnValueOnce(
-        Promise.resolve({
-          ok: true,
-          json: () => Promise.resolve(TILESET_RESPONSE),
-        })
-      );
-
-    vi.stubGlobal('fetch', mockFetch);
-  });
-
   test('default', async () => {
+    stubGlobalFetchForSource();
+
     const tilejson = await vectorQuerySource({
       connectionName: 'carto_dw',
       accessToken: '<token>',
@@ -55,7 +30,7 @@ describe('vectorQuerySource', () => {
       /queryParameters=%7B%22type%22%3A%22Supermarket%22%2C%22minRevenue%22%3A1000000%7D/
     );
 
-    expect(tilesetURL).toMatch(/^https:\/\/xyz\.com\/\?format=tilejson&cache=/);
+    expect(tilesetURL).toMatch(/^https:\/\/xyz\.com\/\?format=tilejson/);
 
     expect(tilejson).toBeTruthy();
     expect(tilejson.tiles).toEqual([
@@ -65,6 +40,8 @@ describe('vectorQuerySource', () => {
   });
 
   test('when aggregationExp is not provided', async () => {
+    stubGlobalFetchForSource();
+
     await vectorQuerySource({
       connectionName: 'carto_dw',
       accessToken: '<token>',
@@ -79,6 +56,8 @@ describe('vectorQuerySource', () => {
   });
 
   test('widgetSource', async () => {
+    stubGlobalFetchForSource();
+
     const {widgetSource} = await vectorQuerySource({
       accessToken: '<token>',
       connectionName: 'carto_dw',

--- a/test/sources/vector-table-source.test.ts
+++ b/test/sources/vector-table-source.test.ts
@@ -1,38 +1,11 @@
 import {WidgetTableSource, vectorTableSource} from '@carto/api-client';
-import {describe, afterEach, vi, test, expect, beforeEach} from 'vitest';
-
-const CACHE = 'vector-table-source-test';
-
-const INIT_RESPONSE = {
-  tilejson: {url: [`https://xyz.com?format=tilejson&cache=${CACHE}`]},
-};
-
-const TILESET_RESPONSE = {
-  tilejson: '2.2.0',
-  tiles: ['https://xyz.com/{z}/{x}/{y}?formatTiles=binary'],
-  tilestats: {layers: []},
-};
+import {describe, vi, test, expect} from 'vitest';
+import {stubGlobalFetchForSource} from '../__mock-fetch.js';
 
 describe('vectorTableSource', () => {
-  beforeEach(() => {
-    const mockFetch = vi
-      .fn()
-      .mockReturnValueOnce(
-        Promise.resolve({ok: true, json: () => Promise.resolve(INIT_RESPONSE)})
-      )
-      .mockReturnValueOnce(
-        Promise.resolve({
-          ok: true,
-          json: () => Promise.resolve(TILESET_RESPONSE),
-        })
-      );
-
-    vi.stubGlobal('fetch', mockFetch);
-  });
-
-  afterEach(() => void vi.restoreAllMocks());
-
   test('default', async () => {
+    stubGlobalFetchForSource();
+
     const tilejson = await vectorTableSource({
       connectionName: 'carto_dw',
       accessToken: '<token>',
@@ -52,7 +25,7 @@ describe('vectorTableSource', () => {
     expect(initURL).toMatch(/spatialDataColumn=mygeom/);
     expect(initURL).toMatch(/spatialDataType=geo/);
     expect(initURL).toMatch(/aggregationExp=SUM%28revenue%29/);
-    expect(tilesetURL).toMatch(/^https:\/\/xyz\.com\/\?format=tilejson&cache=/);
+    expect(tilesetURL).toMatch(/^https:\/\/xyz\.com\/\?format=tilejson/);
 
     expect(tilejson).toBeTruthy();
     expect(tilejson.tiles).toEqual([
@@ -62,6 +35,8 @@ describe('vectorTableSource', () => {
   });
 
   test('when aggregationExp is not provided', async () => {
+    stubGlobalFetchForSource();
+
     await vectorTableSource({
       connectionName: 'carto_dw',
       accessToken: '<token>',
@@ -75,6 +50,8 @@ describe('vectorTableSource', () => {
   });
 
   test('widgetSource', async () => {
+    stubGlobalFetchForSource();
+
     const {widgetSource} = await vectorTableSource({
       accessToken: '<token>',
       connectionName: 'carto_dw',

--- a/test/sources/vector-tileset-source.test.ts
+++ b/test/sources/vector-tileset-source.test.ts
@@ -1,38 +1,11 @@
-import {vectorTilesetSource} from '@carto/api-client';
-import {describe, afterEach, vi, test, expect, beforeEach} from 'vitest';
-
-const CACHE = 'vector-tileset-source-test';
-
-const INIT_RESPONSE = {
-  tilejson: {url: [`https://xyz.com?format=tilejson&cache=${CACHE}`]},
-};
-
-const TILESET_RESPONSE = {
-  tilejson: '2.2.0',
-  tiles: ['https://xyz.com/{z}/{x}/{y}?formatTiles=binary'],
-  tilestats: {layers: []},
-};
+import {vectorTilesetSource, WidgetTilesetSource} from '@carto/api-client';
+import {describe, vi, test, expect} from 'vitest';
+import {stubGlobalFetchForSource} from '../__mock-fetch.js';
 
 describe('vectorTilesetSource', () => {
-  beforeEach(() => {
-    const mockFetch = vi
-      .fn()
-      .mockReturnValueOnce(
-        Promise.resolve({ok: true, json: () => Promise.resolve(INIT_RESPONSE)})
-      )
-      .mockReturnValueOnce(
-        Promise.resolve({
-          ok: true,
-          json: () => Promise.resolve(TILESET_RESPONSE),
-        })
-      );
-
-    vi.stubGlobal('fetch', mockFetch);
-  });
-
-  afterEach(() => void vi.restoreAllMocks());
-
   test('default', async () => {
+    stubGlobalFetchForSource();
+
     const tilejson = await vectorTilesetSource({
       connectionName: 'carto_dw',
       accessToken: '<token>',
@@ -46,12 +19,24 @@ describe('vectorTilesetSource', () => {
     expect(initURL).toMatch(/v3\/maps\/carto_dw\/tileset/);
     expect(initURL).toMatch(/name=a\.b\.vector_tileset/);
 
-    expect(tilesetURL).toMatch(/^https:\/\/xyz\.com\/\?format=tilejson&cache=/);
+    expect(tilesetURL).toMatch(/^https:\/\/xyz\.com\/\?format=tilejson/);
 
     expect(tilejson).toBeTruthy();
     expect(tilejson.tiles).toEqual([
       'https://xyz.com/{z}/{x}/{y}?formatTiles=binary',
     ]);
     expect(tilejson.accessToken).toBe('<token>');
+  });
+
+  test('widgetSource', async () => {
+    stubGlobalFetchForSource();
+
+    const {widgetSource} = await vectorTilesetSource({
+      accessToken: '<token>',
+      connectionName: 'carto_dw',
+      tableName: 'a.b.vector_tileset',
+    });
+
+    expect(widgetSource).toBeInstanceOf(WidgetTilesetSource);
   });
 });


### PR DESCRIPTION
Adds test coverage for #178, and for returning a WidgetTilesetSource from the `fooTilesetSource()` functions. Includes some refactoring of the unit tests for sources and mocking `fetch()` to reduce boilerplate in tests.

#### PR Dependency Tree


* **PR #180** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)