### PR TITLE
fix(tilesets): Fix support for 'storeGeometry' option on tileset widgets

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "homepage": "https://github.com/CartoDB/carto-api-client#readme",
   "author": "Don McCurdy <donmccurdy@carto.com>",
   "packageManager": "yarn@4.3.1",
-  "version": "0.5.4-alpha.0",
+  "version": "0.5.4-alpha.1",
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/src/filters/tileFeatures.ts
+++ b/src/filters/tileFeatures.ts
@@ -22,7 +22,7 @@ export type TileFeatures = {
   spatialFilter: SpatialFilter;
   uniqueIdProperty?: string;
   rasterMetadata?: RasterMetadata;
-  options?: TileFeatureExtractOptions;
+  storeGeometry?: boolean;
 };
 
 /** @privateRemarks Source: @carto/react-core */
@@ -42,7 +42,7 @@ export function tileFeatures({
   spatialDataColumn = DEFAULT_GEO_COLUMN,
   spatialDataType,
   rasterMetadata,
-  options = {},
+  storeGeometry = false,
 }: TileFeatures): FeatureData[] {
   if (spatialDataType === 'geo') {
     return tileFeaturesGeometries({
@@ -50,7 +50,7 @@ export function tileFeatures({
       tileFormat,
       spatialFilter,
       uniqueIdProperty,
-      options,
+      options: {storeGeometry},
     });
   }
 

--- a/src/filters/tileFeaturesGeometries.ts
+++ b/src/filters/tileFeaturesGeometries.ts
@@ -16,7 +16,6 @@ import type {
   Position,
 } from 'geojson';
 import type {SpatialFilter, Tile} from '../types.js';
-import type {TileFeatureExtractOptions} from './tileFeatures.js';
 import {featureCollection} from '@turf/helpers';
 import type {FeatureData} from '../types-internal.js';
 import type {
@@ -39,6 +38,10 @@ type TileDataInternal = {
   numericProps: Record<string, number>;
 };
 
+type GeometryExtractOptions = {
+  storeGeometry?: boolean;
+};
+
 export function tileFeaturesGeometries({
   tiles,
   tileFormat,
@@ -50,7 +53,7 @@ export function tileFeaturesGeometries({
   tileFormat?: TileFormat;
   spatialFilter: SpatialFilter;
   uniqueIdProperty?: string;
-  options?: {storeGeometry?: boolean};
+  options?: GeometryExtractOptions;
 }): FeatureData[] {
   const map = new Map();
 
@@ -212,7 +215,7 @@ function addIntersectedFeaturesInTile({
   bbox: BBox;
   tileFormat?: TileFormat;
   uniqueIdProperty?: string;
-  options?: TileFeatureExtractOptions;
+  options?: GeometryExtractOptions;
 }) {
   const indices = getIndices(data, type);
   const storeGeometry = options?.storeGeometry || false;
@@ -364,7 +367,7 @@ function calculateFeatures({
   bbox: BBox;
   tileFormat?: TileFormat;
   uniqueIdProperty?: string;
-  options?: TileFeatureExtractOptions;
+  options?: GeometryExtractOptions;
 }) {
   if (!data?.properties.length) {
     return;
@@ -409,7 +412,7 @@ function addAllFeaturesInTile({
   bbox: BBox;
   tileFormat?: TileFormat;
   uniqueIdProperty?: string;
-  options?: TileFeatureExtractOptions;
+  options?: GeometryExtractOptions;
 }) {
   const indices = getIndices(data, type);
   const storeGeometry = options?.storeGeometry || false;

--- a/test/filters/tileFeatures.test.ts
+++ b/test/filters/tileFeatures.test.ts
@@ -119,7 +119,7 @@ describe('viewport features with binary mode', () => {
         spatialDataType: 'geo',
         spatialFilter,
         uniqueIdProperty: 'cartodb_id',
-        options: {storeGeometry: true},
+        storeGeometry: true,
       });
 
       expect(properties).toEqual(
@@ -176,7 +176,7 @@ describe('viewport features with binary mode', () => {
         spatialDataType: 'geo',
         spatialFilter,
         uniqueIdProperty: 'cartodb_id',
-        options: {storeGeometry: true},
+        storeGeometry: true,
       });
 
       expect(properties).toEqual(
@@ -233,7 +233,7 @@ describe('viewport features with binary mode', () => {
         spatialDataType: 'geo',
         spatialFilter,
         uniqueIdProperty: 'cartodb_id',
-        options: {storeGeometry: true},
+        storeGeometry: true,
       });
       expect(properties).toEqual(
         expectedProperties.map((expected, i) => ({
@@ -291,7 +291,7 @@ describe('viewport features with binary mode', () => {
         spatialDataType: 'geo',
         spatialFilter,
         uniqueIdProperty: 'cartodb_id',
-        options: {storeGeometry: true},
+        storeGeometry: true,
       });
       expect(properties).toEqual(
         expectedProperties.map((expected, i) => ({
@@ -343,7 +343,7 @@ describe('viewport features with binary mode', () => {
         spatialDataType: 'geo',
         spatialFilter,
         uniqueIdProperty: 'cartodb_id',
-        options: {storeGeometry: true},
+        storeGeometry: true,
       });
       expect(properties).toEqual(
         expectedProperties.map((expected, i) => ({
@@ -391,7 +391,7 @@ describe('viewport features with binary mode', () => {
         spatialDataType: 'geo',
         spatialFilter,
         uniqueIdProperty: 'cartodb_id',
-        options: {storeGeometry: true},
+        storeGeometry: true,
       });
       expect(properties).toEqual(
         expectedProperties.map((expected, i) => ({
@@ -441,7 +441,7 @@ describe('viewport features with binary mode', () => {
         spatialDataType: 'geo',
         spatialFilter,
         uniqueIdProperty: 'cartodb_id',
-        options: {storeGeometry: true},
+        storeGeometry: true,
       });
       expect(properties).toEqual(
         expectedProperties.map((expected, i) => ({
@@ -492,7 +492,7 @@ describe('viewport features with binary mode', () => {
         spatialDataType: 'geo',
         spatialFilter,
         uniqueIdProperty: 'cartodb_id',
-        options: {storeGeometry: true},
+        storeGeometry: true,
       });
       expect(properties).toEqual(
         expectedProperties.map((expected, i) => ({
@@ -543,7 +543,7 @@ describe('viewport features with binary mode', () => {
         spatialDataType: 'geo',
         spatialFilter,
         uniqueIdProperty: 'cartodb_id',
-        options: {storeGeometry: true},
+        storeGeometry: true,
       });
       expect(properties).toEqual(
         expectedProperties.map((expected, i) => ({
@@ -617,7 +617,7 @@ describe('viewport features with binary mode', () => {
           spatialDataType: 'geo',
           spatialFilter,
           uniqueIdProperty: undefined,
-          options: {storeGeometry: true},
+          storeGeometry: true,
         });
         expect(properties).toEqual(
           expectedProperties.map((expected, i) => ({
@@ -670,7 +670,7 @@ describe('viewport features with binary mode', () => {
           spatialDataType: 'geo',
           spatialFilter,
           uniqueIdProperty: undefined,
-          options: {storeGeometry: true},
+          storeGeometry: true,
         });
         expect(properties).toEqual(
           expectedProperties.map((expected, i) => ({
@@ -723,7 +723,7 @@ describe('viewport features with binary mode', () => {
           spatialDataType: 'geo',
           spatialFilter,
           uniqueIdProperty: undefined,
-          options: {storeGeometry: true},
+          storeGeometry: true,
         });
         expect(properties).toEqual(
           expectedProperties.map((expected, i) => ({
@@ -775,7 +775,7 @@ describe('viewport features with binary mode', () => {
           spatialDataType: 'geo',
           spatialFilter,
           uniqueIdProperty: undefined,
-          options: {storeGeometry: true},
+          storeGeometry: true,
         });
         expect(properties).toEqual(
           expectedProperties.map((expected, i) => ({
@@ -830,7 +830,7 @@ describe('viewport features with binary mode', () => {
         spatialDataType: 'geo',
         spatialFilter,
         uniqueIdProperty: 'user_id',
-        options: {storeGeometry: true},
+        storeGeometry: true,
       });
 
       expect(properties).toEqual(
@@ -900,7 +900,7 @@ describe('viewport features with binary mode', () => {
         tileFormat: TileFormat.GEOJSON,
         spatialDataType: 'geo',
         spatialFilter,
-        options: {storeGeometry: true},
+        storeGeometry: true,
       });
       expect(transformTileCoordsToWGS84Spy).toHaveBeenCalledTimes(0);
 
@@ -909,7 +909,7 @@ describe('viewport features with binary mode', () => {
         tileFormat: TileFormat.BINARY,
         spatialDataType: 'geo',
         spatialFilter,
-        options: {storeGeometry: true},
+        storeGeometry: true,
       });
       expect(transformTileCoordsToWGS84Spy).toHaveBeenCalledTimes(0);
 
@@ -926,7 +926,7 @@ describe('viewport features with binary mode', () => {
         tileFormat: TileFormat.MVT,
         spatialDataType: 'geo',
         spatialFilter,
-        options: {storeGeometry: true},
+        storeGeometry: true,
       });
       expect(transformTileCoordsToWGS84Spy).toHaveBeenCalled();
 


### PR DESCRIPTION
For \[sc-487395], the `storeGeometry` option was not correctly passed through into the feature parsing process.

#### PR Dependency Tree


* **PR #181** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)