### PR TITLE
fix(widgets): Include spatialDataColumn in widget requests unconditionally

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "homepage": "https://github.com/CartoDB/carto-api-client#readme",
   "author": "Don McCurdy <donmccurdy@carto.com>",
   "packageManager": "yarn@4.3.1",
-  "version": "0.5.4",
+  "version": "0.5.5-alpha.0",
   "license": "MIT",
   "publishConfig": {
     "access": "public"
@@ -128,5 +128,6 @@
   "resolutions": {
     "@carto/api-client": "portal:./",
     "rollup": "^4.20.0"
-  }
+  },
+  "stableVersion": "0.5.4"
 }

--- a/src/models/model.ts
+++ b/src/models/model.ts
@@ -85,6 +85,7 @@ export function executeModel(props: {
     filters,
     filtersLogicalOperator = 'and',
     spatialDataType = 'geo',
+    spatialDataColumn = DEFAULT_GEO_COLUMN,
     spatialFiltersMode = 'intersects',
   } = source;
 
@@ -98,26 +99,15 @@ export function executeModel(props: {
     filtersLogicalOperator,
   };
 
-  const spatialDataColumn = source.spatialDataColumn || DEFAULT_GEO_COLUMN;
+  queryParams.spatialDataType = spatialDataType;
+  queryParams.spatialDataColumn = spatialDataColumn;
 
-  // Picking Model API requires 'spatialDataColumn'.
-  if (model === 'pick') {
-    queryParams.spatialDataColumn = spatialDataColumn;
-  }
-
-  // API supports multiple filters, we apply it only to spatialDataColumn
-  const spatialFilters = source.spatialFilter
-    ? {[spatialDataColumn]: source.spatialFilter}
-    : undefined;
-
-  if (spatialFilters) {
-    queryParams.spatialFilters = spatialFilters;
-    queryParams.spatialDataColumn = spatialDataColumn;
-    queryParams.spatialDataType = spatialDataType;
-  }
-
-  if (spatialDataType !== 'geo') {
-    queryParams.spatialFiltersMode = spatialFiltersMode;
+  if (source.spatialFilter) {
+    // API supports multiple filters, we apply it only to spatialDataColumn
+    queryParams.spatialFilters = {[spatialDataColumn]: source.spatialFilter};
+    if (spatialDataType !== 'geo') {
+      queryParams.spatialFiltersMode = spatialFiltersMode;
+    }
   }
 
   const urlWithSearchParams =


### PR DESCRIPTION
Since early on (see #34) the API client has included the `spatialDataColumn` and `spatialDataType` parameters in Model API requests if and only if a spatial filter is active. However, I'm seeing table widget requests that include geometry (geom, h3, quadbin) in their list of requested columns receive _different results_ depending on whether these parameters are present, even without a spatial filter. This causes E2E tests to fail. 

The C4R-based code currently in Builder includes both parameters, even without a spatial filter, so for the sake of backward compatibility I think it's safest to include `spatialDataColumn` and `spatialDataType` unconditionally.

#### PR Dependency Tree


* **PR #183** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)