### PR TITLE
feat(widgets): Distribute worker script as standalone JS bundle.

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,9 @@
     "./worker": {
       "types": "./build/worker.d.ts",
       "default": "./build/worker.js"
+    },
+    "./worker.global": {
+      "default": "./build/worker.global.js"
     }
   },
   "browserslist": [

--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
       "types": "./build/worker.d.ts",
       "default": "./build/worker.js"
     },
-    "./worker.global": {
-      "default": "./build/worker.global.js"
+    "./worker-compat": {
+      "default": "./build/worker-compat.js"
     }
   },
   "browserslist": [

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "homepage": "https://github.com/CartoDB/carto-api-client#readme",
   "author": "Don McCurdy <donmccurdy@carto.com>",
   "packageManager": "yarn@4.3.1",
-  "version": "0.5.6-alpha.bundle.2",
+  "version": "0.5.6-alpha.bundle.3",
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "homepage": "https://github.com/CartoDB/carto-api-client#readme",
   "author": "Don McCurdy <donmccurdy@carto.com>",
   "packageManager": "yarn@4.3.1",
-  "version": "0.5.6-alpha.1",
+  "version": "0.5.6-alpha.bundle.2",
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "homepage": "https://github.com/CartoDB/carto-api-client#readme",
   "author": "Don McCurdy <donmccurdy@carto.com>",
   "packageManager": "yarn@4.3.1",
-  "version": "0.5.6-alpha.bundle.3",
+  "version": "0.5.6-alpha.bundle.4",
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/src/widget-sources/widget-tileset-source.ts
+++ b/src/widget-sources/widget-tileset-source.ts
@@ -103,7 +103,7 @@ export class WidgetTilesetSource<
     // must be a static, inline object – duplicated below.
     if (this.props.widgetWorkerUrl) {
       this._workerImpl = new Worker(this.props.widgetWorkerUrl, {
-        type: 'module',
+        // type: 'module',
         name: 'cartowidgettileset',
       });
     } else {

--- a/src/widget-sources/widget-tileset-source.ts
+++ b/src/widget-sources/widget-tileset-source.ts
@@ -99,14 +99,13 @@ export class WidgetTilesetSource<
       return this._workerImpl;
     }
 
-    // For Vite (and perhaps other bundlers) to parse WorkerOptions, it
-    // must be a static, inline object – duplicated below.
     if (this.props.widgetWorkerUrl) {
       this._workerImpl = new Worker(this.props.widgetWorkerUrl, {
-        // type: 'module',
         name: 'cartowidgettileset',
       });
     } else {
+      // For Vite (and perhaps other bundlers) to parse WorkerOptions, it
+      // must be a static, inline object – duplicated below.
       this._workerImpl = new Worker(
         new URL('@carto/api-client/worker', import.meta.url),
         {

--- a/src/widget-sources/widget-tileset-source.ts
+++ b/src/widget-sources/widget-tileset-source.ts
@@ -116,6 +116,10 @@ export class WidgetTilesetSource<
       );
     }
 
+    this._workerImpl.addEventListener('error', (e) => {
+      console.error('widget-tileset-source worker error', e);
+    });
+
     this._workerImpl.postMessage({
       method: Method.INIT,
       params: [this.props],

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -28,8 +28,13 @@ export default defineConfig([
   {
     ...commonConfig,
     format: 'iife',
+    outExtension() {
+      return {
+        js: `.js`,
+      };
+    },
     entry: {
-      worker: 'src/workers/widget-tileset-worker.ts',
+      'worker-compat': 'src/workers/widget-tileset-worker.ts',
     },
   },
 ]);

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -25,4 +25,11 @@ export default defineConfig([
     entry: {'api-client': 'src/index.ts'},
     shims: true, // replace 'import.meta' references
   },
+  {
+    ...commonConfig,
+    format: 'iife',
+    entry: {
+      worker: 'src/workers/widget-tileset-worker.ts',
+    },
+  }
 ]);

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -31,5 +31,5 @@ export default defineConfig([
     entry: {
       worker: 'src/workers/widget-tileset-worker.ts',
     },
-  }
+  },
 ]);


### PR DESCRIPTION
Distribute worker script in bundled version.

We expose worker as bundled JS script in `worker-compat` entry.

Example usage:

```ts
// vite
import cartoApiWorkerUrl from '@carto/api-client/worker-compat?url'
new WidgetTilesetSource({..., workerUrl: cartoApiWorkerUrl})

// manual asset managent
cp node_modules/@carto/api-client/build/worker-compat.js dist/static/carto-api-client-worker-compat.js
new WidgetTilesetSource({..., workerUrl: '/static/carto-api-client-worker-compat.js'})
```
