### PR TITLE
chore(tests): Exclude node_modules from test coverage reporting

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,7 +9,9 @@ export default defineConfig({
     setupFiles: ['test/setup.ts'],
     coverage: {
       provider: 'istanbul',
-      include: ['src/**/*', 'build/**/*'],
+      include: ['src', 'build'],
+      exclude: ['test', 'node_modules'],
+      excludeAfterRemap: true,
     },
   },
 });


### PR DESCRIPTION
Preparation for coverage being reported to Coveralls or elsewhere. Fixes an issue where coverage was reported for dependencies bundled into the library from `node_modules/*`, we only want to show coverage for files in `src/*`.

#### PR Dependency Tree


* **PR #191** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)