### PR TITLE
perf(rasters): Improve raster widget performance for spatial filters covering many cells

### DIFF
--- a/src/filters/tileFeaturesRaster.ts
+++ b/src/filters/tileFeaturesRaster.ts
@@ -11,6 +11,7 @@ import type {
   RasterMetadataBand,
   SpatialDataType,
 } from '../sources/types.js';
+import {CellSet} from '../utils/CellSet.js';
 
 export type TileFeaturesRasterOptions = {
   tiles: RasterTile[];
@@ -45,7 +46,7 @@ export function tileFeaturesRaster({
 
   // Compute covering cells for the spatial filter, at same resolution as the
   // raster pixels, to be used as a mask.
-  const spatialFilterCells = new Set(
+  const spatialFilterCells = new CellSet(
     geometryToCells(options.spatialFilter, cellResolution)
   );
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,4 +28,5 @@ export * from './filters/index.js';
 export * from './operations/index.js';
 export * from './utils/makeIntervalComplete.js';
 export * from './utils/transformToTileCoords.js';
+export * from './utils/CellSet.js';
 export * from './fetch-map/source.js';

--- a/src/utils/CellSet.ts
+++ b/src/utils/CellSet.ts
@@ -1,0 +1,90 @@
+/** Flags 'empty' values in a Uint32Array index. */
+const EMPTY_U32 = 2 ** 32 - 1;
+
+/**
+ * Custom Set-like interface optimized for BigUint64 cell IDs. Unlike Set,
+ * limited in most JavaScript runtimes to ~16M entries, this implementation
+ * can support up to `n = 2^32 - 1` (4 billion) entries, with lookups in
+ * amortized O(1) time.
+ */
+export class CellSet {
+  /** List of cells stored by the set. Stored by reference, without copying. */
+  private cells: bigint[];
+
+  /** DataView representing a single cell ID. Pre-allocated to reduce memory during queries. */
+  private cellView = new DataView(new ArrayBuffer(8));
+
+  /** Hash table, mapping a hash index (computed) to an index in the 'cells' array. */
+  private hashTable: Uint32Array;
+
+  constructor(cells: bigint[]) {
+    this.cells = cells;
+
+    // Pre-allocate hash table for queries.
+    this.hashTable = new Uint32Array(hashBuckets(cells.length)).fill(EMPTY_U32);
+    for (let cellIndex = 0; cellIndex < cells.length; cellIndex++) {
+      this.hashTable[this.hashLookup(cells[cellIndex])] = cellIndex;
+    }
+  }
+
+  has(cell: bigint): boolean {
+    const hashIndex = this.hashLookup(cell);
+    return this.hashTable[hashIndex] !== EMPTY_U32;
+  }
+
+  private hashLookup(cell: bigint): number {
+    // Hash implementation operates on 32-bit chunks, so write the cell ID
+    // into a pre-allocated DataView for easier iteration.
+    this.cellView.setBigUint64(0, cell);
+    const hashval = hash(this.cellView);
+    const hashmod = this.hashTable.length - 1;
+    let bucket = hashval & hashmod;
+
+    // Find the first bucket in the hash table where either (a) no cell
+    // is yet stored, or (b) the stored cell and the query cell are equal.
+    for (let probe = 0; probe <= hashmod; probe++) {
+      const cellIndex = this.hashTable[bucket];
+
+      if (cellIndex === EMPTY_U32 || cell === this.cells[cellIndex]) {
+        return bucket;
+      }
+
+      bucket = (bucket + probe + 1) & hashmod; // Hash collision; quadratic probing.
+    }
+
+    throw new Error('Hash table full.'); // Unreachable.
+  }
+}
+
+/**
+ * MurmurHash2
+ *
+ * References:
+ * - https://github.com/mikolalysenko/murmurhash-js/blob/f19136e9f9c17f8cddc216ca3d44ec7c5c502f60/murmurhash2_gc.js#L14
+ * - https://github.com/zeux/meshoptimizer/blob/e47e1be6d3d9513153188216455bdbed40a206ef/src/indexgenerator.cpp#L12
+ */
+function hash(view: DataView, h = 0): number {
+  const m = 0x5bd1e995;
+  const r = 24;
+
+  for (let i = 0, il = view.byteLength / 4; i < il; i++) {
+    let k = view.getUint32(i * 4);
+
+    k = Math.imul(k, m) >>> 0;
+    k = (k ^ (k >> r)) >>> 0;
+    k = Math.imul(k, m) >>> 0;
+
+    h = Math.imul(h, m) >>> 0;
+    h = (h ^ k) >>> 0;
+  }
+
+  return h;
+}
+
+function hashBuckets(initialCount: number) {
+  let buckets = 1;
+  while (buckets < initialCount + initialCount / 4) {
+    buckets *= 2;
+  }
+  return buckets;
+}

--- a/test/utils/CellSet.test.ts
+++ b/test/utils/CellSet.test.ts
@@ -1,0 +1,70 @@
+import {describe, test, expect} from 'vitest';
+import {CellSet} from '@carto/api-client';
+import {geometryToCells} from 'quadbin';
+import {Feature, Polygon} from 'geojson';
+
+const FEATURE_A: Feature<Polygon> = {
+  type: 'Feature',
+  properties: {},
+  geometry: {
+    coordinates: [
+      [
+        [-40.13189, 45.6739],
+        [-42.10079, 43.01305],
+        [-37.36239, 41.92935],
+        [-35.40455, 44.82921],
+        [-40.13189, 45.6739],
+      ],
+    ],
+    type: 'Polygon',
+  },
+};
+
+const FEATURE_B: Feature<Polygon> = {
+  type: 'Feature',
+  properties: {},
+  geometry: {
+    coordinates: [
+      [
+        [-35.96365, 46.0724],
+        [-37.42281, 45.45737],
+        [-37.97751, 44.22816],
+        [-36.42785, 42.89107],
+        [-33.67079, 42.76472],
+        [-32.42917, 44.74733],
+        [-34.0996, 46.20022],
+        [-35.96365, 46.0724],
+      ],
+    ],
+    type: 'Polygon',
+  },
+};
+
+describe('CellSet', () => {
+  test('has', () => {
+    const cells = new CellSet([0n, 1n, 3n, 4n]);
+
+    for (const cell of [0n, 1n, 3n, 4n]) {
+      expect(cells.has(cell), cell.toString()).toBe(true);
+    }
+
+    for (const cell of [2n, 5n, -1n, 12793n]) {
+      expect(cells.has(cell), cell.toString()).toBe(false);
+    }
+  });
+
+  test('matches native Set', () => {
+    // compute quadbin coverage at res=12, aiming for ~2500 cells.
+    const cellsA = geometryToCells(FEATURE_A.geometry, 12n);
+    const cellsB = geometryToCells(FEATURE_B.geometry, 12n);
+
+    const nativeSet = new Set(cellsA);
+    const cellSet = new CellSet(cellsA);
+
+    const expectedIntersection = cellsB.filter((cell) => nativeSet.has(cell));
+    const actualIntersection = cellsB.filter((cell) => cellSet.has(cell));
+
+    expect(actualIntersection.length).toBeGreaterThan(500);
+    expect(actualIntersection).toEqual(expectedIntersection);
+  });
+});


### PR DESCRIPTION
To compute raster widget results within a spatial filter, we currently compute a [covering](http://s2geometry.io/devguide/examples/coverings.html) for the spatial filter, composed of quadbin cells at the same resolution as the raster tile pixels. When the raster pixels are small, or the spatial filter is large, the number of cells in the spatial filter covering set may be very large. Previously we used a JavaScript [Set](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set) instance to check which pixels are contained by the spatial filter, but Sets are [limited to about ~16M features](https://stackoverflow.com/a/72809580/1314762) in today's JavaScript runtimes, and we may occasionally create a spatial filter covering >4000x4000 pixels.

The problem can be addressed by one — or more — of the following options:

1. Instead of choosing a resolution for the spatial filter based on the raster tile resolution, choose an independent resolution based on the size of the spatial filter region, and query against that. _Results from raster widgets will be approximate._
2. Replace or modify the `geometryToCells` implementation in quadbin-js to return covering cells at mixed resolution. If a large block of the spatial filter's interior can be covered by a much larger cell, 'contains' queries with the parent cell will be faster than iterating over its descendants, and cell counts will be much lower.
3. Avoid using JavaScript Set classes, and implement a custom lookup function

I think we should strongly consider doing (1) or (2), but (1) will require some product discussion and (2) sounds more complex than I'm prepared to implement right now. In the interest of unblocking further development and QA on the raster widgets feature, I've implemented (3) instead, which may complement the other two solutions anyway.

Rather than using Set, we use a custom HashSet implementation based on [MurmurHash2](https://en.wikipedia.org/wiki/MurmurHash). This avoids a hard limit of ~16M cells in the spatial filter, and otherwise has very similar performance compared to Set. I've hashed the entire quadbin key, but some further optimizations might be possible knowing that all cells are at the same resolution.

- Shortcut: [sc-489939]


#### PR Dependency Tree


* **PR #192** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)