### PR TITLE
feat(sources): allow passing tags to baseSource and query methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "homepage": "https://github.com/CartoDB/carto-api-client#readme",
   "author": "Don McCurdy <donmccurdy@carto.com>",
   "packageManager": "yarn@4.3.1",
-  "version": "0.5.9-alpha.PR193.2",
+  "version": "0.5.9-alpha.PR193.3",
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "homepage": "https://github.com/CartoDB/carto-api-client#readme",
   "author": "Don McCurdy <donmccurdy@carto.com>",
   "packageManager": "yarn@4.3.1",
-  "version": "0.5.8",
+  "version": "0.5.9-alpha.PR193.1",
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "homepage": "https://github.com/CartoDB/carto-api-client#readme",
   "author": "Don McCurdy <donmccurdy@carto.com>",
   "packageManager": "yarn@4.3.1",
-  "version": "0.5.9-alpha.PR193.1",
+  "version": "0.5.9-alpha.PR193.2",
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/src/api/query.ts
+++ b/src/api/query.ts
@@ -15,7 +15,7 @@ import {getClient} from '../client.js';
 
 export type QueryOptions = SourceOptions &
   QuerySourceOptions & {
-    /** 
+    /**
      * @internal
      * @experimental
      * Used to append additional parameters to the SQL API request for features specific to providers or integrations.

--- a/src/api/query.ts
+++ b/src/api/query.ts
@@ -13,10 +13,11 @@ import {requestWithParameters} from './request-with-parameters.js';
 import type {APIErrorContext} from './carto-api-error.js';
 import {getClient} from '../client.js';
 
-export type QueryOptions = SourceOptions & QuerySourceOptions & {
-  /** Used to append additional parameters to the SQL API request for features specific to providers or integrations. */
-  additionalParameters?: Record<string, string | boolean | number>;
-};
+export type QueryOptions = SourceOptions &
+  QuerySourceOptions & {
+    /** Used to append additional parameters to the SQL API request for features specific to providers or integrations. */
+    additionalParameters?: Record<string, string | boolean | number>;
+  };
 type UrlParameters = {q: string; queryParameters?: string};
 
 export const query = async function (

--- a/src/api/query.ts
+++ b/src/api/query.ts
@@ -15,8 +15,12 @@ import {getClient} from '../client.js';
 
 export type QueryOptions = SourceOptions &
   QuerySourceOptions & {
-    /** Used to append additional parameters to the SQL API request for features specific to providers or integrations. */
-    additionalParameters?: Record<string, string | boolean | number>;
+    /** 
+     * @internal
+     * @experimental
+     * Used to append additional parameters to the SQL API request for features specific to providers or integrations.
+     */
+    internalParameters?: Record<string, string | boolean | number>;
     /** Used to abort the request. */
     signal?: AbortSignal;
   };
@@ -33,7 +37,7 @@ export const query = async function (
     connectionName,
     sqlQuery,
     queryParameters,
-    additionalParameters,
+    internalParameters,
   } = options;
   const urlParameters: UrlParameters = {q: sqlQuery};
 
@@ -48,7 +52,8 @@ export const query = async function (
   };
   const parameters = {
     client: clientId,
-    ...additionalParameters,
+    ...options.tags,
+    ...internalParameters,
     ...urlParameters,
   };
 

--- a/src/api/query.ts
+++ b/src/api/query.ts
@@ -13,7 +13,9 @@ import {requestWithParameters} from './request-with-parameters.js';
 import type {APIErrorContext} from './carto-api-error.js';
 import {getClient} from '../client.js';
 
-export type QueryOptions = SourceOptions & QuerySourceOptions;
+export type QueryOptions = SourceOptions & QuerySourceOptions & {
+  additionalParameters?: Record<string, string | boolean | number>;
+};
 type UrlParameters = {q: string; queryParameters?: string};
 
 export const query = async function (
@@ -27,6 +29,7 @@ export const query = async function (
     connectionName,
     sqlQuery,
     queryParameters,
+    additionalParameters,
   } = options;
   const urlParameters: UrlParameters = {q: sqlQuery};
 
@@ -39,7 +42,11 @@ export const query = async function (
     Authorization: `Bearer ${options.accessToken}`,
     ...options.headers,
   };
-  const parameters = {client: clientId, ...options.tags, ...urlParameters};
+  const parameters = {
+    client: clientId,
+    ...additionalParameters,
+    ...urlParameters,
+  };
 
   const errorContext: APIErrorContext = {
     requestType: 'SQL',

--- a/src/api/query.ts
+++ b/src/api/query.ts
@@ -17,6 +17,8 @@ export type QueryOptions = SourceOptions &
   QuerySourceOptions & {
     /** Used to append additional parameters to the SQL API request for features specific to providers or integrations. */
     additionalParameters?: Record<string, string | boolean | number>;
+    /** Used to abort the request. */
+    signal?: AbortSignal;
   };
 type UrlParameters = {q: string; queryParameters?: string};
 
@@ -63,5 +65,6 @@ export const query = async function (
     errorContext,
     maxLengthURL,
     localCache,
+    signal: options.signal,
   });
 };

--- a/src/api/query.ts
+++ b/src/api/query.ts
@@ -14,6 +14,7 @@ import type {APIErrorContext} from './carto-api-error.js';
 import {getClient} from '../client.js';
 
 export type QueryOptions = SourceOptions & QuerySourceOptions & {
+  /** Used to append additional parameters to the SQL API request for features specific to providers or integrations. */
   additionalParameters?: Record<string, string | boolean | number>;
 };
 type UrlParameters = {q: string; queryParameters?: string};

--- a/src/api/query.ts
+++ b/src/api/query.ts
@@ -39,7 +39,7 @@ export const query = async function (
     Authorization: `Bearer ${options.accessToken}`,
     ...options.headers,
   };
-  const parameters = {client: clientId, ...urlParameters};
+  const parameters = {client: clientId, ...options.tags, ...urlParameters};
 
   const errorContext: APIErrorContext = {
     requestType: 'SQL',

--- a/src/api/request-with-parameters.ts
+++ b/src/api/request-with-parameters.ts
@@ -146,10 +146,12 @@ function createURLWithParameters(
     if (isPureObject(value) || Array.isArray(value)) {
       baseUrl.searchParams.set(key, JSON.stringify(value));
     } else {
-      baseUrl.searchParams.set(
-        key,
-        (value as string | boolean | number).toString()
-      );
+      if (value !== null && value !== undefined) {
+        baseUrl.searchParams.set(
+          key,
+          (value as string | boolean | number).toString()
+        );
+      }
     }
   }
   return baseUrl.toString();

--- a/src/api/request-with-parameters.ts
+++ b/src/api/request-with-parameters.ts
@@ -23,6 +23,7 @@ export async function requestWithParameters<T = any>({
   errorContext,
   maxLengthURL = DEFAULT_MAX_LENGTH_URL,
   localCache,
+  signal
 }: {
   baseUrl: string;
   parameters?: Record<string, unknown>;
@@ -30,6 +31,7 @@ export async function requestWithParameters<T = any>({
   errorContext: APIErrorContext;
   maxLengthURL?: number;
   localCache?: LocalCacheOptions;
+  signal?: AbortSignal;
 }): Promise<T> {
   // Parameters added to all requests issued with `requestWithParameters()`.
   // These parameters override parameters already in the base URL, but not
@@ -65,8 +67,9 @@ export async function requestWithParameters<T = any>({
           method: 'POST',
           body: JSON.stringify(parameters),
           headers,
+          signal,
         })
-      : fetch(url, {headers});
+      : fetch(url, {headers, signal});
 
   let response: Response | undefined;
   let responseJson: unknown;

--- a/src/api/request-with-parameters.ts
+++ b/src/api/request-with-parameters.ts
@@ -23,7 +23,7 @@ export async function requestWithParameters<T = any>({
   errorContext,
   maxLengthURL = DEFAULT_MAX_LENGTH_URL,
   localCache,
-  signal
+  signal,
 }: {
   baseUrl: string;
   parameters?: Record<string, unknown>;

--- a/src/models/model.ts
+++ b/src/models/model.ts
@@ -99,7 +99,7 @@ export function executeModel(props: {
     queryParameters: source.queryParameters || '',
     filters,
     filtersLogicalOperator,
-    tags,
+    ...(tags ?? {}),
   };
 
   queryParams.spatialDataType = spatialDataType;

--- a/src/models/model.ts
+++ b/src/models/model.ts
@@ -43,6 +43,7 @@ export interface ModelSource {
   spatialDataColumn?: string;
   spatialDataType?: SpatialDataType;
   spatialFiltersMode?: SpatialFilterPolyfillMode;
+  tags?: Record<string, string>;
 }
 
 const {V3} = ApiVersion;
@@ -87,6 +88,7 @@ export function executeModel(props: {
     spatialDataType = 'geo',
     spatialDataColumn = DEFAULT_GEO_COLUMN,
     spatialFiltersMode = 'intersects',
+    tags,
   } = source;
 
   const queryParams: Record<string, unknown> = {
@@ -97,6 +99,7 @@ export function executeModel(props: {
     queryParameters: source.queryParameters || '',
     filters,
     filtersLogicalOperator,
+    tags,
   };
 
   queryParams.spatialDataType = spatialDataType;

--- a/src/sources/base-source.ts
+++ b/src/sources/base-source.ts
@@ -47,7 +47,7 @@ export async function baseSource<UrlParameters extends Record<string, unknown>>(
     Authorization: `Bearer ${options.accessToken}`,
     ...options.headers,
   };
-  const parameters = {client: clientId, ...urlParameters};
+  const parameters = {client: clientId, ...options.tags, ...urlParameters};
 
   const errorContext: APIErrorContext = {
     requestType: 'Map instantiation',

--- a/src/sources/types.ts
+++ b/src/sources/types.ts
@@ -76,7 +76,7 @@ export type SourceOptionalOptions = {
    */
   localCache?: LocalCacheOptions;
 
-  /** Additional tags appended to the request url that can be used to track calls for security purposes. */
+  /** Additional tags appended to HTTP request urls, available for analytics and audits. */
   tags?: Record<string, string>;
 };
 

--- a/src/sources/types.ts
+++ b/src/sources/types.ts
@@ -75,6 +75,9 @@ export type SourceOptionalOptions = {
    * By default, local in-memory caching is enabled.
    */
   localCache?: LocalCacheOptions;
+
+  /** Additional tags appended to the request url that can be used to track calls for security purposes. */
+  tags?: Record<string, string>;
 };
 
 export type LocalCacheOptions = {

--- a/src/sources/types.ts
+++ b/src/sources/types.ts
@@ -76,7 +76,7 @@ export type SourceOptionalOptions = {
    */
   localCache?: LocalCacheOptions;
 
-  /** Additional tags appended to HTTP request urls, available for analytics and audits. */
+  /** Additional tags appended to HTTP requests, available for analytics and audits. */
   tags?: Record<string, string>;
 };
 

--- a/src/widget-sources/widget-remote-source.ts
+++ b/src/widget-sources/widget-remote-source.ts
@@ -60,6 +60,7 @@ export abstract class WidgetRemoteSource<
       filtersLogicalOperator: props.filtersLogicalOperator,
       spatialDataType: props.spatialDataType,
       spatialDataColumn: props.spatialDataColumn,
+      tags: props.tags,
     };
   }
 


### PR DESCRIPTION
In the context of [this initiative](https://app.shortcut.com/cartoteam/write/IkRvYyI6I3V1aWQgIjY4MWExNDI3LTU5MzktNGE5ZC1hNjUzLTczYmI1MzZjZDZhMyI=)

We need a way to allow passing a set of tags to the request url of bath maps API calls and SQL API calls. I have drafted this initial implementation to be as simple as possible to not modify much the already existing behaviour of carto-api-client but allow for the extensibility this initiative requires.

I'll set this to draft until I have tested it on cloud native linking locally, but I'll leave this here in the meantime so we can comment the implementation