### PR TITLE
feat(tileset,raster): Include 'count' in CategoryResponse

### DIFF
--- a/src/operations/groupBy.ts
+++ b/src/operations/groupBy.ts
@@ -6,6 +6,8 @@ import type {FeatureData} from '../types-internal.js';
 export type GroupByFeature = {
   name: string;
   value: number;
+  /* Included only for 'avg' aggregation type. */
+  count?: number;
 }[];
 
 /** @privateRemarks Source: @carto/react-core */
@@ -52,6 +54,7 @@ export function groupValuesByColumn({
     return Array.from(groups).map(([name, value]) => ({
       name,
       value: targetOperation(value),
+      ...(operation === 'avg' && {count: value.length})
     }));
   }
 

--- a/src/widget-sources/types.ts
+++ b/src/widget-sources/types.ts
@@ -206,7 +206,12 @@ export type FeaturesResponse = {rows: Record<string, unknown>[]};
 export type FormulaResponse = {value: number | null};
 
 /** Response from {@link WidgetRemoteSource#getCategories}. */
-export type CategoryResponse = {name: string; value: number}[];
+export type CategoryResponse = {
+  name: string;
+  value: number;
+  /** Number of features in category. Included only for 'avg' aggregation. */
+  count?: number
+}[];
 
 /** Response from {@link WidgetRemoteSource#getRange}. */
 export type RangeResponse = {min: number; max: number} | null;

--- a/src/widget-sources/widget-remote-source.ts
+++ b/src/widget-sources/widget-remote-source.ts
@@ -80,7 +80,7 @@ export abstract class WidgetRemoteSource<
       assert(operationExp, 'operationExp is required for custom operation');
     }
 
-    type CategoriesModelResponse = {rows: {name: string; value: number}[]};
+    type CategoriesModelResponse = { rows: { name: string; value: number;  count?: number}[]};
 
     return executeModel({
       model: 'category',

--- a/test/operations/groupBy.test.ts
+++ b/test/operations/groupBy.test.ts
@@ -37,8 +37,8 @@ describe('groupValuesByColumn', () => {
         {name: 'Category 1', value: 2},
       ],
       avg: [
-        {name: 'Category 2', value: 3},
-        {name: 'Category 1', value: 3},
+        {name: 'Category 2', value: 3, count: 3},
+        {name: 'Category 1', value: 3, count: 2},
       ],
       min: [
         {name: 'Category 2', value: 1},
@@ -71,11 +71,11 @@ describe('groupValuesByColumn', () => {
 
     describe('multiple valuesColumns', () => {
       const RESULTS_FOR_MULTIPLE = Object.entries(RESULTS).reduce(
-        (acc, [operation, result], idx) => {
-          acc[operation] = result.map(({name, value}) => ({
+        (acc, [operation, result]) => {
+          acc[operation] = result.map(({name, value, ...rest}) => ({
             name,
-            // === 0 is AggregationTypes.COUNT
-            value: value * (idx === 0 ? 1 : 2),
+            value: value * (operation === 'count' ? 1 : 2),
+            ...rest
           }));
           return acc;
         },

--- a/test/widget-sources/widget-tileset-source.test.ts
+++ b/test/widget-sources/widget-tileset-source.test.ts
@@ -75,6 +75,23 @@ describe('getCategories', () => {
       },
     ]);
   });
+
+  it('computes avg in categories, with counts', async () => {
+    expect(
+      await source.getCategories({
+        column: 'storetype',
+        operation: 'avg',
+        operationColumn: 'revenue',
+        spatialFilter: MOCK_SPATIAL_FILTER,
+      })
+    ).toEqual([
+      {
+        name: 'Drugstore',
+        value: 1565826.5,
+        count: 6
+      },
+    ]);
+  });
 });
 
 describe('getFeatures', () => {


### PR DESCRIPTION
- Fixes [sc-490022]

In Builder we compute the _Others_ category value based in our category widgets based on the aggregation type of the widget. When 'avg' aggregation is selected we rely on a 'count' property in the API response, which tileset and raster widgets do not currently include. This PR adds the 'count' property to the tileset and raster widget responses for `widget.getCategories()` calls.



#### PR Dependency Tree


* **PR #198** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)