### PR TITLE
chore(repo): Replace dependabot reviewers with CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+/ @CartoDB/app-dev-builder-team

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-/ @CartoDB/app-dev-builder-team
+* @CartoDB/app-dev-builder-team

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,6 @@ updates:
     directory: '/'
     schedule:
       interval: 'monthly'
-    reviewers:
-      - 'CartoDB/app-dev-builder-team'
     groups:
       deck-gl:
         patterns:


### PR DESCRIPTION
Context: https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/