### PR TITLE
perf(rasters): Use per-tile spatial filter coverage for filtering cells

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "homepage": "https://github.com/CartoDB/carto-api-client#readme",
   "author": "Don McCurdy <donmccurdy@carto.com>",
   "packageManager": "yarn@4.3.1",
-  "version": "0.5.6",
+  "version": "0.5.7-alpha.6",
   "license": "MIT",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Refactors how we're checking raster cells against the current spatial filter. Instead of computing one large lookup table for the entire spatial filter, we check each tile to see whether it is fully outside, fully inside, or partially intersects the spatial filter. If the tile partially intersects, then we compute a smaller lookup table just for that tile and proceed with filtering its cells. Technical to follow, in Slack.

This change mostly eliminates the cost of filtering cells against the spatial filter, because (a) most tiles skip the filter, and (b) queries on the smaller lookup tables are faster. For particularly very complex spatial filters (global rivers?) there's still a bottleneck, not measured here, but such filters are not supported in Builder and are not currently a concern.

Results: For large datasets at zoom=3 and resolution=14, the change reduces processing time from 25s to 10.5s on my macbook pro. The remaining time is mostly unrelated to the spatial filter, but comes from converting the binary features into FeatureData. Leaving that part for a separate PR and discussion.



#### PR Dependency Tree


* **PR #201** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)