### PR TITLE
fix(tileset,raster): Support widget calculations without spatial filter

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "homepage": "https://github.com/CartoDB/carto-api-client#readme",
   "author": "Don McCurdy <donmccurdy@carto.com>",
   "packageManager": "yarn@4.3.1",
-  "version": "0.5.7-alpha.6",
+  "version": "0.5.7-alpha-optional-spatial-filter.0",
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "homepage": "https://github.com/CartoDB/carto-api-client#readme",
   "author": "Don McCurdy <donmccurdy@carto.com>",
   "packageManager": "yarn@4.3.1",
-  "version": "0.5.7-alpha-optional-spatial-filter.0",
+  "version": "0.5.7-alpha-optional-spatial-filter.1",
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/src/filters/tileFeatures.ts
+++ b/src/filters/tileFeatures.ts
@@ -19,7 +19,7 @@ export type TileFeatures = {
   tileFormat: TileFormat;
   spatialDataType: SpatialDataType;
   spatialDataColumn?: string;
-  spatialFilter: SpatialFilter;
+  spatialFilter?: SpatialFilter;
   uniqueIdProperty?: string;
   rasterMetadata?: RasterMetadata;
   storeGeometry?: boolean;

--- a/src/filters/tileFeaturesSpatialIndex.ts
+++ b/src/filters/tileFeaturesSpatialIndex.ts
@@ -31,24 +31,26 @@ export function tileFeaturesSpatialIndex({
     return [];
   }
 
+  let intersection: undefined | boolean | Set<bigint | string>;
+
+  // Compute H3 intersection globally, Quadbin intersection per-tile. See tileIntersection.ts.
+  if (spatialIndex === SpatialIndex.H3) {
+    intersection = intersectTileH3(cellResolution as number, spatialFilter);
+  }
+
   for (const tile of tiles) {
     if (tile.isVisible === false || !tile.data) {
       continue;
     }
 
-    const parent = getTileIndex(tile, spatialIndex);
-    const intersection =
-      spatialIndex === SpatialIndex.QUADBIN
-        ? intersectTileQuadbin(
-            parent as bigint,
-            cellResolution as bigint,
-            spatialFilter
-          )
-        : intersectTileH3(
-            parent as string,
-            cellResolution as number,
-            spatialFilter
-          );
+    if (spatialIndex === SpatialIndex.QUADBIN) {
+      const parent = getTileIndex(tile, spatialIndex);
+      intersection = intersectTileQuadbin(
+        parent as bigint,
+        cellResolution as bigint,
+        spatialFilter
+      );
+    }
 
     if (!intersection) continue;
 

--- a/src/filters/tileFeaturesSpatialIndex.ts
+++ b/src/filters/tileFeaturesSpatialIndex.ts
@@ -53,7 +53,7 @@ export function tileFeaturesSpatialIndex({
     if (!intersection) continue;
 
     tile.data.forEach((d: Feature) => {
-      // @ts-expect-error Types need deeper corrections.
+      // @ts-expect-error Mixed types for cell indices.
       if (intersection === true || intersection.has(d.id as bigint | string)) {
         map.set(d.id, {...d.properties, [spatialIndexIDName]: d.id});
       }
@@ -67,7 +67,7 @@ function getTileIndex(
   spatialIndex: SpatialIndex
 ): bigint | string {
   if (spatialIndex === SpatialIndex.QUADBIN) {
-    // @ts-expect-error TODO
+    // @ts-expect-error Missing types for quadbin tile indices.
     return tile.index.q;
   }
   return tile.id;

--- a/src/filters/tileFeaturesSpatialIndex.ts
+++ b/src/filters/tileFeaturesSpatialIndex.ts
@@ -1,15 +1,15 @@
 import {SpatialIndex} from '../constants.js';
-import {getResolution as quadbinGetResolution, geometryToCells} from 'quadbin';
-import bboxClip from '@turf/bbox-clip';
+import {getResolution as quadbinGetResolution} from 'quadbin';
 import type {SpatialFilter, SpatialIndexTile} from '../types.js';
-import type {BBox, Feature} from 'geojson';
-import {getResolution as h3GetResolution, polygonToCells} from 'h3-js';
+import type {Feature} from 'geojson';
+import {getResolution as h3GetResolution} from 'h3-js';
 import type {FeatureData} from '../types-internal.js';
 import type {SpatialDataType} from '../sources/types.js';
+import {intersectTileH3, intersectTileQuadbin} from './tileIntersection.js';
 
 export type TileFeaturesSpatialIndexOptions = {
   tiles: SpatialIndexTile[];
-  spatialFilter: SpatialFilter;
+  spatialFilter?: SpatialFilter;
   spatialDataColumn: string;
   spatialDataType: SpatialDataType;
 };
@@ -22,30 +22,39 @@ export function tileFeaturesSpatialIndex({
 }: TileFeaturesSpatialIndexOptions): FeatureData[] {
   const map = new Map();
   const spatialIndex = getSpatialIndex(spatialDataType);
-  const resolution = getResolution(tiles, spatialIndex);
+  const cellResolution = getResolution(tiles, spatialIndex);
   const spatialIndexIDName = spatialDataColumn
     ? spatialDataColumn
     : spatialIndex;
 
-  if (!resolution) {
+  if (!cellResolution) {
     return [];
   }
-  const cells = getCellsCoverGeometry(spatialFilter, spatialIndex, resolution);
-
-  if (!cells?.length) {
-    return [];
-  }
-
-  // We transform cells to Set to improve the performace
-  const cellsSet = new Set<bigint | string>(cells);
 
   for (const tile of tiles) {
     if (tile.isVisible === false || !tile.data) {
       continue;
     }
 
+    const parent = getTileIndex(tile, spatialIndex);
+    const intersection =
+      spatialIndex === SpatialIndex.QUADBIN
+        ? intersectTileQuadbin(
+            parent as bigint,
+            cellResolution as bigint,
+            spatialFilter
+          )
+        : intersectTileH3(
+            parent as string,
+            cellResolution as number,
+            spatialFilter
+          );
+
+    if (!intersection) continue;
+
     tile.data.forEach((d: Feature) => {
-      if (cellsSet.has(d.id as bigint | string)) {
+      // @ts-expect-error Types need deeper corrections.
+      if (intersection === true || intersection.has(d.id as bigint | string)) {
         map.set(d.id, {...d.properties, [spatialIndexIDName]: d.id});
       }
     });
@@ -53,10 +62,21 @@ export function tileFeaturesSpatialIndex({
   return Array.from(map.values());
 }
 
+function getTileIndex(
+  tile: SpatialIndexTile,
+  spatialIndex: SpatialIndex
+): bigint | string {
+  if (spatialIndex === SpatialIndex.QUADBIN) {
+    // @ts-expect-error TODO
+    return tile.index.q;
+  }
+  return tile.id;
+}
+
 function getResolution(
   tiles: SpatialIndexTile[],
   spatialIndex: SpatialIndex
-): number | undefined {
+): bigint | number | undefined {
   const data = tiles.find((tile) => tile.data?.length)?.data;
 
   if (!data) {
@@ -69,41 +89,6 @@ function getResolution(
 
   if (spatialIndex === SpatialIndex.H3) {
     return h3GetResolution(data[0].id);
-  }
-}
-
-const bboxWest: BBox = [-180, -90, 0, 90];
-const bboxEast: BBox = [0, -90, 180, 90];
-
-function getCellsCoverGeometry(
-  geometry: SpatialFilter,
-  spatialIndex: SpatialIndex,
-  resolution: number
-) {
-  if (spatialIndex === SpatialIndex.QUADBIN) {
-    // @ts-expect-error TODO: Probably ought to be stricter about number vs. bigint types in this file.
-    return geometryToCells(geometry, resolution);
-  }
-
-  if (spatialIndex === SpatialIndex.H3) {
-    // The current H3 polyfill algorithm can't deal with polygon segments of greater than 180 degrees longitude
-    // so we clip the geometry to be sure that none of them is greater than 180 degrees
-    // https://github.com/uber/h3-js/issues/24#issuecomment-431893796
-    return polygonToCells(
-      bboxClip(geometry, bboxWest).geometry.coordinates as
-        | number[][]
-        | number[][][],
-      resolution,
-      true
-    ).concat(
-      polygonToCells(
-        bboxClip(geometry, bboxEast).geometry.coordinates as
-          | number[][]
-          | number[][][],
-        resolution,
-        true
-      )
-    );
   }
 }
 

--- a/src/filters/tileIntersection.ts
+++ b/src/filters/tileIntersection.ts
@@ -19,12 +19,12 @@ import bboxClip from '@turf/bbox-clip';
 // Computes intersections between spatial filters and tiles in various formats,
 // for pre-filtering each tile's features before performing widget calculations.
 //
-// - FILTER INTERSECTS TILE: Requires a more detailed per-feature check for each
-//    feature in the tile. Compute a clipped spatial filter local to the tile or,
-//    for spatial indexes, a covering (set of indices).
-// - FILTER FULLY CONTAINS TILE: Process all features in tile, no more checks.
-// - NO FILTER: Process all features in tile, no more checks.
-// - NO OVERLAP: If tile and spatial filter do not overlap, exclude all features.
+// Return types:
+// - 'true': All features in tile are within spatial filter.
+// - 'false': No features in tile are within spatial filter; skip tile.
+// - SpatialFilter/Set: Requires a more detailed per-feature check for each
+//    feature in the tile. Provides a clipped spatial filter local to the tile
+//    or, for spatial indexes, a set of indices ("covering set").
 //
 // Computing a covering set for spatial indexes may be very expensive for large
 // spatial filters and small cell resolutions. For example, a viewport at z=3

--- a/src/filters/tileIntersection.ts
+++ b/src/filters/tileIntersection.ts
@@ -1,0 +1,157 @@
+import type {BBox, Polygon} from 'geojson';
+import type {SpatialFilter} from '../types.js';
+import bboxPolygon from '@turf/bbox-polygon';
+import booleanWithin from '@turf/boolean-within';
+import intersect from '@turf/intersect';
+import {feature, featureCollection} from '@turf/helpers';
+import {TileFormat} from '../constants.js';
+import {transformToTileCoords} from '../utils/transformToTileCoords.js';
+import {
+  cellToBoundary as quadbinCellToBoundary,
+  geometryToCells as quadbinGeometryToCells,
+} from 'quadbin';
+import {
+  cellToBoundary as h3CellToBoundary,
+  polygonToCells as h3PolygonToCells,
+} from 'h3-js';
+import bboxClip from '@turf/bbox-clip';
+
+// Computes intersections between spatial filters and tiles in various formats.
+// Used to pre-filter tile features before processing for widget calculations.
+//
+// - FILTER INTERSECTS TILE: Requires a more detailed per-feature check for each
+//    feature in the tile. Compute a clipped spatial filter local to the tile or,
+//    for spatial indexes, a covering set.
+// - FILTER FULLY CONTAINS TILE: Process all features in tile, no more checks.
+// - NO FILTER: Process all features in tile, no more checks.
+// - NO OVERLAP: If tile and spatial filter do not overlap, exclude all features.
+//
+// Computing a covering set for spatial indexes may be very expensive for large
+// spatial filters and small cell resolutions. For example, a viewport at z=3
+// would contain ~18,000,000 raster cells at resolution=14. To avoid ever
+// creating a covering set of this size, do filtering per-tile, not globally.
+
+///////////////////////////////////////////////////////////////////////////////
+// GEOMETRY
+
+/** @internal */
+export function intersectTileGeometry(
+  tileBbox: BBox,
+  tileFormat?: TileFormat,
+  spatialFilter?: SpatialFilter
+): boolean | SpatialFilter {
+  const tilePolygon = bboxPolygon(tileBbox);
+
+  if (!spatialFilter || booleanWithin(tilePolygon, spatialFilter)) {
+    return true;
+  }
+
+  const clippedSpatialFilter = intersect(
+    featureCollection([tilePolygon, feature(spatialFilter)])
+  );
+
+  if (!clippedSpatialFilter) {
+    return false;
+  }
+
+  // Transform into local coordinates [0..1]. We assume MVT tiles use local
+  // coordinates but geojson or binary features are already WGS84.
+  return tileFormat === TileFormat.MVT
+    ? transformToTileCoords(clippedSpatialFilter.geometry, tileBbox)
+    : clippedSpatialFilter.geometry;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// RASTER
+
+/** @internal */
+export function intersectTileRaster(
+  parent: bigint,
+  cellResolution: bigint,
+  spatialFilter?: SpatialFilter
+) {
+  return intersectTileQuadbin(parent, cellResolution, spatialFilter);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// QUADBIN
+
+/** @internal */
+export function intersectTileQuadbin(
+  parent: bigint,
+  cellResolution: bigint,
+  spatialFilter?: SpatialFilter
+): boolean | Set<bigint> {
+  const tilePolygon = quadbinCellToBoundary(parent);
+
+  if (!spatialFilter || booleanWithin(tilePolygon, spatialFilter)) {
+    return true;
+  }
+
+  const clippedSpatialFilter = intersect(
+    featureCollection([feature(tilePolygon), feature(spatialFilter)])
+  );
+
+  if (!clippedSpatialFilter) {
+    return false;
+  }
+
+  const cells = quadbinGeometryToCells(
+    clippedSpatialFilter.geometry,
+    cellResolution
+  );
+
+  return new Set(cells);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// H3
+
+const BBOX_WEST: BBox = [-180, -90, 0, 90];
+const BBOX_EAST: BBox = [0, -90, 180, 90];
+
+/** @internal */
+export function intersectTileH3(
+  parent: string,
+  cellResolution: number,
+  spatialFilter?: SpatialFilter
+): boolean | Set<string> {
+  const tilePolygon: Polygon = {
+    type: 'Polygon',
+    coordinates: [h3CellToBoundary(parent, true)],
+  };
+
+  if (!spatialFilter || booleanWithin(tilePolygon, spatialFilter)) {
+    return true;
+  }
+
+  const clippedSpatialFilter = intersect(
+    featureCollection([feature(tilePolygon), feature(spatialFilter)])
+  );
+
+  if (!clippedSpatialFilter) {
+    return false;
+  }
+
+  // The current H3 polyfill algorithm can't deal with polygon segments of greater than 180 degrees longitude
+  // so we clip the geometry to be sure that none of them is greater than 180 degrees
+  // https://github.com/uber/h3-js/issues/24#issuecomment-431893796
+
+  const cellsWest = h3PolygonToCells(
+    bboxClip(clippedSpatialFilter, BBOX_WEST).geometry.coordinates as
+      | number[][]
+      | number[][][],
+    cellResolution,
+    true
+  );
+
+  const cellsEast = h3PolygonToCells(
+    bboxClip(clippedSpatialFilter, BBOX_EAST).geometry.coordinates as
+      | number[][]
+      | number[][][],
+    cellResolution,
+    true
+  );
+
+  return new Set(cellsWest.concat(cellsEast));
+}

--- a/src/filters/tileIntersection.ts
+++ b/src/filters/tileIntersection.ts
@@ -20,8 +20,8 @@ import bboxClip from '@turf/bbox-clip';
 // for pre-filtering each tile's features before performing widget calculations.
 //
 // Return types:
-// - 'true': All features in tile are within spatial filter.
-// - 'false': No features in tile are within spatial filter; skip tile.
+// - true: All features in tile are within spatial filter.
+// - false: No features in tile are within spatial filter; skip tile.
 // - SpatialFilter/Set: Requires a more detailed per-feature check for each
 //    feature in the tile. Provides a clipped spatial filter local to the tile
 //    or, for spatial indexes, a set of indices ("covering set").

--- a/src/filters/tileIntersection.ts
+++ b/src/filters/tileIntersection.ts
@@ -16,12 +16,12 @@ import {
 } from 'h3-js';
 import bboxClip from '@turf/bbox-clip';
 
-// Computes intersections between spatial filters and tiles in various formats.
-// Used to pre-filter tile features before processing for widget calculations.
+// Computes intersections between spatial filters and tiles in various formats,
+// for pre-filtering each tile's features before performing widget calculations.
 //
 // - FILTER INTERSECTS TILE: Requires a more detailed per-feature check for each
 //    feature in the tile. Compute a clipped spatial filter local to the tile or,
-//    for spatial indexes, a covering set.
+//    for spatial indexes, a covering (set of indices).
 // - FILTER FULLY CONTAINS TILE: Process all features in tile, no more checks.
 // - NO FILTER: Process all features in tile, no more checks.
 // - NO OVERLAP: If tile and spatial filter do not overlap, exclude all features.
@@ -29,7 +29,8 @@ import bboxClip from '@turf/bbox-clip';
 // Computing a covering set for spatial indexes may be very expensive for large
 // spatial filters and small cell resolutions. For example, a viewport at z=3
 // would contain ~18,000,000 raster cells at resolution=14. To avoid ever
-// creating a covering set of this size, do filtering per-tile, not globally.
+// creating a covering set of this size, do filtering per-tile, not globally,
+// and skip the covering for tiles fully inside or outside the spatial filter.
 
 ///////////////////////////////////////////////////////////////////////////////
 // GEOMETRY

--- a/src/widget-sources/widget-tileset-source-impl.ts
+++ b/src/widget-sources/widget-tileset-source-impl.ts
@@ -74,14 +74,13 @@ export class WidgetTilesetSourceImpl extends WidgetSource<WidgetTilesetSourcePro
     this._features.length = 0;
   }
 
-  protected _extractTileFeatures(spatialFilter: SpatialFilter) {
+  protected _extractTileFeatures(spatialFilter?: SpatialFilter) {
     // When spatial filter has not changed, don't redo extraction. If tiles or
     // tile extract options change, features will have been cleared already.
     const prevInputs = this._tileFeatureExtractPreviousInputs;
     if (
       this._features.length &&
-      prevInputs.spatialFilter &&
-      booleanEqual(prevInputs.spatialFilter, spatialFilter)
+      spatialFilterEquals(prevInputs.spatialFilter, spatialFilter)
     ) {
       return;
     }
@@ -383,7 +382,6 @@ export class WidgetTilesetSourceImpl extends WidgetSource<WidgetTilesetSourcePro
     filters?: Record<string, Filter>,
     filterOwner?: string
   ): FeatureData[] {
-    assert(spatialFilter, 'spatialFilter required for tilesets');
     this._extractTileFeatures(spatialFilter);
     return applyFilters(
       this._features,
@@ -421,4 +419,10 @@ function normalizeColumns(columns: string | string[]): string[] {
     : typeof columns === 'string'
       ? [columns]
       : [];
+}
+
+function spatialFilterEquals(a?: SpatialFilter, b?: SpatialFilter) {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  return booleanEqual(a, b);
 }


### PR DESCRIPTION
WidgetTilesetSource and WidgetRasterSource previously required a spatial filter to return widget results. With this update the spatial filter is no longer required. Omitting the spatial filter is preferred when the entire map is visible, to skip unnecessary checks against an all-inclusive bounding box. 

To support this change for all local layer types (geo, quadbin, h3, raster), and for easier understanding of the differences between them, I've refactored the intersection code into a common file (`tileIntersection.ts`). The general approach remains the same as #201, now applied to other layer types. 

H3 is a bit of a special case; child cells are not necessarily within the parent's boundary. For now I've kept a global covering set (not per-tile) for H3, to avoid any changes to E2E results, but for future reference we probably do have other options with [`polygonToCellsExperimental`](https://h3geo.org/docs/api/regions#polygontocellsexperimental).
 
Fixes [sc-491354].


#### PR Dependency Tree


* **PR #204** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)