### PR TITLE
perf(rasters): Add cellToChildrenRaster()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.5
 
+- perf(rasters): Improve performance of raster widget spatial filtering (TODO)
+
 ### 0.5.7
 
 - feat(widgets): Allow local widget calculations without spatial filter (#204)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## 0.5
 
-- perf(rasters): Improve performance of raster widget spatial filtering (TODO)
+### Unreleased
+
+- perf(rasters): Improve performance of raster widget spatial filtering (#207)
 
 ### 0.5.7
 


### PR DESCRIPTION
Adds `cellToChildrenRaster()`, an alternative for the `quadbin` module's `cellToChildren`. While `cellToChildrenRaster` is about 25% slower than `cellToChildren`, it is _much_ faster than calling `cellToChildren` then going back and sorting the results into the order used by raster tiles. Because `quadbin` package isn't otherwise concerned with the raster format, I'm adding the new function here rather than in `quadbin`.

The optimization improves the biggest slow path left after #201. For large datasets at zoom=3 and resolution=14, widget feature pre-processing is reduced from 10–12s to 1-2s on my macbook pro. This pre-processing is shared by all widgets using the same dataset and spatial filter, and not repeated per-widget.






#### PR Dependency Tree


* **PR #207** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)