### PR TITLE
chore(build): Silence import.meta warning in IIFE builds

### DIFF
--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -33,6 +33,12 @@ export default defineConfig([
         js: `.js`,
       };
     },
+    esbuildOptions(options) {
+      options.logOverride ||= {};
+      // "import.meta" is not available with "iife" output, but we don't
+      // need the Worker URL inside the worker itself anyway.
+      options.logOverride['empty-import-meta'] = 'silent';
+    },
     entry: {
       'worker-compat': 'src/workers/widget-tileset-worker.ts',
     },


### PR DESCRIPTION
Silences the warning below when building the IIFE build, used in workers. We don't need the worker url inside the worker itself, so the warning isn't relevant.

```plaintext
 WARN  ▲ [WARNING] "import.meta" is not available with the "iife" output format and will be empty [empty-import-meta]             2:52:22 PM

    src/widget-sources/widget-tileset-source.ts:110:44:
      110 │         new URL('@carto/api-client/worker', import.meta.url),
          ╵                                             ~~~~~~~~~~~

  You need to set the output format to "esm" for "import.meta" to work correctly.
```


#### PR Dependency Tree


* **PR #213** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)