### PR TITLE
feat(widgets): Add experimental getExtent() API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## 0.5
 
+### 0.5.14
+
+- feat(widgets): Add 'getExtent()' method, experimental (#220)
+
+### 0.5.13
+
+- fix(constants): Export RasterBandColorinterp (#216)
+
 ### 0.5.12
 
 - feat(sources): allow passing tags to baseSource and query methods (#193)

--- a/examples/01-basic/app.ts
+++ b/examples/01-basic/app.ts
@@ -81,7 +81,11 @@ function updateLayers() {
 
   deck.setProps({layers: [layer]});
   data
-    .then(({attribution}) => {
+    .then(({attribution, widgetSource}) => {
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      widgetSource.getExtent({}).then((response) => {
+        console.log('getExtent', response);
+      });
       document.querySelector('#footer')!.innerHTML = attribution;
     })
     .catch((error) => {

--- a/examples/01-basic/app.ts
+++ b/examples/01-basic/app.ts
@@ -81,11 +81,7 @@ function updateLayers() {
 
   deck.setProps({layers: [layer]});
   data
-    .then(({attribution, widgetSource}) => {
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises
-      widgetSource.getExtent({}).then((response) => {
-        console.log('getExtent', response);
-      });
+    .then(({attribution}) => {
       document.querySelector('#footer')!.innerHTML = attribution;
     })
     .catch((error) => {

--- a/examples/05-raster/app.ts
+++ b/examples/05-raster/app.ts
@@ -83,7 +83,6 @@ function updateLayers() {
 
 function updateTiles(tiles: unknown[]) {
   data.widgetSource.loadTiles(tiles);
-  console.log('loadTiles', tiles);
   updateWidgetsDebounced();
 }
 

--- a/src/sources/h3-tileset-source.ts
+++ b/src/sources/h3-tileset-source.ts
@@ -34,7 +34,7 @@ export const h3TilesetSource = async function (
         tileFormat: getTileFormat(result),
         spatialDataColumn,
         spatialDataType: 'h3',
-        spatialDataBBox: result.bounds,
+        spatialDataBounds: result.bounds,
       }),
     })
   ) as Promise<H3TilesetSourceResponse>;

--- a/src/sources/h3-tileset-source.ts
+++ b/src/sources/h3-tileset-source.ts
@@ -34,6 +34,7 @@ export const h3TilesetSource = async function (
         tileFormat: getTileFormat(result),
         spatialDataColumn,
         spatialDataType: 'h3',
+        spatialDataBBox: result.bounds,
       }),
     })
   ) as Promise<H3TilesetSourceResponse>;

--- a/src/sources/quadbin-tileset-source.ts
+++ b/src/sources/quadbin-tileset-source.ts
@@ -34,7 +34,7 @@ export const quadbinTilesetSource = async function (
         tileFormat: getTileFormat(result),
         spatialDataColumn,
         spatialDataType: 'quadbin',
-        spatialDataBBox: result.bounds,
+        spatialDataBounds: result.bounds,
       }),
     })
   ) as Promise<QuadbinTilesetSourceResponse>;

--- a/src/sources/quadbin-tileset-source.ts
+++ b/src/sources/quadbin-tileset-source.ts
@@ -34,6 +34,7 @@ export const quadbinTilesetSource = async function (
         tileFormat: getTileFormat(result),
         spatialDataColumn,
         spatialDataType: 'quadbin',
+        spatialDataBBox: result.bounds,
       }),
     })
   ) as Promise<QuadbinTilesetSourceResponse>;

--- a/src/sources/raster-source.ts
+++ b/src/sources/raster-source.ts
@@ -43,7 +43,7 @@ export const rasterSource = async function (
         tileFormat: getTileFormat(result),
         spatialDataColumn: 'quadbin',
         spatialDataType: 'quadbin',
-        spatialDataBBox: result.bounds,
+        spatialDataBounds: result.bounds,
         rasterMetadata: result.raster_metadata!,
       }),
     })

--- a/src/sources/raster-source.ts
+++ b/src/sources/raster-source.ts
@@ -43,6 +43,7 @@ export const rasterSource = async function (
         tileFormat: getTileFormat(result),
         spatialDataColumn: 'quadbin',
         spatialDataType: 'quadbin',
+        spatialDataBBox: result.bounds,
         rasterMetadata: result.raster_metadata!,
       }),
     })

--- a/src/sources/vector-tileset-source.ts
+++ b/src/sources/vector-tileset-source.ts
@@ -35,7 +35,7 @@ export const vectorTilesetSource = async function (
         tileFormat: getTileFormat(result),
         spatialDataColumn,
         spatialDataType: 'geo',
-        spatialDataBBox: result.bounds,
+        spatialDataBounds: result.bounds,
       }),
     })
   ) as Promise<VectorTilesetSourceResponse>;

--- a/src/sources/vector-tileset-source.ts
+++ b/src/sources/vector-tileset-source.ts
@@ -35,6 +35,7 @@ export const vectorTilesetSource = async function (
         tileFormat: getTileFormat(result),
         spatialDataColumn,
         spatialDataType: 'geo',
+        spatialDataBBox: result.bounds,
       }),
     })
   ) as Promise<VectorTilesetSourceResponse>;

--- a/src/widget-sources/types.ts
+++ b/src/widget-sources/types.ts
@@ -1,3 +1,4 @@
+import type {BBox} from 'geojson';
 import type {
   SpatialFilterPolyfillMode,
   TileResolution,
@@ -206,6 +207,9 @@ export interface TimeSeriesRequestOptions extends BaseRequestOptions {
   splitByCategoryValues?: string[];
 }
 
+/** @experimental */
+export type ExtentRequestOptions = BaseRequestOptions;
+
 /******************************************************************************
  * WIDGET API RESPONSES
  */
@@ -256,3 +260,6 @@ export type TimeSeriesResponse = {
 
 /** Response from {@link WidgetRemoteSource#getHistogram}. */
 export type HistogramResponse = number[];
+
+/** @experimental */
+export type ExtentResponse = {bbox: BBox};

--- a/src/widget-sources/widget-remote-source.ts
+++ b/src/widget-sources/widget-remote-source.ts
@@ -395,7 +395,7 @@ export abstract class WidgetRemoteSource<
   }
 
   /** @experimental */
-  async getExtent(options: ExtentRequestOptions): Promise<ExtentResponse> {
+  async getExtent(options: ExtentRequestOptions = {}): Promise<ExtentResponse> {
     const {signal, filters = this.props.filters, filterOwner} = options;
 
     const {

--- a/src/widget-sources/widget-remote-source.ts
+++ b/src/widget-sources/widget-remote-source.ts
@@ -441,7 +441,6 @@ export abstract class WidgetRemoteSource<
         xmax: number;
         ymax: number;
       };
-      metadata: {categories: string[]};
     };
 
     return requestWithParameters<StatsResponse>({

--- a/src/widget-sources/widget-source.ts
+++ b/src/widget-sources/widget-source.ts
@@ -1,6 +1,8 @@
 import type {
   CategoryRequestOptions,
   CategoryResponse,
+  ExtentRequestOptions,
+  ExtentResponse,
   FeaturesRequestOptions,
   FeaturesResponse,
   FormulaRequestOptions,
@@ -124,4 +126,7 @@ export abstract class WidgetSource<
   abstract getTimeSeries(
     options: TimeSeriesRequestOptions
   ): Promise<TimeSeriesResponse>;
+
+  /** @experimental */
+  abstract getExtent(options: ExtentRequestOptions): Promise<ExtentResponse>;
 }

--- a/src/widget-sources/widget-source.ts
+++ b/src/widget-sources/widget-source.ts
@@ -128,5 +128,5 @@ export abstract class WidgetSource<
   ): Promise<TimeSeriesResponse>;
 
   /** @experimental */
-  abstract getExtent(options: ExtentRequestOptions): Promise<ExtentResponse>;
+  abstract getExtent(options?: ExtentRequestOptions): Promise<ExtentResponse>;
 }

--- a/src/widget-sources/widget-tileset-source-impl.ts
+++ b/src/widget-sources/widget-tileset-source-impl.ts
@@ -2,6 +2,7 @@
 import type {
   CategoryRequestOptions,
   CategoryResponse,
+  ExtentResponse,
   FeaturesResponse,
   FormulaRequestOptions,
   FormulaResponse,
@@ -388,6 +389,11 @@ export class WidgetTilesetSourceImpl extends WidgetSource<WidgetTilesetSourcePro
       min: aggregationFunctions.min(filteredFeatures, column),
       max: aggregationFunctions.max(filteredFeatures, column),
     };
+  }
+
+  /** @experimental */
+  async getExtent(): Promise<ExtentResponse> {
+    return Promise.reject(new Error('not implemented'));
   }
 
   /****************************************************************************

--- a/src/widget-sources/widget-tileset-source.ts
+++ b/src/widget-sources/widget-tileset-source.ts
@@ -18,7 +18,7 @@ import type {
 } from './types.js';
 import type {SpatialFilter, Tile} from '../types.js';
 import type {TileFeatureExtractOptions} from '../filters/index.js';
-import type {FeatureCollection} from 'geojson';
+import type {BBox, FeatureCollection} from 'geojson';
 import {WidgetSource, type WidgetSourceProps} from './widget-source.js';
 import {Method} from '../workers/constants.js';
 import type {WorkerRequest, WorkerResponse} from '../workers/types.js';
@@ -30,6 +30,10 @@ export type WidgetTilesetSourceProps = WidgetSourceProps &
   Omit<TilesetSourceOptions, 'filters'> & {
     tileFormat: TileFormat;
     spatialDataType: SpatialDataType;
+    /**
+     * Extent of spatial data, typically from TileJSON. Does not include filters.
+     */
+    spatialDataBBox: BBox;
   };
 
 export type WidgetTilesetSourceResult = {widgetSource: WidgetTilesetSource};
@@ -324,6 +328,8 @@ export class WidgetTilesetSource<
 
   /** @experimental */
   async getExtent(): Promise<ExtentResponse> {
-    return Promise.reject(new Error('not implemented'));
+    return Promise.resolve({
+      bbox: this.props.spatialDataBBox,
+    });
   }
 }

--- a/src/widget-sources/widget-tileset-source.ts
+++ b/src/widget-sources/widget-tileset-source.ts
@@ -1,6 +1,7 @@
 import type {
   CategoryRequestOptions,
   CategoryResponse,
+  ExtentResponse,
   FeaturesResponse,
   FormulaRequestOptions,
   FormulaResponse,
@@ -319,5 +320,10 @@ export class WidgetTilesetSource<
     ...options
   }: RangeRequestOptions): Promise<RangeResponse> {
     return this._executeWorkerMethod(Method.GET_RANGE, [options], signal);
+  }
+
+  /** @experimental */
+  async getExtent(): Promise<ExtentResponse> {
+    return Promise.reject(new Error('not implemented'));
   }
 }

--- a/src/widget-sources/widget-tileset-source.ts
+++ b/src/widget-sources/widget-tileset-source.ts
@@ -33,7 +33,7 @@ export type WidgetTilesetSourceProps = WidgetSourceProps &
     /**
      * Extent of spatial data, typically from TileJSON. Does not include filters.
      */
-    spatialDataBBox: BBox;
+    spatialDataBounds: BBox;
   };
 
 export type WidgetTilesetSourceResult = {widgetSource: WidgetTilesetSource};
@@ -329,7 +329,7 @@ export class WidgetTilesetSource<
   /** @experimental */
   async getExtent(): Promise<ExtentResponse> {
     return Promise.resolve({
-      bbox: this.props.spatialDataBBox,
+      bbox: this.props.spatialDataBounds,
     });
   }
 }

--- a/test/widget-sources/widget-tileset-source.test.ts
+++ b/test/widget-sources/widget-tileset-source.test.ts
@@ -5,11 +5,13 @@ import {
   createViewportSpatialFilter,
 } from '@carto/api-client';
 import {MOCK_GEOJSON} from './__mock-geojson.js';
+import type {BBox} from 'geojson';
 
 let source: WidgetTilesetSource;
 
 const MOCK_COLUMNS = Object.keys(MOCK_GEOJSON.features[0].properties);
 const MOCK_SPATIAL_FILTER = createViewportSpatialFilter([-175, 85, 175, -85]);
+const MOCK_BOUNDS = [-9.2, 37.5, 1.0, 43.5] as BBox;
 
 beforeEach(() => {
   source = new WidgetTilesetSource({
@@ -18,6 +20,7 @@ beforeEach(() => {
     accessToken: '••••',
     tileFormat: TileFormat.BINARY,
     spatialDataType: 'geo',
+    spatialDataBounds: MOCK_BOUNDS,
   });
 
   source.loadGeoJSON({
@@ -246,5 +249,12 @@ describe('getTable', () => {
       totalCount: 1,
       rows: [MOCK_GEOJSON.features[0].properties],
     });
+  });
+});
+
+describe('getExtent', () => {
+  it('should return TileJSON bounds', async () => {
+    const result = await source.getExtent();
+    expect(result).toEqual({bbox: MOCK_BOUNDS});
   });
 });


### PR DESCRIPTION
Adds _experimental_ `getExtent()` method to all WidgetSource classes. The API is currently experimental, and may receive breaking changes or deprecations outside of semver-major release versions.

Example:

```js
const { ...data, widgetSource } = await vectorTableSource(...);
const { bbox } = await widgetSource.getExtent();
```

As in turf.js, the bbox is given in [xmin, ymin, xmax, ymax] order.

[sc-497971]

#### PR Dependency Tree


* **PR #220** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)