### PR TITLE
feat(fetch-map): support for raster layers and updateTriggers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Unreleased
+
+- feat(fetchMap): Raster layers, update triggers and other fixes (#223)
+
 ## 0.5
 
 ### 0.5.16

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "d3-format": "^3.1.0",
     "d3-scale": "^4.0.2",
     "h3-js": "^4.1.0",
-    "jsep": "^0.3.4",
+    "jsep": "^1.4.0",
     "quadbin": "^0.4.1-alpha.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "d3-format": "^3.1.0",
     "d3-scale": "^4.0.2",
     "h3-js": "^4.1.0",
+    "jsep": "^0.3.4",
     "quadbin": "^0.4.1-alpha.0"
   },
   "devDependencies": {

--- a/src/fetch-map/basemap-styles.ts
+++ b/src/fetch-map/basemap-styles.ts
@@ -92,7 +92,7 @@ export const STYLE_LAYER_GROUPS: StyleLayerGroup[] = [
 ];
 
 export function applyLayerGroupFilters(
-  style: any,
+  style: any, // this Maplibre/Mapbox style, we don't want to add a dependency on Maplibre
   visibleLayerGroups: Record<StyleLayerGroupSlug, boolean>
 ) {
   if (!Array.isArray(style?.layers)) {

--- a/src/fetch-map/index.ts
+++ b/src/fetch-map/index.ts
@@ -1,4 +1,5 @@
 export {default as BASEMAP} from './basemap-styles.js';
+export {getRasterTileLayerStyleProps as _getRasterTileLayerStyleProps} from './raster-layer.js';
 export {fetchMap} from './fetch-map.js';
 export type {FetchMapOptions, FetchMapResult} from './fetch-map.js';
 export type {

--- a/src/fetch-map/index.ts
+++ b/src/fetch-map/index.ts
@@ -15,3 +15,4 @@ export type {
 export * from './basemap.js';
 export * from './layer-map.js';
 export * from './parse-map.js';
+export {getLog10ScaleSteps as _getLog10ScaleSteps} from './utils.js';

--- a/src/fetch-map/index.ts
+++ b/src/fetch-map/index.ts
@@ -1,4 +1,7 @@
-export {default as BASEMAP} from './basemap-styles.js';
+export {
+  default as BASEMAP,
+  applyLayerGroupFilters as _applyLayerGroupFilters,
+} from './basemap-styles.js';
 export {getRasterTileLayerStyleProps as _getRasterTileLayerStyleProps} from './raster-layer.js';
 export {fetchMap} from './fetch-map.js';
 export type {FetchMapOptions, FetchMapResult} from './fetch-map.js';

--- a/src/fetch-map/layer-map.ts
+++ b/src/fetch-map/layer-map.ts
@@ -379,9 +379,9 @@ export function calculateLayerScale(
   const {colors} = range;
 
   if (scaleType === 'custom') {
+    domain = calculateDomain(data, name, scaleType, colors.length);
+    const [min, max] = domain as number[];
     if (range.uiCustomScaleType === 'logarithmic') {
-      domain = calculateDomain(data, name, scaleType, colors.length);
-      const [min, max] = domain as number[];
       scaleDomain = getLog10ScaleSteps({
         min,
         max,
@@ -391,8 +391,9 @@ export function calculateLayerScale(
       scaleColor = colors;
     } else if (range.colorMap) {
       const {colorMap} = range;
+      scaleDomain = [];
       colorMap.forEach(([value, color]) => {
-        (domain as string[]).push(value);
+        (scaleDomain as number[]).push(Number(value));
         scaleColor.push(color);
       });
     }

--- a/src/fetch-map/layer-map.ts
+++ b/src/fetch-map/layer-map.ts
@@ -225,8 +225,7 @@ function domainFromAttribute(
       min: attribute.min,
       max: attribute.max,
       steps: scaleLength,
-      // really don't understand why this null is needed for overflow items
-    }) as number[];
+    });
   }
   if (scaleType === 'ordinal' || scaleType === 'point') {
     if (!attribute.categories) {

--- a/src/fetch-map/layer-map.ts
+++ b/src/fetch-map/layer-map.ts
@@ -75,7 +75,21 @@ function identity<T>(v: T): T {
   return v;
 }
 
+const hexToRGB = (c: any) => {
+  const {r, g, b} = rgb(c);
+  return [r, g, b];
+};
+
+const rgbToHex = (c: number[]) => {
+  const [r, g, b] = c;
+  const rStr = r.toString(16).padStart(2, '0');
+  const gStr = g.toString(16).padStart(2, '0');
+  const bStr = b.toString(16).padStart(2, '0');
+  return `#${rStr}${gStr}${bStr}`.toUpperCase();
+};
+
 const UNKNOWN_COLOR = '#868d91';
+const UNKNOWN_COLOR_RGB = hexToRGB(UNKNOWN_COLOR);
 
 export const OPACITY_MAP: Record<string, string> = {
   getFillColor: 'opacity',
@@ -342,14 +356,14 @@ export function getColorAccessor(
       accessorKeys = findAccessorKey(accessorKeys, properties);
     }
     const propertyValue = properties[accessorKeys[0]];
-    const {r, g, b} = rgb(scale(propertyValue));
+    const [r, g, b] = scale(propertyValue);
     return [r, g, b, propertyValue === null ? 0 : alpha];
   };
   return {
     accessor: normalizeAccessor(accessor, data),
     scaleDomain: scale.domain(),
     domain,
-    range: scale.range() as string[],
+    range: scale.range().map(rgbToHex),
   };
 }
 
@@ -395,8 +409,8 @@ export function calculateLayerScale(
     scale: createColorScale(
       scaleType,
       scaleDomain || domain,
-      scaleColor,
-      UNKNOWN_COLOR
+      scaleColor.map(hexToRGB),
+      UNKNOWN_COLOR_RGB
     ),
     domain,
   };

--- a/src/fetch-map/layer-map.ts
+++ b/src/fetch-map/layer-map.ts
@@ -216,6 +216,9 @@ function domainFromAttribute(
   scaleLength: number
 ) {
   if (scaleType === 'ordinal' || scaleType === 'point') {
+    if (!attribute.categories) {
+      return [0, 1];
+    }
     return attribute.categories
       .map((c: any) => c.category)
       .filter((c: any) => c !== undefined && c !== null);

--- a/src/fetch-map/layer-map.ts
+++ b/src/fetch-map/layer-map.ts
@@ -344,26 +344,27 @@ export function getColorAccessor(
 } {
   const {scale, domain} = calculateLayerScale(
     colorColumn || name,
-    scaleType,
+    colorColumn ? 'identity' : scaleType,
     range,
     data
   );
   const alpha = opacityToAlpha(opacity);
 
-  let accessorKeys = getAccessorKeys(name, aggregation);
+  let accessorKeys = getAccessorKeys(colorColumn || name, aggregation);
   const accessor = (properties: any) => {
     if (!(accessorKeys[0] in properties)) {
       accessorKeys = findAccessorKey(accessorKeys, properties);
     }
     const propertyValue = properties[accessorKeys[0]];
-    const [r, g, b] = scale(propertyValue);
-    return [r, g, b, propertyValue === null ? 0 : alpha];
+    const scaled = scale(propertyValue);
+    const rgb = typeof scaled === 'string' ? hexToRGB(scaled) : scaled;
+    return [...rgb, propertyValue === null ? 0 : alpha];
   };
   return {
     accessor: normalizeAccessor(accessor, data),
     scaleDomain: scale.domain(),
     domain,
-    range: scale.range().map(rgbToHex),
+    range: (scale.range() || []).map(rgbToHex),
   };
 }
 

--- a/src/fetch-map/layer-map.ts
+++ b/src/fetch-map/layer-map.ts
@@ -115,6 +115,13 @@ const sharedPropMap = {
   },
 };
 
+const rasterPropsMap = {
+  isVisible: 'visible',
+  visConfig: {
+    opacity: 'opacity',
+  },
+};
+
 const customMarkersPropsMap = {
   color: 'getIconColor',
   visConfig: {
@@ -174,6 +181,13 @@ export function getLayerProps(
     throw new Error(
       `Outdated layer type: ${type}. Please open map in CARTO Builder to automatically migrate.`
     );
+  }
+
+  if (type === 'raster') {
+    return {
+      propMap: rasterPropsMap,
+      defaultProps: {},
+    };
   }
 
   let basePropMap: any = sharedPropMap;
@@ -350,18 +364,19 @@ export function calculateLayerScale(
     }
   }
 
-  return createColorScale(scaleType, domain, scaleColor);
+  return createColorScale(scaleType, domain, scaleColor, UNKNOWN_COLOR);
 }
 
-export function createColorScale(
+export function createColorScale<T>(
   scaleType: ScaleType,
   domain: string[] | number[],
-  range: string[]
+  range: T[],
+  unknown: T
 ) {
   const scale = SCALE_FUNCS[scaleType]();
   scale.domain(domain);
   scale.range(range);
-  scale.unknown!(UNKNOWN_COLOR);
+  scale.unknown!(unknown as any);
 
   return scale;
 }

--- a/src/fetch-map/layer-map.ts
+++ b/src/fetch-map/layer-map.ts
@@ -39,7 +39,7 @@ import type {
 import type {ProviderType, SchemaField} from '../types.js';
 import {DEFAULT_AGGREGATION_EXP_ALIAS} from '../constants-internal.js';
 import {AggregationTypes} from '../constants.js';
-import type {RasterMetadataBand, TilejsonResult} from '../sources/types.js';
+import type {TilejsonResult} from '../sources/types.js';
 
 export type D3Scale = {
   domain: (d?: any) => any[];

--- a/src/fetch-map/parse-map.ts
+++ b/src/fetch-map/parse-map.ts
@@ -40,7 +40,11 @@ import type {TilejsonResult} from '../sources/types.js';
 export type Scale = {
   type: ScaleType;
   field: VisualChannelField;
+
+  /** Natural domain of the scale, as defined by the data  */
   domain: string[] | number[];
+
+  /** Domain of the user to construct d3 scale */
   scaleDomain?: string[] | number[];
   range?: string[] | number[];
 };
@@ -52,11 +56,13 @@ export type ScaleKey =
   | 'elevation'
   | 'weight';
 
+export type Scales = Partial<Record<ScaleKey, Scale>>;
+
 export type LayerDescriptor = {
   type: LayerType;
   props: Record<string, any>;
   filters?: Filters;
-  scales: Partial<Record<ScaleKey, Scale>>;
+  scales: Scales;
 };
 
 export type ParseMapResult = {
@@ -451,7 +457,7 @@ function createChannelProps(
   {
     const {enable3d, heightRange} = visConfig;
     const {heightField, heightScale} = visualChannels;
-    if (heightField && heightRange && heightScale && enable3d) {
+    if (heightField && heightRange && enable3d) {
       const {accessor, ...scaleProps} = getSizeAccessor(
         heightField,
         heightScale,

--- a/src/fetch-map/parse-map.ts
+++ b/src/fetch-map/parse-map.ts
@@ -130,7 +130,8 @@ export function parseMap(json: any) {
   const {keplerMapConfig, datasets, token} = json;
   assert(keplerMapConfig.version === 'v1', 'Only support Kepler v1');
   const mapConfig = keplerMapConfig.config as KeplerMapConfig;
-  const {mapState, mapStyle, popupSettings, legendSettings, visState} = mapConfig;
+  const {mapState, mapStyle, popupSettings, legendSettings, visState} =
+    mapConfig;
   const {layers} = visState;
 
   const layersReverse = [...layers].reverse();
@@ -273,11 +274,12 @@ function createChannelProps(
   } = visualChannels;
   if (layerType === 'raster') {
     const rasterStyleType = config.visConfig.rasterStyleType;
-    if (rasterStyleType === 'rgb') {
+    if (rasterStyleType === 'Rgb') {
       return {
         channelProps: getRasterTileLayerStylePropsRgb({
           layerConfig: config,
           rasterMetadata: data.raster_metadata,
+          visualChannels,
         }),
         scales: {},
       };

--- a/src/fetch-map/parse-map.ts
+++ b/src/fetch-map/parse-map.ts
@@ -129,8 +129,8 @@ export function getLayerDescriptor({
 export function parseMap(json: any) {
   const {keplerMapConfig, datasets, token} = json;
   assert(keplerMapConfig.version === 'v1', 'Only support Kepler v1');
-  const config = keplerMapConfig.config as KeplerMapConfig;
-  const {mapState, mapStyle, popupSettings, legendSettings, visState} = config;
+  const mapConfig = keplerMapConfig.config as KeplerMapConfig;
+  const {mapState, mapStyle, popupSettings, legendSettings, visState} = mapConfig;
   const {layers} = visState;
 
   const layersReverse = [...layers].reverse();
@@ -154,8 +154,8 @@ export function parseMap(json: any) {
         );
         assert(dataset, `No dataset matching dataId: ${dataId}`);
         const layerDescriptor = getLayerDescriptor({
-          mapConfig: keplerMapConfig,
-          layer: layer,
+          mapConfig,
+          layer,
           dataset,
         });
         return layerDescriptor;

--- a/src/fetch-map/parse-map.ts
+++ b/src/fetch-map/parse-map.ts
@@ -36,7 +36,7 @@ import {
   getRasterTileLayerStylePropsRgb,
   getRasterTileLayerStylePropsScaledBand,
 } from './raster-layer.js';
-import type { TilejsonResult } from '../sources/types.js';
+import type {TilejsonResult} from '../sources/types.js';
 
 export type Scale = {
   field: VisualChannelField;

--- a/src/fetch-map/parse-map.ts
+++ b/src/fetch-map/parse-map.ts
@@ -75,6 +75,7 @@ export function parseMap(json: any) {
   const {filters, mapState, mapStyle, popupSettings, legendSettings} = config;
   const {layers, layerBlending, interactionConfig} = config.visState;
 
+  const layersReverse = [...layers].reverse()
   return {
     id: json.id,
     title: json.title,
@@ -87,8 +88,7 @@ export function parseMap(json: any) {
     popupSettings,
     legendSettings,
     token,
-    layers: layers
-      .reverse()
+    layers: layersReverse
       .map(({id, type, config, visualChannels}: MapConfigLayer) => {
         try {
           const {dataId} = config;

--- a/src/fetch-map/parse-map.ts
+++ b/src/fetch-map/parse-map.ts
@@ -320,7 +320,7 @@ function createChannelProps(
       data
     );
     result.getFillColor = accessor;
-    scales.fillColor = updateTriggers.fillColor = {
+    scales.fillColor = updateTriggers.getFillColor = {
       field: colorField,
       type: colorScale!,
       ...domainAndRangeFromScale(scale),

--- a/src/fetch-map/raster-layer.ts
+++ b/src/fetch-map/raster-layer.ts
@@ -377,6 +377,9 @@ export function domainFromRasterMetadataBand(
   }
   if (scaleType === 'custom') {
     if (colorRange.uiCustomScaleType === 'logarithmic') {
+      if (colorRange.colorMap) {
+        return colorRange.colorMap?.map(([value]) => value) || [];
+      }
       return [band.stats.min, band.stats.max];
     } else {
       // actually custom, read colorMap
@@ -449,6 +452,33 @@ export function getRasterTileLayerStylePropsScaledBand({
       visualChannels,
     }),
   };
+}
+
+export function getRasterTileLayerStyleProps({
+  layerConfig,
+  visualChannels,
+  rasterMetadata,
+}: {
+  layerConfig: MapLayerConfig;
+  visualChannels: VisualChannels;
+  rasterMetadata: RasterMetadata;
+}) {
+  const {visConfig} = layerConfig;
+  const {rasterStyleType} = visConfig;
+
+  if (rasterStyleType === 'Rgb') {
+    return getRasterTileLayerStylePropsRgb({
+      layerConfig,
+      rasterMetadata,
+      visualChannels,
+    });
+  } else {
+    return getRasterTileLayerStylePropsScaledBand({
+      layerConfig,
+      rasterMetadata,
+      visualChannels,
+    });
+  }
 }
 
 export function getRasterTileLayerUpdateTriggers({

--- a/src/fetch-map/raster-layer.ts
+++ b/src/fetch-map/raster-layer.ts
@@ -382,7 +382,7 @@ export function domainFromRasterMetadataBand(
         min: band.stats.min,
         max: band.stats.max,
         steps: colorRange.colors.length,
-      }) as number[];
+      });
     } else {
       // actually custom, read colorMap
       return colorRange.colorMap?.map(([value]) => value) || [];

--- a/src/fetch-map/raster-layer.ts
+++ b/src/fetch-map/raster-layer.ts
@@ -13,6 +13,7 @@ import type {
   VisualChannels,
 } from './types.js';
 import {createColorScale, type ScaleType} from './layer-map.js';
+import {getLog10ScaleSteps} from './utils.js';
 
 const UNKNOWN_COLOR = [134, 141, 145];
 
@@ -377,10 +378,11 @@ export function domainFromRasterMetadataBand(
   }
   if (scaleType === 'custom') {
     if (colorRange.uiCustomScaleType === 'logarithmic') {
-      if (colorRange.colorMap) {
-        return colorRange.colorMap?.map(([value]) => value) || [];
-      }
-      return [band.stats.min, band.stats.max];
+      return getLog10ScaleSteps({
+        min: band.stats.min,
+        max: band.stats.max,
+        steps: colorRange.colors.length,
+      }) as number[];
     } else {
       // actually custom, read colorMap
       return colorRange.colorMap?.map(([value]) => value) || [];

--- a/src/fetch-map/raster-layer.ts
+++ b/src/fetch-map/raster-layer.ts
@@ -1,0 +1,449 @@
+import type {RasterMetadata, RasterMetadataBand} from '@carto/api-client';
+
+import {
+  createVecExprEvaluator,
+  type VecExprResult,
+  type VecExprVecLike,
+} from './vec-expr-evaluator.js';
+import type {
+  ColorBand,
+  ColorRange,
+  MapLayerConfig,
+  RasterLayerConfigColorBand,
+  VisualChannels,
+} from './types.js';
+import {createColorScale, type ScaleType} from './layer-map.js';
+
+const RASTER_COLOR_BANDS = ['red', 'green', 'blue'] as const;
+
+function getHasDataPredicate(noData: number | string | undefined) {
+  if (noData === 'nan') {
+    return (v: number) => !isNaN(v);
+  }
+  if (typeof noData === 'string') {
+    noData = parseFloat(noData);
+  }
+  if (typeof noData === 'number') {
+    return (v: number) => v !== noData && !isNaN(v);
+  }
+
+  return () => true;
+}
+
+// this is data as seen in RasterLayer
+type RasterLayerData = {
+  blockSize: number;
+  cells: BinaryDataCells;
+};
+
+// this is data as seen in RasterColumnLayer - the one that actually renders pixels
+// (binary data is just wrapped)
+type RasterColumnLayerData = {
+  length: number; // number of pixels
+  data: RasterLayerData;
+
+  // used to store buffers directly to be used by deck.gl, so we can skip accessors
+  attributes?: Record<string, ArrayLike<number>>;
+
+  // temporary storage for expression results filled in dataTransform
+  expressionEvalContext?: Record<string, ArrayLike<number>>;
+  customExpressionResults?: Record<string, VecExprResult>;
+};
+
+type BinaryDataCells = {
+  numericProps: Record<string, {value: VecExprVecLike}>;
+};
+
+function createRasterColumnLayerDataTransform(
+  transform: (dataWrapped: RasterColumnLayerData) => RasterColumnLayerData
+) {
+  return (data: RasterLayerData | RasterColumnLayerData) => {
+    if (!data || !('data' in data) || !data?.data?.cells?.numericProps) {
+      // we're in RasterLayer, or we've got invalid data
+      return data as RasterLayerData;
+    }
+    // we only transform data when in RasterColumnLayer
+    return transform(data);
+  };
+}
+
+function createEvaluationContext(
+  numericProps: Record<string, {value: VecExprVecLike}>,
+  noData: number | string | undefined
+) {
+  // Optimization note
+  // Seems like Array.from(256k+typed array takes even 15ms), so _we_ can afford to copy the array if we really don't need it to
+  // only copy values to array only if we really see nodata in all bands
+  const hasData = getHasDataPredicate(noData);
+  const bands = Object.entries(numericProps).map(([bandName, {value}]) => ({
+    bandName,
+    values: value,
+    copied: false,
+  }));
+
+  const length = bands[0].values.length;
+
+  for (let i = 0; i < length; i++) {
+    let hasSomeData = false;
+    for (let j = 0; j < bands.length; j++) {
+      hasSomeData = hasSomeData || hasData(bands[j].values[i]);
+    }
+    if (!hasSomeData) {
+      for (let j = 0; j < bands.length; j++) {
+        if (!bands[j].copied) {
+          bands[j].copied = true;
+          bands[j].values = Array.from(bands[j].values);
+        }
+        bands[j].values[i] = NaN;
+      }
+    }
+  }
+
+  const context = bands.reduce(
+    (agg, {bandName, values}) => {
+      agg[bandName] = values;
+      return agg;
+    },
+    {} as Record<string, ArrayLike<number>>
+  );
+  return context;
+}
+
+function createExprDataTransform({
+  colorBand,
+  rasterMetadata,
+  usedSymbols,
+}: {
+  colorBand: RasterLayerConfigColorBand | null | undefined;
+  rasterMetadata: RasterMetadata;
+  usedSymbols: string[];
+}) {
+  if (!colorBand || !colorBand.type || colorBand.type === 'none') {
+    return undefined;
+  }
+
+  const expr = colorBand?.type === 'expression' ? colorBand.value : undefined;
+  const vecExprEvaluator = expr ? createVecExprEvaluator(expr) : undefined;
+
+  const dataTransform = createRasterColumnLayerDataTransform(
+    (dataWrapped: RasterColumnLayerData) => {
+      const data = dataWrapped.data;
+      if (expr) {
+        const cachedResult = dataWrapped.customExpressionResults?.[expr];
+        if (cachedResult) {
+          return dataWrapped;
+        }
+      }
+
+      let context = dataWrapped.expressionEvalContext;
+      if (!context) {
+        const usedNumericProps = usedSymbols.reduce(
+          (acc, symbol) => {
+            acc[symbol] = data.cells.numericProps[symbol];
+            return acc;
+          },
+          {} as Record<string, {value: VecExprVecLike}>
+        );
+        context = createEvaluationContext(
+          usedNumericProps,
+          rasterMetadata.nodata
+        );
+        dataWrapped = {
+          ...dataWrapped,
+          expressionEvalContext: context,
+        };
+      }
+
+      if (!vecExprEvaluator || !expr) return dataWrapped;
+
+      const evalResult = vecExprEvaluator(context);
+      return {
+        ...dataWrapped,
+        customExpressionResults: {
+          ...dataWrapped.customExpressionResults,
+          [expr]: evalResult,
+        },
+      };
+    }
+  );
+  return dataTransform;
+}
+
+function combineDataTransforms<T>(
+  dataTransforms: (((data: T) => T) | undefined)[]
+): ((data: T) => T) | undefined {
+  const actualTransforms = dataTransforms.filter((v) => v) as ((
+    data: T
+  ) => T)[];
+
+  if (actualTransforms.length === 0) return undefined;
+  if (actualTransforms.length === 1) return actualTransforms[0];
+
+  return (data: T) =>
+    actualTransforms.reduce(
+      (aggData, transformFun) => transformFun(aggData),
+      data
+    );
+}
+
+function createRgbToColorBufferDataTransform({
+  bandDefs,
+  attribute,
+}: {
+  bandDefs: Partial<Record<ColorBand, RasterLayerConfigColorBand>>;
+  attribute: string;
+}) {
+  return createRasterColumnLayerDataTransform(
+    (dataWrapped: RasterColumnLayerData) => {
+      const length = dataWrapped.length;
+
+      const getBandBufferOrValue = (colorBand?: RasterLayerConfigColorBand) => {
+        if (colorBand?.type === 'expression') {
+          return dataWrapped.customExpressionResults?.[colorBand.value];
+        }
+        if (colorBand?.type === 'band') {
+          // we could use original band, but this one is already cleared from nodata if needed
+          return dataWrapped.expressionEvalContext?.[colorBand.value];
+        }
+        return 0;
+      };
+
+      const red = getBandBufferOrValue(bandDefs.red);
+      const green = getBandBufferOrValue(bandDefs.green);
+      const blue = getBandBufferOrValue(bandDefs.blue);
+
+      const colorBuffer = new Uint8Array(length * 4);
+      for (
+        let inputIndex = 0, outputIndex = 0;
+        inputIndex < length;
+        inputIndex++, outputIndex += 4
+      ) {
+        const redRaw =
+          typeof red === 'number' ? red : red ? red[inputIndex] : NaN;
+        const greenRaw =
+          typeof green === 'number' ? green : green ? green[inputIndex] : NaN;
+        const blueRaw =
+          typeof blue === 'number' ? blue : blue ? blue[inputIndex] : NaN;
+
+        if (isNaN(redRaw) && isNaN(greenRaw) && isNaN(blueRaw)) {
+          // skip pixel
+          bufferSetRgba(colorBuffer, outputIndex, 0, 0, 0, 0);
+        } else {
+          bufferSetRgba(
+            colorBuffer,
+            outputIndex,
+            redRaw,
+            greenRaw,
+            blueRaw,
+            255
+          );
+        }
+      }
+
+      // clear cached buffers
+      // This transform is applied last -after expression & band evaluators which store and
+      // cache values for _this_ transform.
+      // Now,  _assuming_ this is last transform we can clear those buffers.
+      dataWrapped.customExpressionResults = undefined;
+      dataWrapped.expressionEvalContext = undefined;
+
+      return {
+        ...dataWrapped,
+        attributes: {
+          [attribute]: colorBuffer,
+        },
+      };
+    }
+  );
+}
+
+function getUsedSymbols(colorBands: RasterLayerConfigColorBand[]) {
+  return Array.from(
+    colorBands.reduce((symbols, band) => {
+      if (band.type === 'expression') {
+        const expressionSymbols =
+          createVecExprEvaluator(band.value)?.symbols || [];
+        expressionSymbols.forEach((symbol) => symbols.add(symbol));
+      }
+      if (band.type === 'band') {
+        symbols.add(band.value);
+      }
+      return symbols;
+    }, new Set<string>())
+  );
+}
+
+export function getRasterTileLayerStylePropsRgb({
+  layerConfig,
+  rasterMetadata,
+}: {
+  layerConfig: MapLayerConfig;
+  rasterMetadata: RasterMetadata;
+}) {
+  const {visConfig} = layerConfig;
+  const {colorBands} = visConfig;
+
+  const bandDefs = {
+    red: colorBands?.find((band) => band.band === 'red'),
+    green: colorBands?.find((band) => band.band === 'green'),
+    blue: colorBands?.find((band) => band.band === 'blue'),
+  };
+
+  const rgbToInstanceFillColorsDataTransform =
+    createRgbToColorBufferDataTransform({
+      bandDefs,
+      attribute: 'instanceFillColors',
+    });
+
+  const usedSymbols = colorBands ? getUsedSymbols(colorBands) : [];
+  const bandTransforms = RASTER_COLOR_BANDS.map((band) =>
+    createExprDataTransform({
+      colorBand: bandDefs[band],
+      rasterMetadata,
+      usedSymbols,
+    })
+  );
+  const combinedDataTransform = combineDataTransforms([
+    ...bandTransforms,
+    rgbToInstanceFillColorsDataTransform,
+  ]);
+
+  return {
+    dataTransform: combinedDataTransform as () => any,
+  };
+}
+
+function createBandColorScaleDataTransform({
+  bandName,
+  scaleFun,
+  nodata,
+  attribute,
+}: {
+  bandName: string;
+  scaleFun: (v: number) => number[];
+  nodata: number | string | undefined;
+  attribute: string;
+}) {
+  const hasData = getHasDataPredicate(nodata);
+
+  return createRasterColumnLayerDataTransform(
+    (dataWrapped: RasterColumnLayerData) => {
+      const length = dataWrapped.length;
+      const bandBuffer = dataWrapped.data.cells.numericProps[bandName].value;
+      const colorBuffer = new Uint8Array(length * 4);
+
+      for (let i = 0; i < length; i++) {
+        const rawValue = bandBuffer[i];
+        if (!hasData(rawValue)) {
+          // skip pixel
+          bufferSetRgba(colorBuffer, i * 4, 0, 0, 0, 0);
+        } else {
+          const colorRgb = scaleFun(rawValue);
+          bufferSetRgba(
+            colorBuffer,
+            i * 4,
+            colorRgb[0],
+            colorRgb[1],
+            colorRgb[2],
+            255
+          );
+        }
+      }
+      return {
+        ...dataWrapped,
+        attributes: {
+          [attribute]: colorBuffer,
+        },
+      };
+    }
+  );
+}
+
+export function domainFromRasterMetadataBand(
+  band: RasterMetadataBand,
+  scaleType: ScaleType,
+  colorRange: ColorRange
+) {
+  if (scaleType === 'ordinal') {
+    return colorRange.colorMap?.map(([value]) => value) || [];
+  }
+  if (scaleType === 'custom') {
+    if (colorRange.uiCustomScaleType === 'logarithmic') {
+      return [band.stats.min, band.stats.max];
+    } else {
+      // actually custom, read colorMap
+      return colorRange.colorMap?.map(([value]) => value) || [];
+    }
+  }
+  const scaleLength = colorRange.colors.length;
+  if (scaleType === 'quantile') {
+    const quantiles = band.stats.quantiles?.[scaleLength];
+    if (!quantiles) {
+      return [0, 1];
+    }
+    return [band.stats.min, ...quantiles, band.stats.max];
+  }
+  return [band.stats.min, band.stats.max];
+}
+
+/**
+ * Get RasterLayerStyle props for ColorRange and UniqueValues modes
+ *
+ * Effectively, applies selected color scale applied to one band.
+ */
+export function getRasterTileLayerStylePropsScaledBand({
+  layerConfig,
+  rasterMetadata,
+  visualChannels,
+}: {
+  layerConfig: MapLayerConfig;
+  visualChannels: VisualChannels;
+  rasterMetadata: RasterMetadata;
+}) {
+  const {visConfig} = layerConfig;
+  const {colorField} = visualChannels;
+  const {rasterStyleType} = visConfig;
+
+  const colorRange =
+    rasterStyleType === 'colorRange'
+      ? visConfig.colorRange
+      : visConfig.uniqueValuesColorRange;
+  const scaleType =
+    rasterStyleType === 'colorRange' ? visualChannels.colorScale : 'ordinal';
+  const bandInfo = rasterMetadata.bands.find(
+    (band) => band.name === colorField?.name
+  );
+
+  if (!colorField?.name || !scaleType || !colorRange || !bandInfo) {
+    return {};
+  }
+
+  const domain = domainFromRasterMetadataBand(bandInfo, scaleType, colorRange);
+
+  const scaleFun = createColorScale(scaleType, domain, colorRange.colors);
+
+  const bandColorScaleDataTransform = createBandColorScaleDataTransform({
+    bandName: bandInfo.name,
+    scaleFun,
+    nodata: bandInfo?.nodata ?? rasterMetadata.nodata,
+    attribute: 'instanceFillColors',
+  });
+
+  return {
+    dataTransform: bandColorScaleDataTransform as () => any,
+  };
+}
+
+function bufferSetRgba(
+  target: VecExprVecLike,
+  index: number,
+  r: number,
+  g: number,
+  b: number,
+  a: number
+) {
+  target[index + 0] = r;
+  target[index + 1] = g;
+  target[index + 2] = b;
+  target[index + 3] = a;
+}

--- a/src/fetch-map/raster-layer.ts
+++ b/src/fetch-map/raster-layer.ts
@@ -1,4 +1,4 @@
-import type {RasterMetadata, RasterMetadataBand} from '@carto/api-client';
+import type {RasterMetadata, RasterMetadataBand} from '../sources/types.js';
 
 import {
   createVecExprEvaluator,
@@ -13,6 +13,8 @@ import type {
   VisualChannels,
 } from './types.js';
 import {createColorScale, type ScaleType} from './layer-map.js';
+
+const UNKNOWN_COLOR = [134, 141, 145];
 
 const RASTER_COLOR_BANDS = ['red', 'green', 'blue'] as const;
 
@@ -420,7 +422,12 @@ export function getRasterTileLayerStylePropsScaledBand({
 
   const domain = domainFromRasterMetadataBand(bandInfo, scaleType, colorRange);
 
-  const scaleFun = createColorScale(scaleType, domain, colorRange.colors);
+  const scaleFun = createColorScale(
+    scaleType,
+    domain,
+    colorRange.colors.map(hexToRGB),
+    UNKNOWN_COLOR
+  );
 
   const bandColorScaleDataTransform = createBandColorScaleDataTransform({
     bandName: bandInfo.name,
@@ -446,4 +453,12 @@ function bufferSetRgba(
   target[index + 1] = g;
   target[index + 2] = b;
   target[index + 3] = a;
+}
+
+function hexToRGB(hexColor: string): [number, number, number] {
+  const r = parseInt(hexColor.slice(1, 3), 16);
+  const g = parseInt(hexColor.slice(3, 5), 16);
+  const b = parseInt(hexColor.slice(5, 7), 16);
+
+  return [r, g, b];
 }

--- a/src/fetch-map/types.ts
+++ b/src/fetch-map/types.ts
@@ -91,7 +91,7 @@ export type VisConfig = {
   clusterLevel?: number;
   isTextVisible?: boolean;
 
-  rasterStyleType?: 'rgb' | 'colorRange' | 'uniqueValues';
+  rasterStyleType?: 'Rgb' | 'ColorRange' | 'UniqueValues';
   colorBands?: RasterLayerConfigColorBand[];
 
   uniqueValuesColorRange?: ColorRange;

--- a/src/fetch-map/types.ts
+++ b/src/fetch-map/types.ts
@@ -39,7 +39,7 @@ export type ColorRange = {
   colorMap: string[][] | undefined;
   name: string;
   type: string;
-  uiCustomScaleType?: 'logarithmic'
+  uiCustomScaleType?: 'logarithmic';
 };
 
 export type CustomMarkersRange = {
@@ -50,15 +50,13 @@ export type CustomMarkersRange = {
   othersMarker?: string;
 };
 
-
-export type ColorBand = 'red' | 'green' | 'blue' | 'alpha'
+export type ColorBand = 'red' | 'green' | 'blue' | 'alpha';
 
 export type RasterLayerConfigColorBand = {
-  band: ColorBand
-  type: 'none' | 'band' | 'expression'
-  value: string // band name or expression
-}
-
+  band: ColorBand;
+  type: 'none' | 'band' | 'expression';
+  value: string; // band name or expression
+};
 
 export type VisConfig = {
   filled?: boolean;

--- a/src/fetch-map/types.ts
+++ b/src/fetch-map/types.ts
@@ -63,7 +63,7 @@ export type VisConfig = {
   opacity?: number;
   enable3d?: boolean;
 
-  colorAggregation?: any;
+  colorAggregation?: string;
   colorRange: ColorRange;
 
   customMarkers?: boolean;
@@ -73,17 +73,17 @@ export type VisConfig = {
   radius: number;
   radiusRange?: number[];
 
-  sizeAggregation?: any;
-  sizeRange?: any;
+  sizeAggregation?: string;
+  sizeRange?: number[];
 
-  strokeColorAggregation?: any;
+  strokeColorAggregation?: string;
   strokeOpacity?: number;
   strokeColorRange?: ColorRange;
 
-  heightRange?: any;
-  heightAggregation?: any;
+  heightRange?: number[];
+  heightAggregation?: string;
 
-  weightAggregation?: any;
+  weightAggregation?: string;
 
   // type = clusterTile
   clusterLevel?: number;

--- a/src/fetch-map/types.ts
+++ b/src/fetch-map/types.ts
@@ -39,6 +39,7 @@ export type ColorRange = {
   colorMap: string[][] | undefined;
   name: string;
   type: string;
+  uiCustomScaleType?: 'logarithmic'
 };
 
 export type CustomMarkersRange = {
@@ -48,6 +49,16 @@ export type CustomMarkersRange = {
   }[];
   othersMarker?: string;
 };
+
+
+export type ColorBand = 'red' | 'green' | 'blue' | 'alpha'
+
+export type RasterLayerConfigColorBand = {
+  band: ColorBand
+  type: 'none' | 'band' | 'expression'
+  value: string // band name or expression
+}
+
 
 export type VisConfig = {
   filled?: boolean;
@@ -79,6 +90,11 @@ export type VisConfig = {
   // type = clusterTile
   clusterLevel?: number;
   isTextVisible?: boolean;
+
+  rasterStyleType?: 'rgb' | 'colorRange' | 'uniqueValues';
+  colorBands?: RasterLayerConfigColorBand[];
+
+  uniqueValuesColorRange?: ColorRange;
 };
 
 export type TextLabel = {

--- a/src/fetch-map/utils.ts
+++ b/src/fetch-map/utils.ts
@@ -85,3 +85,59 @@ export function formatDate(value: string | number | Date): string {
 export function formatTimestamp(value: string | number | Date): string {
   return String(Math.floor(new Date(value).getTime() / 1000));
 }
+
+function roundedPow10(exp: number) {
+  // Math.pow(10, less than 4) generates "0.0...009999999999999999" instead of "0.0...01"
+  // round it ...
+  const raw = Math.pow(10, exp);
+  if (exp < 0) {
+    const shift = Math.pow(10, -exp);
+    return Math.round(raw * shift) / shift;
+  }
+  return raw;
+}
+
+/**
+ * Create domain for D3 threshold scale with logarithmic steps.
+ *
+ * If min is 0, it starts with max and goes down to fill color scale.
+ * If max is Infinity, it starts with 10 and goes up to fill color scale.
+ * Othersise it starts on first power of 10 that is greater than min.
+ *
+ * Generates `steps-1` entries, as this is what d3 threshold scale expects
+ *
+ * @see https://d3js.org/d3-scale/threshold
+ */
+export function getLog10ScaleSteps({
+  min,
+  max,
+  steps,
+}: {
+  min: number;
+  max: number;
+  steps: number;
+}): number[] {
+  if (min === 0) {
+    if (max === Infinity) {
+      // count aggregations have [0, Infinity]
+      // that will yield [10, 100, 1000, ...]
+      return [...Array(steps - 1)].map((_v, i) => roundedPow10(i + 1));
+    }
+    // if stats.min = 0, we only can attempt to start from max and decrease powers until
+    // we use all color buckets ...
+    const maxLog = Math.log10(max);
+    const endExponent = Math.ceil(maxLog);
+    const startExponent = endExponent - steps + 1;
+    return [...Array(steps - 1)].map((_v, i) =>
+      roundedPow10(startExponent + i)
+    );
+  } else {
+    const minLog = Math.log10(min);
+    const startExponent =
+      Math.ceil(minLog) === minLog ? minLog + 1 : Math.ceil(minLog);
+
+    return [...Array(steps - 1)].map((_v, i) =>
+      roundedPow10(startExponent + i)
+    );
+  }
+}

--- a/src/fetch-map/vec-expr-evaluator.ts
+++ b/src/fetch-map/vec-expr-evaluator.ts
@@ -1,0 +1,373 @@
+import jsep from 'jsep';
+
+/**
+ * Create vector expresion evaluator.
+ *
+ * Used to calculate vector expressions, such as `(band_1 * 3) + band_2/2`,
+ * where `band_1` and `band_2` are arrays or typed arrays.
+ *
+ * Note that all vector operations are element-wise, in paricular `band_1 * band_2`
+ * is not "mathematical" dot or cross product, but just element-wise multiplication.
+ *
+ * Based on:
+ * - Copyright (c) 2013 Stephen Oney, http://jsep.from.so/, MIT License
+ * - Copyright (c) 2023 Don McCurdy, https://github.com/donmccurdy/expression-eval, MIT License
+ */
+export function createVecExprEvaluator(
+  expression: string | jsep.Expression
+): VecExprEvaluator | null {
+  try {
+    const parsed = compile(expression);
+    const evalFun = (context: object) => evaluate(parsed, context);
+    evalFun.symbols = getSymbols(parsed);
+    return evalFun as VecExprEvaluator;
+  } catch {
+    return null;
+  }
+}
+
+export function evaluateVecExpr(
+  expression: string | jsep.Expression,
+  context: object
+) {
+  try {
+    return createVecExprEvaluator(expression)?.(context);
+  } catch {
+    return null;
+  }
+}
+
+export enum ErrorCode {
+  InvalidSyntax,
+  UnknownIdentifier,
+}
+
+export type ValidationResult = {
+  valid: boolean;
+  errorCode?: ErrorCode;
+  errorMessage?: string;
+};
+
+export function validateVecExprSyntax(
+  expression: string | jsep.Expression,
+  context: Record<string, unknown>
+): ValidationResult {
+  let parsed: jsep.Expression;
+  try {
+    parsed = compile(expression);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } catch (e: any) {
+    return {
+      valid: false,
+      errorCode: ErrorCode.InvalidSyntax,
+      errorMessage: e && 'message' in e ? String(e.message) : String(e),
+    };
+  }
+  return validate(parsed, context);
+}
+
+export function createValidationContext(
+  validSymbols: string[]
+): Record<string, unknown> {
+  return validSymbols.reduce((acc, symbol) => {
+    acc[symbol] = 1;
+    return acc;
+  }, {});
+}
+
+export type VecExprVecLike =
+  | number[]
+  | Float32Array
+  | Float64Array
+  | Uint8Array
+  | Int8Array
+  | Int32Array
+  | Uint32Array
+  | Uint16Array
+  | Int16Array;
+
+export type VecExprResult = number | VecExprVecLike;
+
+export type VecExprEvaluator = {
+  (context: object): VecExprResult;
+
+  symbols?: string[];
+};
+
+function createResultArray(
+  typeTemplate: VecExprVecLike,
+  length: number = typeTemplate.length
+): VecExprVecLike {
+  return new Array(length);
+}
+
+function isVecLike(a: unknown): a is number[] {
+  return Array.isArray(a) || ArrayBuffer.isView(a);
+}
+
+const createBinopVec =
+  (scalarBinOp: (a: number, b: number) => number) =>
+  (left: number[], right: number[]) => {
+    const length = Math.min(left.length, right.length);
+    const r = createResultArray(left, length);
+    for (let i = 0; i < length; i++) {
+      r[i] = scalarBinOp(left[i], right[i]);
+    }
+    return r;
+  };
+
+const createBinopVecNum =
+  (scalarBinOp: (a: number, b: number) => number) =>
+  (left: number[], right: number) => {
+    const length = left.length;
+    const r = createResultArray(left, length);
+    for (let i = 0; i < length; i++) {
+      r[i] = scalarBinOp(left[i], right);
+    }
+    return r;
+  };
+
+// number vec op
+const createBinopNumVec =
+  (scalarBinOp: (a: number, b: number) => number) =>
+  (left: number, right: number[]) => {
+    const length = right.length;
+    const r = createResultArray(right, length);
+    for (let i = 0; i < length; i++) {
+      r[i] = scalarBinOp(left, right[i]);
+    }
+    return r;
+  };
+
+const createUnopVec = (scalarUnop: (a: number) => number) => (a: number[]) => {
+  const length = a.length;
+  const r = createResultArray(a, length);
+  for (let i = 0; i < length; i++) {
+    r[i] = scalarUnop(a[i]);
+  }
+  return r;
+};
+
+function mapDictValues<V, NewV>(dict: Record<string, V>, fun: (v: V) => NewV) {
+  return Object.keys(dict).reduce(
+    (acc, key) => {
+      acc[key] = fun(dict[key]);
+      return acc;
+    },
+    {} as Record<string, NewV>
+  );
+}
+
+const binopsNum: Record<string, (a: number, b: number) => number> = {
+  '||': (a: number, b: number) => a || b,
+  '&&': (a: number, b: number) => a && b,
+  '|': (a: number, b: number) => a | b,
+  '^': (a: number, b: number) => a ^ b,
+  '&': (a: number, b: number) => a & b,
+  '==': (a: number, b: number) => Number(a == b),
+  '!=': (a: number, b: number) => Number(a != b),
+  '===': (a: number, b: number) => Number(a === b),
+  '!==': (a: number, b: number) => Number(a !== b),
+  '<': (a: number, b: number) => Number(a < b),
+  '>': (a: number, b: number) => Number(a > b),
+  '<=': (a: number, b: number) => Number(a <= b),
+  '>=': (a: number, b: number) => Number(a >= b),
+  '<<': (a: number, b: number) => a << b,
+  '>>': (a: number, b: number) => a >> b,
+  '>>>': (a: number, b: number) => a >>> b,
+  '+': (a: number, b: number) => a + b,
+  '-': (a: number, b: number) => a - b,
+  '*': (a: number, b: number) => a * b,
+  '/': (a: number, b: number) => a / b,
+  '%': (a: number, b: number) => a % b,
+};
+
+const unopsNum = {
+  '-': (a: number) => -a,
+  '+': (a: number) => +a,
+  '~': (a: number) => ~a,
+  '!': (a: number) => Number(!a),
+};
+
+const binopsVector = mapDictValues(binopsNum, createBinopVec);
+const binopsNumVec = mapDictValues(binopsNum, createBinopNumVec);
+const binopsVecNum = mapDictValues(binopsNum, createBinopVecNum);
+
+const unopsVector = mapDictValues(unopsNum, createUnopVec);
+
+function getBinop(operator: string, left: VecExprResult, right: VecExprResult) {
+  const isLeftVec = isVecLike(left);
+  const isRightVec = isVecLike(right);
+  if (isLeftVec && isRightVec) {
+    return binopsVector[operator];
+  } else if (isLeftVec) {
+    return binopsVecNum[operator];
+  } else if (isRightVec) {
+    return binopsNumVec[operator];
+  } else {
+    return binopsNum[operator];
+  }
+}
+
+type AnyExpression =
+  | jsep.ArrayExpression
+  | jsep.BinaryExpression
+  | jsep.MemberExpression
+  | jsep.CallExpression
+  | jsep.ConditionalExpression
+  | jsep.Identifier
+  | jsep.Literal
+  | jsep.LogicalExpression
+  | jsep.ThisExpression
+  | jsep.UnaryExpression;
+
+export function evaluate(_node: jsep.Expression, context: object) {
+  const node = _node as AnyExpression;
+
+  switch (node.type) {
+    case 'BinaryExpression': {
+      const left = evaluate(node.left, context);
+      const right = evaluate(node.right, context);
+      const binopFun = getBinop(node.operator, left, right);
+
+      return binopFun(left, right);
+    }
+
+    case 'ConditionalExpression': {
+      const val = evaluate(node.test, context);
+      if (isVecLike(val)) {
+        const length = val.length;
+        const consequentVal = evaluate(node.consequent, context);
+        const alternateVal = evaluate(node.alternate, context);
+        const r = createResultArray(val);
+        for (let i = 0; i < length; i++) {
+          const entryVal = val[i] ? consequentVal : alternateVal;
+          r[i] = isVecLike(entryVal) ? (entryVal[i] ?? NaN) : entryVal;
+        }
+        return r;
+      } else {
+        return val
+          ? evaluate(node.consequent, context)
+          : evaluate(node.alternate, context);
+      }
+    }
+
+    case 'Identifier':
+      return context[node.name];
+
+    case 'Literal':
+      return node.value;
+
+    case 'LogicalExpression': {
+      const left = evaluate(node.left, context);
+      const right = evaluate(node.right, context);
+      const binopFun = getBinop(node.operator, left, right);
+      return binopFun(left, right);
+    }
+
+    case 'UnaryExpression': {
+      const val = evaluate(node.argument, context);
+      const unopFun = isVecLike(val)
+        ? unopsVector[node.operator]
+        : unopsNum[node.operator];
+      return unopFun(val);
+    }
+
+    default:
+      return undefined;
+  }
+}
+
+const validResult = {valid: true};
+
+function visit(_node: jsep.Expression, visitor: (node: AnyExpression) => void) {
+  const node = _node as AnyExpression;
+
+  visitor(node);
+  switch (node.type) {
+    case 'BinaryExpression': {
+      visit(node.left, visitor);
+      visit(node.right, visitor);
+      break;
+    }
+
+    case 'ConditionalExpression': {
+      visit(node.test, visitor);
+      visit(node.consequent, visitor);
+      visit(node.alternate, visitor);
+      break;
+    }
+
+    case 'LogicalExpression': {
+      visit(node.left, visitor);
+      visit(node.right, visitor);
+      break;
+    }
+
+    case 'UnaryExpression': {
+      visit(node.argument, visitor);
+      break;
+    }
+  }
+}
+
+const supportedExpressionTypes = [
+  'BinaryExpression',
+  'UnaryExpression',
+  'ConditionalExpression',
+  'LogicalExpression',
+  'Identifier',
+  'Literal',
+];
+
+function validate(_node: jsep.Expression, context: object): ValidationResult {
+  const node = _node as AnyExpression;
+
+  const errors: ValidationResult[] = [];
+
+  visit(node, (node) => {
+    if (!supportedExpressionTypes.includes(node.type)) {
+      errors.push({
+        valid: false,
+        errorCode: ErrorCode.InvalidSyntax,
+        errorMessage: `Not allowed`,
+      });
+      return;
+    }
+    if (node.type === 'Identifier') {
+      if (!Object.prototype.hasOwnProperty.call(context, node.name)) {
+        return errors.push({
+          valid: false,
+          errorCode: ErrorCode.UnknownIdentifier,
+          errorMessage: `"${node.name}" not found`,
+        });
+      }
+    }
+    if (node.type === 'Literal') {
+      // we actually support only numbers
+      if (typeof node.value !== 'number') {
+        return errors.push({
+          valid: false,
+          errorCode: ErrorCode.InvalidSyntax,
+          errorMessage: `Only number literals are supported`,
+        });
+      }
+    }
+  });
+  return errors.length ? errors[0] : validResult;
+}
+
+function getSymbols(node: jsep.Expression): string[] {
+  const symbols = new Set<string>();
+
+  visit(node, (node) => {
+    if (node.type === 'Identifier') {
+      symbols.add(node.name);
+    }
+  });
+  return Array.from(symbols);
+}
+
+export function compile(expression: string | jsep.Expression) {
+  return jsep(expression);
+}

--- a/src/fetch-map/vec-expr-evaluator.ts
+++ b/src/fetch-map/vec-expr-evaluator.ts
@@ -55,7 +55,6 @@ export function validateVecExprSyntax(
   let parsed: jsep.Expression;
   try {
     parsed = compile(expression);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } catch (e: any) {
     return {
       valid: false,

--- a/src/fetch-map/vec-expr-evaluator.ts
+++ b/src/fetch-map/vec-expr-evaluator.ts
@@ -66,18 +66,6 @@ export function validateVecExprSyntax(
   return validate(parsed, context);
 }
 
-export function createValidationContext(
-  validSymbols: string[]
-): Record<string, unknown> {
-  return validSymbols.reduce(
-    (acc, symbol) => {
-      acc[symbol] = 1;
-      return acc;
-    },
-    {} as Record<string, unknown>
-  );
-}
-
 export type VecExprVecLike =
   | number[]
   | Float32Array

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ export type {
 } from './fetch-map/index.js';
 export {
   createVecExprEvaluator as _createVecExprEvaluator,
+  evaluateVecExpr as _evaluateVecExpr,
   validateVecExprSyntax as _validateVecExprSyntax,
   type VecExprResult as _VecExprResult,
   ErrorCode as _ErrorCode,

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,11 @@ export * from './client.js';
 export * from './constants.js';
 export * from './deck/index.js';
 export * from './fetch-map/index.js';
-export type {LayerDescriptor, LayerType} from './fetch-map/index.js';
+export type {
+  LayerDescriptor,
+  LayerType,
+  _getRasterTileLayerStyleProps,
+} from './fetch-map/index.js';
 export {
   createVecExprEvaluator as _createVecExprEvaluator,
   validateVecExprSyntax as _validateVecExprSyntax,

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,11 +2,6 @@ export * from './client.js';
 export * from './constants.js';
 export * from './deck/index.js';
 export * from './fetch-map/index.js';
-export type {
-  LayerDescriptor,
-  LayerType,
-  _getRasterTileLayerStyleProps,
-} from './fetch-map/index.js';
 export {
   createVecExprEvaluator as _createVecExprEvaluator,
   evaluateVecExpr as _evaluateVecExpr,

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,12 @@ export * from './constants.js';
 export * from './deck/index.js';
 export * from './fetch-map/index.js';
 export type {LayerDescriptor, LayerType} from './fetch-map/index.js';
+export {
+  createVecExprEvaluator as _createVecExprEvaluator,
+  validateVecExprSyntax as _validateVecExprSyntax,
+  type VecExprResult as _VecExprResult,
+  ErrorCode as _ErrorCode,
+} from './fetch-map/vec-expr-evaluator.js';
 export * from './filters.js';
 export * from './geo.js';
 export * from './sources/index.js';

--- a/src/sources/types.ts
+++ b/src/sources/types.ts
@@ -292,14 +292,64 @@ export interface Tilestats {
 
 export interface Layer {
   layer: string;
+  /** Number of features in the layer. */
   count: number;
+
+  /** Number of attributes in the layer. */
   attributeCount: number;
   attributes: Attribute[];
+
+  /** Type of geometry as in geojson geometry type (Point, LineString, Polygon, etc.) */
+  geometry?: string;
+}
+
+export interface AttributeCategoryItem {
+  category: string;
+  frequency: number;
+}
+
+/**
+ * Quantiles by number of buckets.
+ *
+ * Example:
+ * ```ts
+ *   {
+ *     // for 3 buckets, first 1/3 of items lies in range [min, 20], second 1/3 is in [20, 40], and last 1/3 is in [40, max]
+ *     3: [20, 40],
+ *     4: [20, 30, 50], for 4 buckets ...
+ *   }
+ * ```
+ */
+export interface QuantileStats {
+  [bucketCount: number]: number[];
 }
 
 export interface Attribute {
-  attribute: string;
+  /**
+   * String, Number, Timestamp, Boolean
+   */
   type: string;
+
+  /**
+   * Attribute name.
+   */
+  attribute: string;
+
+  // Stats for numeric attributes
+  min?: number;
+  max?: number;
+  sum?: number;
+
+  /** Quantiles by number of buckets */
+  quantiles?:
+    | {
+        // Quantile stats for numeric attributes in static spatial index tilesets are enclosed in extra global object
+        global: QuantileStats;
+      }
+    | QuantileStats;
+
+  // Stats for string/boolean attributes
+  categories?: AttributeCategoryItem[];
 }
 
 export interface VectorLayer {
@@ -325,17 +375,8 @@ export type RasterMetadataBandStats = {
 
   /**
    * Quantiles by number of buckets.
-   *
-   * Example:
-   * ```ts
-   *   {
-   *     // for 3 buckets, first 1/3 of items lies in range [min, 20], second 1/3 is in [20, 40], and last 1/3 is in [40, max]
-   *     3: [20, 40],
-   *     4: [20, 30, 50], for 4 buckets ...
-   *   }
-   * ```
    */
-  quantiles?: Record<number, number[]>;
+  quantiles?: QuantileStats;
 
   /**
    * Top values by number of values.

--- a/test/fetch-map/layer-map.spec.ts
+++ b/test/fetch-map/layer-map.spec.ts
@@ -66,7 +66,7 @@ describe('layer-map', () => {
     ];
 
     test.each(COLOR_TESTS)('getColorAccessor $colorScale', (testCase) => {
-      const {accessor, scale} = getColorAccessor(
+      const {accessor, range} = getColorAccessor(
         testCase.colorField,
         testCase.colorScale,
         {range: testCase.colorRange},
@@ -74,7 +74,7 @@ describe('layer-map', () => {
         testCase.data
       );
       expect(accessor(testCase.d)).toEqual(testCase.expected);
-      expect(scale.range()).toEqual(testCase.colorRange.colors);
+      expect(range).toEqual(testCase.colorRange.colors);
     });
   });
 

--- a/test/fetch-map/raster-layer.spec.ts
+++ b/test/fetch-map/raster-layer.spec.ts
@@ -330,11 +330,6 @@ describe('getRasterTileLayerStyleProps', () => {
           colorRange: {
             ...dummyColorRange,
             colors: ['#ff0000', '#00ff00', '#0000ff'],
-            colorMap: [
-              [10, '#ff0000'],
-              [100, '#00ff00'],
-              [null, '#0000ff'],
-            ],
             uiCustomScaleType: 'logarithmic',
           },
         },

--- a/test/fetch-map/raster-layer.spec.ts
+++ b/test/fetch-map/raster-layer.spec.ts
@@ -1,0 +1,480 @@
+import {describe, it, expect} from 'vitest';
+import {
+  _getRasterTileLayerStyleProps as getRasterTileLayerStyleProps,
+  RasterMetadata,
+  RasterMetadataBandStats,
+} from '@carto/api-client';
+
+const dummyColorRange = {
+  type: 'custom',
+  category: 'carto',
+  colors: ['#ff0000', '#00ff00', '#0000ff'],
+  name: 'dummy colors',
+  colorMap: [],
+};
+
+const dummyLayerConfig = {
+  dataId: 'data',
+  visConfig: {
+    colorRange: undefined,
+    radius: 5,
+  },
+  label: '',
+  isVisible: false,
+  isConfigActive: false,
+  color: [],
+  textLabel: [],
+  columns: {},
+  colorUI: {},
+  highlightColor: [255, 128, 128, 0],
+  hidden: false,
+};
+
+const dummyStats: RasterMetadataBandStats = {
+  min: 0,
+  max: 255,
+  mean: 100,
+  stddev: 3,
+  sum: 2333,
+  sum_squares: 3322,
+  count: 1000,
+  quantiles: {
+    3: [50, 100],
+    4: [60, 110, 150],
+  },
+  top_values: {
+    0: 400,
+    1: 300,
+    2: 100,
+    3: 100,
+    25: 100,
+  },
+};
+
+const dummyRasterMetadataRgb: RasterMetadata = {
+  block_resolution: 1,
+  minresolution: 10,
+  maxresolution: 10,
+  nodata: 255,
+  bounds: [-170, -80, 170, 80],
+  center: [0, 0, 12],
+  bands: [
+    {
+      type: 'uint8',
+      name: 'band_1',
+      nodata: '255',
+      stats: dummyStats,
+      colorinterp: 'red',
+    },
+    {
+      type: 'uint8',
+      name: 'band_2',
+      nodata: '255',
+      stats: dummyStats,
+      colorinterp: 'green',
+    },
+    {
+      type: 'uint8',
+      name: 'band_3',
+      nodata: '255',
+      stats: dummyStats,
+      colorinterp: 'blue',
+    },
+  ],
+  width: 0,
+  height: 0,
+  block_width: 0,
+  block_height: 0,
+  num_blocks: 0,
+  num_pixels: 0,
+  pixel_resolution: 0,
+};
+
+const dummyRasterMetadataRandom: RasterMetadata = {
+  ...dummyRasterMetadataRgb,
+  bands: [
+    {
+      type: 'uint8',
+      name: 'band_xxx',
+      nodata: '255',
+      stats: dummyStats,
+    },
+    {
+      type: 'uint8',
+      name: 'band_yyy',
+      nodata: '255',
+      stats: dummyStats,
+    },
+  ],
+};
+
+const defaultQualitativeColor = {
+  name: 'Pastel',
+  type: 'qualitative',
+  category: 'CARTO',
+  colors: [
+    '#66C5CC',
+    '#F6CF71',
+    '#F89C74',
+    '#DCB0F2',
+    '#87C55F',
+    '#9EB9F3',
+    '#FE88B1',
+    '#C9DB74',
+    '#8BE0A4',
+    '#B497E7',
+    '#D3B484',
+    '#B3B3B3',
+  ],
+  colorMap: [],
+};
+
+describe('getRasterTileLayerStyleProps', () => {
+  const getFillColorRgba = (data, index) => {
+    const instanceFillColors = data.data.attributes?.instanceFillColors;
+    if (instanceFillColors) {
+      const bufferIndex = index * 4;
+      return [
+        instanceFillColors[bufferIndex + 0],
+        instanceFillColors[bufferIndex + 1],
+        instanceFillColors[bufferIndex + 2],
+        instanceFillColors[bufferIndex + 3],
+      ];
+    }
+    return undefined;
+  };
+
+  const getFillColorHex = (a, b) => {
+    const rgba = getFillColorRgba(a, b);
+    return rgba && rgbToHex(rgba).toUpperCase();
+  };
+
+  const runFillColorTests = (testValues, info) => {
+    testValues.forEach(({expected}, index) => {
+      const getFillColor =
+        typeof expected === 'string' ? getFillColorHex : getFillColorRgba;
+      expect(getFillColor(info, index)).toEqual(expected);
+    });
+  };
+  it('rgb', () => {
+    const {dataTransform} = getRasterTileLayerStyleProps({
+      layerConfig: {
+        ...dummyLayerConfig,
+        visConfig: {
+          ...dummyLayerConfig.visConfig,
+          rasterStyleType: 'Rgb',
+          colorBands: [
+            {band: 'red', type: 'band', value: 'band_1'},
+            {band: 'green', type: 'band', value: 'band_2'},
+            {band: 'blue', type: 'band', value: 'band_3'},
+          ],
+        },
+      },
+      rasterMetadata: dummyRasterMetadataRandom,
+      visualChannels: {},
+    });
+    const testValues = [
+      {
+        input: {band_1: 123, band_2: 33, band_3: 233, band_xxx: 0},
+        expected: [123, 33, 233, 255],
+      },
+      {
+        input: {band_1: 255, band_2: 33, band_3: 111, band_xxx: 0},
+        expected: [255, 33, 111, 255],
+      },
+
+      // feature3: all _used_ bands in given pixel are nodata -> skip pixel
+      {
+        input: {band_1: 255, band_2: 255, band_3: 255, band_xxx: 333},
+        expected: [0, 0, 0, 0],
+      },
+    ];
+
+    const info = makeWrappedObjectInfo(
+      dataTransform,
+      ...testValues.map(({input}) => input)
+    );
+
+    runFillColorTests(testValues, info);
+  });
+
+  it('rgb expressions', () => {
+    const {dataTransform} = getRasterTileLayerStyleProps({
+      layerConfig: {
+        ...dummyLayerConfig,
+        visConfig: {
+          ...dummyLayerConfig.visConfig,
+          rasterStyleType: 'Rgb',
+          colorBands: [
+            {band: 'red', type: 'expression', value: 'band_1 - 1'}, // vec - scalar
+            {band: 'green', type: 'expression', value: 'band_2 * band_1'}, // vec * vec
+            {
+              band: 'blue',
+              type: 'expression',
+              value: '(band_3 + band_2 + band_1)/3',
+            }, // parentheses + vec / scalar
+          ],
+        },
+      },
+      rasterMetadata: dummyRasterMetadataRandom,
+      visualChannels: {},
+    });
+
+    const testValues = [
+      {
+        input: {band_1: 1, band_2: 2, band_3: 3, band_xxx: 0},
+        expected: [1 - 1, 2 * 1, (3 + 2 + 1) / 3, 255],
+      },
+      {
+        input: {band_1: 10, band_2: 20, band_3: 30, band_xxx: 0},
+        expected: [10 - 1, 20 * 10, (30 + 20 + 10) / 3, 255],
+      },
+
+      // feature3: all _used_ bands in given pixel are nodata -> skip pixel
+      {
+        input: {band_1: 255, band_2: 255, band_3: 255, band_xxx: 111},
+        expected: [0, 0, 0, 0],
+      },
+    ];
+
+    const info = makeWrappedObjectInfo(
+      dataTransform,
+      ...testValues.map(({input}) => input)
+    );
+
+    runFillColorTests(testValues, info);
+  });
+
+  it('colorRange / quantile', () => {
+    const {dataTransform} = getRasterTileLayerStyleProps({
+      layerConfig: {
+        ...dummyLayerConfig,
+        visConfig: {
+          ...dummyLayerConfig.visConfig,
+          rasterStyleType: 'ColorRange',
+          colorRange: {
+            ...dummyColorRange,
+            colors: ['#ff0000', '#00ff00', '#0000ff'],
+          },
+        },
+      },
+      rasterMetadata: dummyRasterMetadataRgb,
+      visualChannels: {
+        colorScale: 'quantile',
+        colorField: {
+          name: 'band_1',
+          type: 'integer',
+        },
+      },
+    });
+
+    const testValues = [
+      {input: 40, expected: [255, 0, 0, 255]},
+      {input: 60, expected: [0, 255, 0, 255]},
+      {input: 110, expected: [0, 0, 255, 255]},
+      {input: 255, expected: [0, 0, 0, 0]}, // nodata -> transparent
+    ];
+    const info = makeWrappedObjectInfo(
+      dataTransform,
+      ...testValues.map(({input}) => ({band_1: input}))
+    );
+
+    runFillColorTests(testValues, info);
+  });
+
+  it('colorRange / quantize', () => {
+    const {dataTransform} = getRasterTileLayerStyleProps({
+      layerConfig: {
+        ...dummyLayerConfig,
+        visConfig: {
+          ...dummyLayerConfig.visConfig,
+          rasterStyleType: 'ColorRange',
+          colorRange: {
+            ...dummyColorRange,
+            colors: ['#ff0000', '#00ff00', '#0000ff'],
+          },
+        },
+      },
+      rasterMetadata: dummyRasterMetadataRgb,
+      visualChannels: {
+        colorScale: 'quantize',
+        colorField: {
+          name: 'band_1',
+          type: 'integer',
+        },
+      },
+    });
+
+    const testValues = [
+      {input: 10, expected: [255, 0, 0, 255]},
+      // { input: 123, expected: [0, 255, 0, 255] },
+
+      {input: 240, expected: [0, 0, 255, 255]},
+      {input: 255, expected: [0, 0, 0, 0]}, // nodata -> transparent
+    ];
+
+    const info = makeWrappedObjectInfo(
+      dataTransform,
+      ...testValues.map(({input}) => ({band_1: input}))
+    );
+
+    runFillColorTests(testValues, info);
+  });
+  it('colorRange / log', () => {
+    const {dataTransform} = getRasterTileLayerStyleProps({
+      layerConfig: {
+        ...dummyLayerConfig,
+        visConfig: {
+          ...dummyLayerConfig.visConfig,
+          rasterStyleType: 'ColorRange',
+          colorRange: {
+            ...dummyColorRange,
+            colors: ['#ff0000', '#00ff00', '#0000ff'],
+            colorMap: [
+              [10, '#ff0000'],
+              [100, '#00ff00'],
+              [null, '#0000ff'],
+            ],
+            uiCustomScaleType: 'logarithmic',
+          },
+        },
+      },
+      rasterMetadata: dummyRasterMetadataRgb,
+      visualChannels: {
+        colorScale: 'custom',
+        colorField: {
+          name: 'band_1',
+          type: 'integer',
+        },
+      },
+    });
+
+    const testValues = [
+      {input: 4, expected: [255, 0, 0, 255]},
+      {input: 15, expected: [0, 255, 0, 255]},
+      {input: 150, expected: [0, 0, 255, 255]},
+      {input: 255, expected: [0, 0, 0, 0]}, // nodata -> transparent
+    ];
+
+    const info = makeWrappedObjectInfo(
+      dataTransform,
+      ...testValues.map(({input}) => ({band_1: input}))
+    );
+
+    runFillColorTests(testValues, info);
+  });
+  it('uniqueValue / default', () => {
+    const {dataTransform} = getRasterTileLayerStyleProps({
+      layerConfig: {
+        ...dummyLayerConfig,
+        visConfig: {
+          ...dummyLayerConfig.visConfig,
+          rasterStyleType: 'UniqueValues',
+          uniqueValuesColorRange: {
+            ...defaultQualitativeColor,
+            colorMap: [0, 1, 2, 3, 25].map((v, i) => [
+              v,
+              defaultQualitativeColor.colors[i],
+            ]),
+          },
+        },
+      },
+      rasterMetadata: dummyRasterMetadataRgb,
+      visualChannels: {
+        colorField: {
+          name: 'band_1',
+          type: 'integer',
+        },
+      },
+    });
+
+    const testValues = [
+      {input: 0, expected: defaultQualitativeColor.colors[0]},
+      {input: 1, expected: defaultQualitativeColor.colors[1]},
+      {input: 2, expected: defaultQualitativeColor.colors[2]},
+      {input: 3, expected: defaultQualitativeColor.colors[3]},
+      {input: 25, expected: defaultQualitativeColor.colors[4]},
+      {input: 255, expected: [0, 0, 0, 0]}, // nodata -> transparent
+    ];
+
+    const info = makeWrappedObjectInfo(
+      dataTransform,
+      ...testValues.map(({input}) => ({band_1: input}))
+    );
+
+    runFillColorTests(testValues, info);
+  });
+  it('uniqueValue / custom', () => {
+    const {dataTransform} = getRasterTileLayerStyleProps({
+      layerConfig: {
+        ...dummyLayerConfig,
+        visConfig: {
+          ...dummyLayerConfig.visConfig,
+          rasterStyleType: 'UniqueValues',
+          uniqueValuesColorRange: {
+            ...dummyColorRange,
+            colorMap: [
+              [0, '#ff0000'],
+              [1, '#00ff00'],
+              [2, '#0000ff'],
+            ],
+            colors: ['#ff0000', '#00ff00', '#0000ff'],
+          },
+        },
+      },
+      rasterMetadata: dummyRasterMetadataRgb,
+      visualChannels: {
+        colorScale: 'quantile',
+        colorField: {
+          name: 'band_1',
+          type: 'integer',
+        },
+      },
+    });
+
+    const testValues = [
+      {input: 0, expected: [255, 0, 0, 255]},
+      {input: 1, expected: [0, 255, 0, 255]},
+      {input: 2, expected: [0, 0, 255, 255]},
+      {input: 255, expected: [0, 0, 0, 0]}, // nodata -> transparent
+    ];
+
+    const info = makeWrappedObjectInfo(
+      dataTransform,
+      ...testValues.map(({input}) => ({band_1: input}))
+    );
+
+    runFillColorTests(testValues, info);
+  });
+});
+
+function makeWrappedObjectInfo(
+  dataTransform,
+  ...features: Record<string, number>[]
+) {
+  const data = {
+    length: features.length,
+    data: {
+      blockSize: 1,
+      cells: {
+        numericProps: Object.entries(features[0]).reduce(
+          (agg, [key]) => ({
+            ...agg,
+            [key]: {value: new Float32Array(features.map((f) => f[key]))},
+          }),
+          {}
+        ),
+      },
+    },
+  };
+  return {
+    index: 0,
+    data: dataTransform ? dataTransform(data) : data,
+  };
+}
+
+function rgbToHex(rgbColorArray: number[]): string {
+  return `#${rgbColorArray[0].toString(16).padStart(2, '0')}${rgbColorArray[1]
+    .toString(16)
+    .padStart(2, '0')}${rgbColorArray[2].toString(16).padStart(2, '0')}`;
+}

--- a/test/fetch-map/vec-expr-evaluator.test.ts
+++ b/test/fetch-map/vec-expr-evaluator.test.ts
@@ -1,0 +1,316 @@
+import {describe, it, expect} from 'vitest';
+import {
+  _createVecExprEvaluator as createVecExprEvaluator,
+  _ErrorCode as ErrorCode,
+  _validateVecExprSyntax as validateVecExprSyntax,
+  _VecExprResult as VecExprResult,
+} from '@carto/api-client';
+
+const repeat = (n, fn) => {
+  for (let i = 0; i < n; i++) {
+    fn();
+  }
+};
+
+describe('vecExprEvaluator', () => {
+  const band_1 = [1, 2, 3, 4, 5];
+  const band_2 = [10, 10, 10, 10, 10];
+  const band_3 = [0, 1, 0, 1, 0];
+
+  const safeCreateVecExprEvaluator = (expr: string) => {
+    const evaluator = createVecExprEvaluator(expr);
+    if (!evaluator) {
+      throw new Error(`Failed to create evaluator for ${expr}`);
+    }
+    return evaluator;
+  };
+
+  describe('evaluate', () => {
+    it('works with numbers', () => {
+      expect(safeCreateVecExprEvaluator('1')({})).toEqual(1);
+      expect(safeCreateVecExprEvaluator('-23.3')({})).toEqual(-23.3);
+      expect(safeCreateVecExprEvaluator('0')({})).toEqual(0);
+    });
+    it('works vector + number expressions', () => {
+      expect(safeCreateVecExprEvaluator('band_1 + 1')({band_1})).toEqual([
+        2, 3, 4, 5, 6,
+      ]);
+      expect(safeCreateVecExprEvaluator('1 + band_1')({band_1})).toEqual([
+        2, 3, 4, 5, 6,
+      ]);
+    });
+    it('works vector + vector expressions', () => {
+      expect(safeCreateVecExprEvaluator('band_1 + band_1')({band_1})).toEqual([
+        2, 4, 6, 8, 10,
+      ]);
+      expect(safeCreateVecExprEvaluator('band_1 * band_1')({band_1})).toEqual([
+        1, 4, 9, 16, 25,
+      ]);
+      expect(
+        safeCreateVecExprEvaluator('(band_1 - 1 ) * band_1')({band_1})
+      ).toEqual([0, 2, 6, 12, 20]);
+      expect(
+        safeCreateVecExprEvaluator('band_1  / band_2')({band_1, band_2})
+      ).toEqual([0.1, 0.2, 0.3, 0.4, 0.5]);
+    });
+    it('works vector vs vector logical expressions', () => {
+      expect(
+        safeCreateVecExprEvaluator('band_3 || band_1')({band_1, band_3})
+      ).toEqual([1, 1, 3, 1, 5]);
+      expect(
+        safeCreateVecExprEvaluator('band_3 && band_2')({band_2, band_3})
+      ).toEqual([0, 10, 0, 10, 0]);
+    });
+
+    it(`uint8 arithmetic doesn't overflow`, () => {
+      // we have to ensure, we don't do math on bytes, so we don't overflow easily
+      // (83+98+93) would actually overflow and result would be bad
+      const band_1 = new Uint8Array([60, 83, 90, 86, 80, 77]);
+      const band_2 = new Uint8Array([75, 98, 105, 101, 93, 90]);
+      const band_3 = new Uint8Array([70, 93, 100, 96, 86, 83]);
+      expect(
+        safeCreateVecExprEvaluator('(band_1 + band_2 + band_3)/3')({
+          band_1,
+          band_2,
+          band_3,
+        })
+      ).toEqual(
+        Array.from(band_1).map((v, i) => {
+          return (band_1[i] + band_2[i] + band_3[i]) / 3;
+        })
+      );
+    });
+  });
+  describe('validate', () => {
+    const validResult = {valid: true};
+    it('supports basic valid literals', () => {
+      expect(validateVecExprSyntax('1', {})).toEqual(validResult);
+      expect(validateVecExprSyntax('-1', {})).toEqual(validResult);
+      expect(validateVecExprSyntax('0', {})).toEqual(validResult);
+      expect(validateVecExprSyntax('1.2', {})).toEqual(validResult);
+      expect(validateVecExprSyntax('-1.2', {})).toEqual(validResult);
+      expect(validateVecExprSyntax('1e4', {})).toEqual(validResult);
+      expect(validateVecExprSyntax('-1.5e4', {})).toEqual(validResult);
+    });
+    it('accepts known symbols', () => {
+      expect(validateVecExprSyntax('a', {a: '1'})).toEqual(validResult);
+      expect(validateVecExprSyntax('1 ? b : a', {a: 1, b: 2})).toEqual(
+        validResult
+      );
+      expect(validateVecExprSyntax('1==2 ? b : a', {a: 1, b: 2})).toEqual(
+        validResult
+      );
+    });
+    it('accepts basic arithmetics on symbols', () => {
+      const context = {band_1: true, band_2: true};
+
+      expect(validateVecExprSyntax('band_1 ? band_2 : 1', context)).toEqual(
+        validResult
+      );
+      expect(validateVecExprSyntax('(band_1 + band_2) / 2', context)).toEqual(
+        validResult
+      );
+      expect(validateVecExprSyntax('band_1 + 4', context)).toEqual(validResult);
+    });
+    it('rejects unsupported literals', () => {
+      const invalidLiteral = {
+        valid: false,
+        errorCode: ErrorCode.InvalidSyntax,
+        errorMessage: 'Only number literals are supported',
+      };
+      expect(validateVecExprSyntax('false', {})).toEqual(invalidLiteral);
+      expect(validateVecExprSyntax('true', {})).toEqual(invalidLiteral);
+      expect(validateVecExprSyntax('1 || "abc"', {a: '1'})).toEqual(
+        invalidLiteral
+      );
+      expect(validateVecExprSyntax("'abc'", {})).toEqual(invalidLiteral);
+    });
+    it('rejects unsupported globals', () => {
+      expect(validateVecExprSyntax('NaN', {})).toEqual({
+        valid: false,
+        errorCode: ErrorCode.UnknownIdentifier,
+        errorMessage: '"NaN" not found',
+      });
+      expect(validateVecExprSyntax('Math', {})).toMatchObject({valid: false});
+      expect(validateVecExprSyntax('fetch', {})).toMatchObject({valid: false});
+      expect(validateVecExprSyntax('Object', {})).toMatchObject({valid: false});
+      expect(validateVecExprSyntax('window', {})).toMatchObject({valid: false});
+      expect(validateVecExprSyntax('hasOwnProperty', {})).toMatchObject({
+        valid: false,
+      });
+    });
+    it('rejects function calls & member access', () => {
+      expect(validateVecExprSyntax('a(1)', {a: 1})).toEqual({
+        errorCode: ErrorCode.InvalidSyntax,
+        valid: false,
+        errorMessage: 'Not allowed',
+      });
+      expect(validateVecExprSyntax('a.length', {a: [1, 2, 3]})).toMatchObject({
+        valid: false,
+        errorCode: ErrorCode.InvalidSyntax,
+        errorMessage: 'Not allowed',
+      });
+    });
+    it('rejects unknown symbols', () => {
+      expect(validateVecExprSyntax('c', {a: '1'})).toEqual({
+        valid: false,
+        errorCode: ErrorCode.UnknownIdentifier,
+        errorMessage: '"c" not found',
+      });
+      expect(validateVecExprSyntax('a', {})).toEqual({
+        valid: false,
+        errorCode: ErrorCode.UnknownIdentifier,
+        errorMessage: '"a" not found',
+      });
+      expect(validateVecExprSyntax('a ? b : 1', {a: '1'})).toEqual({
+        valid: false,
+        errorCode: ErrorCode.UnknownIdentifier,
+        errorMessage: '"b" not found',
+      });
+    });
+    it('rejects totally broken syntax', () => {
+      const context = {band_1: true, band_2: true};
+      expect(validateVecExprSyntax('1 + ', context)).toEqual({
+        valid: false,
+        errorCode: ErrorCode.InvalidSyntax,
+        errorMessage: 'Expected expression after + at character 4',
+      });
+      expect(validateVecExprSyntax('band_1 + 2)', context)).toEqual({
+        valid: false,
+        errorCode: ErrorCode.InvalidSyntax,
+        errorMessage: 'Unexpected ")" at character 10',
+      });
+      expect(validateVecExprSyntax('(2 + band_1', context)).toEqual({
+        valid: false,
+        errorCode: ErrorCode.InvalidSyntax,
+        errorMessage: 'Unclosed ( at character 11',
+      });
+      expect(validateVecExprSyntax('(2band_1+', context)).toEqual({
+        valid: false,
+        errorCode: ErrorCode.InvalidSyntax,
+        errorMessage:
+          'Variable names cannot start with a number (2b) at character 2',
+      });
+    });
+  });
+
+  // const PERFTEST_REPETITIONS = 4; // repeats, by default decreased not to slow down the tests
+  const PERFTEST_REPETITIONS = 15; // repeats, with 15-20 (at least on M1) you should see actual numbers reported by vitest
+  const PERFTEST_ARRAYS_SIZE = 200000; // size of arrays
+
+  // this test shows that it was necessary to vectorize the expression evaluation
+  describe(`performance ${PERFTEST_REPETITIONS} x evaluate expr on array ${PERFTEST_ARRAYS_SIZE}`, () => {
+    const band_1 = Array.from(new Array(PERFTEST_ARRAYS_SIZE)).map(
+      (_, i) => i % 255
+    );
+    const band_2 = Array.from(new Array(PERFTEST_ARRAYS_SIZE)).map(
+      (_, i) => 255 - (i % 255)
+    );
+    const band_3 = Array.from(new Array(PERFTEST_ARRAYS_SIZE)).map(
+      (_, i) => (i % 255) / 2
+    );
+
+    const expression = '(band_1 - band_2 + band_3)/3';
+    const expectedResult = Array.from(band_1).map((v, i) => {
+      return (band_1[i] - band_2[i] + band_3[i]) / 3;
+    });
+
+    // asserts are very slow actually - like 1s on big arrays so disable them by default
+    const validateResult = false; // true
+
+    it(`vectorized`, () => {
+      let result: VecExprResult = [];
+      repeat(PERFTEST_REPETITIONS, () => {
+        result = safeCreateVecExprEvaluator(expression)({
+          band_1,
+          band_2,
+          band_3,
+        });
+      });
+
+      if (validateResult) {
+        expect(result).toEqual(expectedResult);
+      }
+    });
+    it(`non-vectorized / plain object`, () => {
+      const evaluator = safeCreateVecExprEvaluator(expression);
+      let result: number[] = [];
+      repeat(PERFTEST_REPETITIONS, () => {
+        result = new Array(PERFTEST_ARRAYS_SIZE);
+        for (let i = 0; i < PERFTEST_ARRAYS_SIZE; i++) {
+          const obj = {band_1: band_1[i], band_2: band_2[i], band_3: band_3[i]};
+          result[i] = evaluator(obj) as number;
+        }
+      });
+      if (validateResult) {
+        expect(result).toEqual(expectedResult);
+      }
+    });
+    it(`non-vectorized / reuse plain object`, () => {
+      const evaluator = safeCreateVecExprEvaluator(expression);
+      const obj = {band_1: 0, band_2: 0, band_3: 0};
+
+      let result: number[] = [];
+      repeat(PERFTEST_REPETITIONS, () => {
+        result = new Array(PERFTEST_ARRAYS_SIZE);
+        for (let i = 0; i < PERFTEST_ARRAYS_SIZE; i++) {
+          obj.band_1 = band_1[i];
+          obj.band_2 = band_2[i];
+          obj.band_3 = band_3[i];
+          result[i] = evaluator(obj) as number;
+        }
+      });
+      if (validateResult) {
+        expect(result).toEqual(expectedResult);
+      }
+    });
+    it(`non-vectorized / proxy object`, () => {
+      const evaluator = safeCreateVecExprEvaluator(expression);
+      const bands = {band_1, band_2, band_3};
+
+      let result: number[] = [];
+      repeat(PERFTEST_REPETITIONS, () => {
+        result = new Array(PERFTEST_ARRAYS_SIZE);
+        for (let i = 0; i < PERFTEST_ARRAYS_SIZE; i++) {
+          const obj = new Proxy(
+            {},
+            {
+              get(target, property) {
+                return bands[property as string][i];
+              },
+            }
+          );
+          result[i] = evaluator(obj) as number;
+        }
+      });
+      if (validateResult) {
+        expect(result).toEqual(expectedResult);
+      }
+    });
+    it(`perf: non-vectorized / reused proxy object`, () => {
+      // on M1/node20 this test shows that proxy objects are slower than plain objects
+      const evaluator = safeCreateVecExprEvaluator(expression);
+      const bands = {band_1, band_2, band_3};
+
+      let result: number[] = [];
+      let i = 0;
+      const obj = new Proxy(
+        {},
+        {
+          get(target, property) {
+            return bands[property as string][i];
+          },
+        }
+      );
+      repeat(PERFTEST_REPETITIONS, () => {
+        result = new Array(PERFTEST_ARRAYS_SIZE);
+        for (i = 0; i < PERFTEST_ARRAYS_SIZE; i++) {
+          result[i] = evaluator(obj) as number;
+        }
+      });
+      if (validateResult) {
+        expect(result).toEqual(expectedResult);
+      }
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -223,7 +223,7 @@ __metadata:
     d3-format: "npm:^3.1.0"
     d3-scale: "npm:^4.0.2"
     h3-js: "npm:^4.1.0"
-    jsep: "npm:^0.3.4"
+    jsep: "npm:^1.4.0"
     quadbin: "npm:^0.4.1-alpha.0"
   languageName: node
   linkType: soft
@@ -276,7 +276,7 @@ __metadata:
     echarts: "npm:^6.0.0"
     eslint: "npm:^9.22.0"
     h3-js: "npm:^4.1.0"
-    jsep: "npm:^0.3.4"
+    jsep: "npm:^1.4.0"
     lit: "npm:^3.2.1"
     lit-analyzer: "npm:^2.0.3"
     maplibre-gl: "npm:^5.2.0"
@@ -4245,10 +4245,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jsep@npm:^0.3.4":
-  version: 0.3.5
-  resolution: "jsep@npm:0.3.5"
-  checksum: 10c0/fb5def7a4ba1cee41d144ebdd0d477785dc84b6bc1fed6cf5169f106de980dbe363bf99cb36a450435d7fd952d22b1d76e1609aeb5c7e7cbbbdb6d15fad03614
+"jsep@npm:^1.4.0":
+  version: 1.4.0
+  resolution: "jsep@npm:1.4.0"
+  checksum: 10c0/fe60adf47e050e22eadced42514a51a15a3cf0e2d147896584486acd8ee670fc16641101b9aeb81f4aaba382043d29744b7aac41171e8106515b14f27e0c7116
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -223,6 +223,7 @@ __metadata:
     d3-format: "npm:^3.1.0"
     d3-scale: "npm:^4.0.2"
     h3-js: "npm:^4.1.0"
+    jsep: "npm:^0.3.4"
     quadbin: "npm:^0.4.1-alpha.0"
   languageName: node
   linkType: soft
@@ -275,6 +276,7 @@ __metadata:
     echarts: "npm:^6.0.0"
     eslint: "npm:^9.22.0"
     h3-js: "npm:^4.1.0"
+    jsep: "npm:^0.3.4"
     lit: "npm:^3.2.1"
     lit-analyzer: "npm:^2.0.3"
     maplibre-gl: "npm:^5.2.0"
@@ -4240,6 +4242,13 @@ __metadata:
   version: 1.1.0
   resolution: "jsbn@npm:1.1.0"
   checksum: 10c0/4f907fb78d7b712e11dea8c165fe0921f81a657d3443dde75359ed52eb2b5d33ce6773d97985a089f09a65edd80b11cb75c767b57ba47391fee4c969f7215c96
+  languageName: node
+  linkType: hard
+
+"jsep@npm:^0.3.4":
+  version: 0.3.5
+  resolution: "jsep@npm:0.3.5"
+  checksum: 10c0/fb5def7a4ba1cee41d144ebdd0d477785dc84b6bc1fed6cf5169f106de980dbe363bf99cb36a450435d7fd952d22b1d76e1609aeb5c7e7cbbbdb6d15fad03614
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Extend parseMap/fetchMap with new functionality

* parseMap/fetchMap: support for raster layers configured by builder
* parseMap/fetchMap: add updateTriggers
* parseMap/fetchMap: add support for variable stroke width (fix)
* parseMap/fetchMap: expose domain (natural) and scaleDomain  (passed to d3 scale) as separate properties
* parseMap: don't mutate input (fix)
* expose getLayerDescriptor to get props of single layer
* vector expression evaluator moved here as private API (as it's prerequisite for performant raster layer rendering)
