### PR TITLE
feat(widgets): Add getAggregations() method

### DIFF
--- a/src/models/model.ts
+++ b/src/models/model.ts
@@ -24,6 +24,7 @@ const AVAILABLE_MODELS = [
   'range',
   'scatterplot',
   'table',
+  'aggregations',
 ] as const;
 
 export type Model = (typeof AVAILABLE_MODELS)[number];

--- a/src/widget-sources/types.ts
+++ b/src/widget-sources/types.ts
@@ -278,7 +278,9 @@ export type TimeSeriesResponse = {
 export type HistogramResponse = number[];
 
 /** Response from {@link WidgetRemoteSource#getAggregations}. */
-export type AggregationsResponse = Record<string, number>;
+export type AggregationsResponse = {
+  rows: Record<string, number>[];
+};
 
 /** @experimental */
 export type ExtentResponse = {bbox: BBox};

--- a/src/widget-sources/types.ts
+++ b/src/widget-sources/types.ts
@@ -207,6 +207,22 @@ export interface TimeSeriesRequestOptions extends BaseRequestOptions {
   splitByCategoryValues?: string[];
 }
 
+/**
+ * Examples:
+ *   * aggregations with array syntax
+ *      * aggregations: [{column: 'pop_high', operation: 'sum', alias: 'high_pop'}, {column: 'pop_low', operation: 'avg'}]
+ *   * aggregations with string syntax
+ *      * aggregations: 'sum(pop_high) as high_pop, avg(pop_low) as avg_low'
+ *
+ * Options for {@link WidgetRemoteSource#getAggregations}.
+ */
+export interface AggregationsRequestOptions extends BaseRequestOptions {
+  /** Aggregations to compute. Can be an array of objects or a SQL string expression. */
+  aggregations: 
+    | { column: string; operation: AggregationType; alias?: string }[]
+    | string;
+}
+
 /** @experimental */
 export type ExtentRequestOptions = BaseRequestOptions;
 
@@ -260,6 +276,9 @@ export type TimeSeriesResponse = {
 
 /** Response from {@link WidgetRemoteSource#getHistogram}. */
 export type HistogramResponse = number[];
+
+/** Response from {@link WidgetRemoteSource#getAggregations}. */
+export type AggregationsResponse = Record<string, number>;
 
 /** @experimental */
 export type ExtentResponse = {bbox: BBox};

--- a/src/widget-sources/types.ts
+++ b/src/widget-sources/types.ts
@@ -218,8 +218,12 @@ export interface TimeSeriesRequestOptions extends BaseRequestOptions {
  */
 export interface AggregationsRequestOptions extends BaseRequestOptions {
   /** Aggregations to compute. Can be an array of objects or a SQL string expression. */
-  aggregations: 
-    | { column: string; operation: Exclude<AggregationType, 'custom'>; alias?: string }[]
+  aggregations:
+    | {
+        column: string;
+        operation: Exclude<AggregationType, 'custom'>;
+        alias?: string;
+      }[]
     | string;
 }
 

--- a/src/widget-sources/types.ts
+++ b/src/widget-sources/types.ts
@@ -222,7 +222,7 @@ export interface AggregationsRequestOptions extends BaseRequestOptions {
     | {
         column: string;
         operation: Exclude<AggregationType, 'custom'>;
-        alias?: string;
+        alias: string;
       }[]
     | string;
 }

--- a/src/widget-sources/types.ts
+++ b/src/widget-sources/types.ts
@@ -283,7 +283,7 @@ export type HistogramResponse = number[];
 
 /** Response from {@link WidgetRemoteSource#getAggregations}. */
 export type AggregationsResponse = {
-  rows: Record<string, number>[];
+  rows: Record<string, number | string | null>[];
 };
 
 /** @experimental */

--- a/src/widget-sources/types.ts
+++ b/src/widget-sources/types.ts
@@ -219,7 +219,7 @@ export interface TimeSeriesRequestOptions extends BaseRequestOptions {
 export interface AggregationsRequestOptions extends BaseRequestOptions {
   /** Aggregations to compute. Can be an array of objects or a SQL string expression. */
   aggregations: 
-    | { column: string; operation: AggregationType; alias?: string }[]
+    | { column: string; operation: Exclude<AggregationType, 'custom'>; alias?: string }[]
     | string;
 }
 

--- a/src/widget-sources/widget-remote-source.ts
+++ b/src/widget-sources/widget-remote-source.ts
@@ -408,8 +408,6 @@ export abstract class WidgetRemoteSource<
       aggregations,
     } = options;
 
-    type AggregationsModelResponse = {rows: Record<string, number>[]};
-
     return executeModel({
       model: 'aggregations',
       source: {
@@ -421,7 +419,7 @@ export abstract class WidgetRemoteSource<
         aggregations,
       },
       opts: {signal, headers: this.props.headers},
-    }).then((res: AggregationsModelResponse) => ({
+    }).then((res: AggregationsResponse) => ({
       rows: res.rows.map((row) => normalizeObjectKeys(row)),
     }));
   }

--- a/src/widget-sources/widget-remote-source.ts
+++ b/src/widget-sources/widget-remote-source.ts
@@ -419,9 +419,9 @@ export abstract class WidgetRemoteSource<
         aggregations,
       },
       opts: {signal, headers: this.props.headers},
-    }).then((res: AggregationsModelResponse) => 
-      res.rows.length > 0 ? normalizeObjectKeys(res.rows[0]) : {}
-    );
+    }).then((res: AggregationsModelResponse) => ({
+      rows: res.rows.map(row => normalizeObjectKeys(row))
+    }));
   }
 
   /** @experimental */

--- a/src/widget-sources/widget-remote-source.ts
+++ b/src/widget-sources/widget-remote-source.ts
@@ -1,5 +1,7 @@
 import {executeModel, type ModelSource} from '../models/index.js';
 import type {
+  AggregationsRequestOptions,
+  AggregationsResponse,
   CategoryRequestOptions,
   CategoryResponse,
   ExtentRequestOptions,
@@ -392,6 +394,34 @@ export abstract class WidgetRemoteSource<
       rows: normalizeObjectKeys(res.rows),
       categories: res.metadata?.categories,
     }));
+  }
+
+  async getAggregations(options: AggregationsRequestOptions): Promise<AggregationsResponse> {
+    const {
+      signal,
+      filters = this.props.filters,
+      filterOwner,
+      spatialFilter,
+      spatialFiltersMode,
+      aggregations,
+    } = options;
+
+    type AggregationsModelResponse = {rows: Record<string, number>[]};
+
+    return executeModel({
+      model: 'aggregations',
+      source: {
+        ...this.getModelSource(filters, filterOwner),
+        spatialFiltersMode,
+        spatialFilter,
+      },
+      params: {
+        aggregations,
+      },
+      opts: {signal, headers: this.props.headers},
+    }).then((res: AggregationsModelResponse) => 
+      res.rows.length > 0 ? normalizeObjectKeys(res.rows[0]) : {}
+    );
   }
 
   /** @experimental */

--- a/src/widget-sources/widget-remote-source.ts
+++ b/src/widget-sources/widget-remote-source.ts
@@ -396,7 +396,9 @@ export abstract class WidgetRemoteSource<
     }));
   }
 
-  async getAggregations(options: AggregationsRequestOptions): Promise<AggregationsResponse> {
+  async getAggregations(
+    options: AggregationsRequestOptions
+  ): Promise<AggregationsResponse> {
     const {
       signal,
       filters = this.props.filters,
@@ -420,7 +422,7 @@ export abstract class WidgetRemoteSource<
       },
       opts: {signal, headers: this.props.headers},
     }).then((res: AggregationsModelResponse) => ({
-      rows: res.rows.map(row => normalizeObjectKeys(row))
+      rows: res.rows.map((row) => normalizeObjectKeys(row)),
     }));
   }
 

--- a/src/widget-sources/widget-source.ts
+++ b/src/widget-sources/widget-source.ts
@@ -1,4 +1,6 @@
 import type {
+  AggregationsRequestOptions,
+  AggregationsResponse,
   CategoryRequestOptions,
   CategoryResponse,
   ExtentRequestOptions,
@@ -126,6 +128,15 @@ export abstract class WidgetSource<
   abstract getTimeSeries(
     options: TimeSeriesRequestOptions
   ): Promise<TimeSeriesResponse>;
+
+  /**
+   * Returns multiple aggregated values computed over matching data. Suitable
+   * for aggregated statistics from pivoted tables, such as H3 tables with
+   * pre-computed aggregations across multiple columns.
+   */
+  abstract getAggregations(
+    options: AggregationsRequestOptions
+  ): Promise<AggregationsResponse>;
 
   /** @experimental */
   abstract getExtent(options?: ExtentRequestOptions): Promise<ExtentResponse>;

--- a/src/widget-sources/widget-tileset-source-impl.ts
+++ b/src/widget-sources/widget-tileset-source-impl.ts
@@ -434,7 +434,7 @@ export class WidgetTilesetSourceImpl extends WidgetSource<WidgetTilesetSourcePro
       usedAliases.add(aliasKey);
 
       const targetOperation = aggregationFunctions[operation];
-      result[aggregationKey] = targetOperation(filteredFeatures, column)
+      result[aggregationKey] = targetOperation(filteredFeatures, column);
     }
 
     return {rows: [result]};

--- a/src/widget-sources/widget-tileset-source-impl.ts
+++ b/src/widget-sources/widget-tileset-source-impl.ts
@@ -20,7 +20,7 @@ import type {
   TimeSeriesResponse,
 } from './types.js';
 import {InvalidColumnError, assert, assignOptional} from '../utils.js';
-import type {Filter, SpatialFilter, Tile} from '../types.js';
+import type {Filter, SpatialFilter, Tile, AggregationType} from '../types.js';
 
 import {
   type TileFeatureExtractOptions,
@@ -149,6 +149,9 @@ export class WidgetTilesetSourceImpl extends WidgetSource<WidgetTilesetSourcePro
       assertColumn(this._features, column);
     }
 
+    if (operation === 'custom') {
+      throw new Error(`Unsupported aggregation operation: ${operation}`);
+    }
     const targetOperation = aggregationFunctions[operation];
     return {
       value: targetOperation(filteredFeatures, column, joinOperation),
@@ -433,6 +436,9 @@ export class WidgetTilesetSourceImpl extends WidgetSource<WidgetTilesetSourcePro
       }
       usedAliases.add(aliasKey);
 
+      if (operation === 'custom') {
+        throw new Error(`Unsupported aggregation operation: ${operation}`);
+      }
       const targetOperation = aggregationFunctions[operation];
       result[aggregationKey] = targetOperation(filteredFeatures, column);
     }

--- a/src/widget-sources/widget-tileset-source-impl.ts
+++ b/src/widget-sources/widget-tileset-source-impl.ts
@@ -439,7 +439,7 @@ export class WidgetTilesetSourceImpl extends WidgetSource<WidgetTilesetSourcePro
         throw new Error(`Unsupported aggregation operation: ${operation}`);
       }
       const targetOperation = aggregationFunctions[operation];
-      result[aliasKey] = targetOperation(filteredFeatures, column);
+      result[alias] = targetOperation(filteredFeatures, column);
     }
 
     return {rows: [result]};

--- a/src/widget-sources/widget-tileset-source-impl.ts
+++ b/src/widget-sources/widget-tileset-source-impl.ts
@@ -418,11 +418,17 @@ export class WidgetTilesetSourceImpl extends WidgetSource<WidgetTilesetSourcePro
 
     // Handle array-based aggregations
     const result: Record<string, number> = {};
-    
+    const usedAliases = new Set<string>();
+
     for (const {column, operation, alias} of aggregations) {
       assertColumn(this._features, column);
       
       const aggregationKey = alias || `${operation}_${column}`;
+      const aliasKey = aggregationKey.toLowerCase();
+      if (usedAliases.has(aliasKey)) {
+        throw new Error(`Duplicate aggregation alias: ${aggregationKey}`);
+      }
+      usedAliases.add(aliasKey);
       
       if (operation === AggregationTypes.Count) {
         result[aggregationKey] = filteredFeatures.length;

--- a/src/widget-sources/widget-tileset-source-impl.ts
+++ b/src/widget-sources/widget-tileset-source-impl.ts
@@ -20,7 +20,7 @@ import type {
   TimeSeriesResponse,
 } from './types.js';
 import {InvalidColumnError, assert, assignOptional} from '../utils.js';
-import type {Filter, SpatialFilter, Tile, AggregationType} from '../types.js';
+import type {Filter, SpatialFilter, Tile} from '../types.js';
 
 import {
   type TileFeatureExtractOptions,
@@ -149,7 +149,7 @@ export class WidgetTilesetSourceImpl extends WidgetSource<WidgetTilesetSourcePro
       assertColumn(this._features, column);
     }
 
-    if (operation === 'custom') {
+    if (!(operation in aggregationFunctions)) {
       throw new Error(`Unsupported aggregation operation: ${operation}`);
     }
     const targetOperation = aggregationFunctions[operation];
@@ -436,7 +436,7 @@ export class WidgetTilesetSourceImpl extends WidgetSource<WidgetTilesetSourcePro
       }
       usedAliases.add(aliasKey);
 
-      if (operation === 'custom') {
+      if (!(operation in aggregationFunctions)) {
         throw new Error(`Unsupported aggregation operation: ${operation}`);
       }
       const targetOperation = aggregationFunctions[operation];

--- a/src/widget-sources/widget-tileset-source-impl.ts
+++ b/src/widget-sources/widget-tileset-source-impl.ts
@@ -444,7 +444,7 @@ export class WidgetTilesetSourceImpl extends WidgetSource<WidgetTilesetSourcePro
       } else if (operation === AggregationTypes.Max) {
         result[aggregationKey] = aggregationFunctions.max(filteredFeatures, column);
       } else {
-        throw new Error(`Unsupported aggregation operation: ${operation}`);
+        throw new Error(`Unsupported aggregation operation: ${String(operation)}`);
       }
     }
 

--- a/src/widget-sources/widget-tileset-source-impl.ts
+++ b/src/widget-sources/widget-tileset-source-impl.ts
@@ -425,26 +425,40 @@ export class WidgetTilesetSourceImpl extends WidgetSource<WidgetTilesetSourcePro
       if ((column && column !== '*') || operation !== AggregationTypes.Count) {
         assertColumn(this._features, column);
       }
-      
+
       const aggregationKey = alias || `${operation}_${column}`;
       const aliasKey = aggregationKey.toLowerCase();
       if (usedAliases.has(aliasKey)) {
         throw new Error(`Duplicate aggregation alias: ${aggregationKey}`);
       }
       usedAliases.add(aliasKey);
-      
+
       if (operation === AggregationTypes.Count) {
         result[aggregationKey] = filteredFeatures.length;
       } else if (operation === AggregationTypes.Sum) {
-        result[aggregationKey] = aggregationFunctions.sum(filteredFeatures, column);
+        result[aggregationKey] = aggregationFunctions.sum(
+          filteredFeatures,
+          column
+        );
       } else if (operation === AggregationTypes.Avg) {
-        result[aggregationKey] = aggregationFunctions.avg(filteredFeatures, column);
+        result[aggregationKey] = aggregationFunctions.avg(
+          filteredFeatures,
+          column
+        );
       } else if (operation === AggregationTypes.Min) {
-        result[aggregationKey] = aggregationFunctions.min(filteredFeatures, column);
+        result[aggregationKey] = aggregationFunctions.min(
+          filteredFeatures,
+          column
+        );
       } else if (operation === AggregationTypes.Max) {
-        result[aggregationKey] = aggregationFunctions.max(filteredFeatures, column);
+        result[aggregationKey] = aggregationFunctions.max(
+          filteredFeatures,
+          column
+        );
       } else {
-        throw new Error(`Unsupported aggregation operation: ${String(operation)}`);
+        throw new Error(
+          `Unsupported aggregation operation: ${String(operation)}`
+        );
       }
     }
 

--- a/src/widget-sources/widget-tileset-source-impl.ts
+++ b/src/widget-sources/widget-tileset-source-impl.ts
@@ -421,7 +421,10 @@ export class WidgetTilesetSourceImpl extends WidgetSource<WidgetTilesetSourcePro
     const usedAliases = new Set<string>();
 
     for (const {column, operation, alias} of aggregations) {
-      assertColumn(this._features, column);
+      // Column is required except when operation is 'count'.
+      if ((column && column !== '*') || operation !== AggregationTypes.Count) {
+        assertColumn(this._features, column);
+      }
       
       const aggregationKey = alias || `${operation}_${column}`;
       const aliasKey = aggregationKey.toLowerCase();

--- a/src/widget-sources/widget-tileset-source-impl.ts
+++ b/src/widget-sources/widget-tileset-source-impl.ts
@@ -433,33 +433,8 @@ export class WidgetTilesetSourceImpl extends WidgetSource<WidgetTilesetSourcePro
       }
       usedAliases.add(aliasKey);
 
-      if (operation === AggregationTypes.Count) {
-        result[aggregationKey] = filteredFeatures.length;
-      } else if (operation === AggregationTypes.Sum) {
-        result[aggregationKey] = aggregationFunctions.sum(
-          filteredFeatures,
-          column
-        );
-      } else if (operation === AggregationTypes.Avg) {
-        result[aggregationKey] = aggregationFunctions.avg(
-          filteredFeatures,
-          column
-        );
-      } else if (operation === AggregationTypes.Min) {
-        result[aggregationKey] = aggregationFunctions.min(
-          filteredFeatures,
-          column
-        );
-      } else if (operation === AggregationTypes.Max) {
-        result[aggregationKey] = aggregationFunctions.max(
-          filteredFeatures,
-          column
-        );
-      } else {
-        throw new Error(
-          `Unsupported aggregation operation: ${String(operation)}`
-        );
-      }
+      const targetOperation = aggregationFunctions[operation];
+      result[aggregationKey] = targetOperation(filteredFeatures, column)
     }
 
     return {rows: [result]};

--- a/src/widget-sources/widget-tileset-source-impl.ts
+++ b/src/widget-sources/widget-tileset-source-impl.ts
@@ -406,7 +406,7 @@ export class WidgetTilesetSourceImpl extends WidgetSource<WidgetTilesetSourcePro
     );
 
     if (!this._features.length) {
-      return {};
+      return {rows: []};
     }
 
     // Handle string-based aggregations
@@ -445,7 +445,7 @@ export class WidgetTilesetSourceImpl extends WidgetSource<WidgetTilesetSourcePro
       }
     }
 
-    return result;
+    return {rows: [result]};
   }
 
   /** @experimental */

--- a/src/widget-sources/widget-tileset-source-impl.ts
+++ b/src/widget-sources/widget-tileset-source-impl.ts
@@ -429,10 +429,9 @@ export class WidgetTilesetSourceImpl extends WidgetSource<WidgetTilesetSourcePro
         assertColumn(this._features, column);
       }
 
-      const aggregationKey = alias || `${operation}_${column}`;
-      const aliasKey = aggregationKey.toLowerCase();
+      const aliasKey = alias.toLowerCase();
       if (usedAliases.has(aliasKey)) {
-        throw new Error(`Duplicate aggregation alias: ${aggregationKey}`);
+        throw new Error(`Duplicate aggregation alias: ${aliasKey}`);
       }
       usedAliases.add(aliasKey);
 
@@ -440,7 +439,7 @@ export class WidgetTilesetSourceImpl extends WidgetSource<WidgetTilesetSourcePro
         throw new Error(`Unsupported aggregation operation: ${operation}`);
       }
       const targetOperation = aggregationFunctions[operation];
-      result[aggregationKey] = targetOperation(filteredFeatures, column);
+      result[aliasKey] = targetOperation(filteredFeatures, column);
     }
 
     return {rows: [result]};

--- a/src/widget-sources/widget-tileset-source.ts
+++ b/src/widget-sources/widget-tileset-source.ts
@@ -332,7 +332,11 @@ export class WidgetTilesetSource<
     signal,
     ...options
   }: AggregationsRequestOptions): Promise<AggregationsResponse> {
-    return this._executeWorkerMethod(Method.GET_AGGREGATIONS, [options], signal);
+    return this._executeWorkerMethod(
+      Method.GET_AGGREGATIONS,
+      [options],
+      signal
+    );
   }
 
   /** @experimental */

--- a/src/widget-sources/widget-tileset-source.ts
+++ b/src/widget-sources/widget-tileset-source.ts
@@ -1,4 +1,6 @@
 import type {
+  AggregationsRequestOptions,
+  AggregationsResponse,
   CategoryRequestOptions,
   CategoryResponse,
   ExtentResponse,
@@ -324,6 +326,13 @@ export class WidgetTilesetSource<
     ...options
   }: RangeRequestOptions): Promise<RangeResponse> {
     return this._executeWorkerMethod(Method.GET_RANGE, [options], signal);
+  }
+
+  async getAggregations({
+    signal,
+    ...options
+  }: AggregationsRequestOptions): Promise<AggregationsResponse> {
+    return this._executeWorkerMethod(Method.GET_AGGREGATIONS, [options], signal);
   }
 
   /** @experimental */

--- a/src/workers/constants.ts
+++ b/src/workers/constants.ts
@@ -10,4 +10,5 @@ export enum Method {
   GET_TABLE = 'getTable',
   GET_TIME_SERIES = 'getTimeSeries',
   GET_RANGE = 'getRange',
+  GET_AGGREGATIONS = 'getAggregations',
 }

--- a/test/widget-sources/widget-remote-source.test.ts
+++ b/test/widget-sources/widget-remote-source.test.ts
@@ -47,8 +47,7 @@ test('getAggregations - normaliza claves y mezcla alias/por defecto', async () =
     accessToken: '<token>',
     connectionName: 'carto_dw',
   });
-
-  // Simula un DW que devuelve claves con mayúsculas variadas y/o sin alias
+  // Simulate a DW that returns keys with varying uppercase and/or without alias
   const serverRow = {
     SUM_POP_HIGH: 10,
     avg_pop_low: 5,

--- a/test/widget-sources/widget-remote-source.test.ts
+++ b/test/widget-sources/widget-remote-source.test.ts
@@ -6,7 +6,7 @@ import {
   WidgetRemoteSource,
   WidgetRemoteSourceProps,
 } from '@carto/api-client';
-import { AggregationTypes } from '../../src/constants';
+import {AggregationTypes} from '../../src/constants';
 import type {BBox} from 'geojson';
 
 const createMockResponse = (data: unknown) => ({
@@ -57,16 +57,18 @@ test('getAggregations - normaliza claves y mezcla alias/por defecto', async () =
 
   const mockFetch = vi
     .fn()
-    .mockResolvedValueOnce(
-      createMockResponse({ rows: [serverRow] })
-    );
+    .mockResolvedValueOnce(createMockResponse({rows: [serverRow]}));
   vi.stubGlobal('fetch', mockFetch);
 
   const result = await widgetSource.getAggregations({
     aggregations: [
-      { column: 'pop_high', operation: AggregationTypes.Sum, alias: 'Sum_Pop_High' },
-      { column: 'pop_low', operation: AggregationTypes.Avg },
-      { column: '*', operation: AggregationTypes.Count, alias: 'COUNT_Records' },
+      {
+        column: 'pop_high',
+        operation: AggregationTypes.Sum,
+        alias: 'Sum_Pop_High',
+      },
+      {column: 'pop_low', operation: AggregationTypes.Avg},
+      {column: '*', operation: AggregationTypes.Count, alias: 'COUNT_Records'},
     ],
   });
 
@@ -74,14 +76,16 @@ test('getAggregations - normaliza claves y mezcla alias/por defecto', async () =
   // y el cliente debe devolver un objeto con rows array.
   // Alias provistos y por defecto deben convivir y ser normalizados.
   expect(result).toEqual({
-    rows: [{
-      // alias provisto "Sum_Pop_High" -> server devolvió SUM_POP_HIGH -> normalizado a minúsculas
-      sum_pop_high: 10,
-      // sin alias -> por defecto avg_pop_low
-      avg_pop_low: 5,
-      // alias provisto COUNT_Records -> server COUNT_records -> minúsculas
-      count_records: 7,
-    }]
+    rows: [
+      {
+        // alias provisto "Sum_Pop_High" -> server devolvió SUM_POP_HIGH -> normalizado a minúsculas
+        sum_pop_high: 10,
+        // sin alias -> por defecto avg_pop_low
+        avg_pop_low: 5,
+        // alias provisto COUNT_Records -> server COUNT_records -> minúsculas
+        count_records: 7,
+      },
+    ],
   });
 
   const params = new URL(mockFetch.mock.lastCall[0]).searchParams.entries();
@@ -102,54 +106,62 @@ test('getAggregations - normalización de alias con diferentes casings', async (
   const serverRow = {
     // BigQuery podría devolver en UPPERCASE
     TOTAL_REVENUE: 50000,
-    // PostgreSQL podría mantener el caso original 
+    // PostgreSQL podría mantener el caso original
     Customer_Count: 125,
     // Snowflake podría devolver todo en mayúsculas
     AVG_ORDER_VALUE: 400.5,
     // Sin alias, generado automáticamente por el backend
     max_rating: 5,
     // Algunos DW podrían devolver en mixedCase
-    minScore: 1.2
+    minScore: 1.2,
   };
 
   const mockFetch = vi
     .fn()
-    .mockResolvedValueOnce(
-      createMockResponse({ rows: [serverRow] })
-    );
+    .mockResolvedValueOnce(createMockResponse({rows: [serverRow]}));
   vi.stubGlobal('fetch', mockFetch);
 
   const result = await widgetSource.getAggregations({
     aggregations: [
-      { column: 'revenue', operation: AggregationTypes.Sum, alias: 'Total_Revenue' },
-      { column: '*', operation: AggregationTypes.Count, alias: 'Customer_Count' },
-      { column: 'order_value', operation: AggregationTypes.Avg, alias: 'AVG_ORDER_VALUE' },
-      { column: 'rating', operation: AggregationTypes.Max }, // sin alias
-      { column: 'score', operation: AggregationTypes.Min, alias: 'MinScore' },
+      {
+        column: 'revenue',
+        operation: AggregationTypes.Sum,
+        alias: 'Total_Revenue',
+      },
+      {column: '*', operation: AggregationTypes.Count, alias: 'Customer_Count'},
+      {
+        column: 'order_value',
+        operation: AggregationTypes.Avg,
+        alias: 'AVG_ORDER_VALUE',
+      },
+      {column: 'rating', operation: AggregationTypes.Max}, // sin alias
+      {column: 'score', operation: AggregationTypes.Min, alias: 'MinScore'},
     ],
   });
 
-  // normalizeObjectKeys debe convertir TODAS las claves a minúsculas, 
+  // normalizeObjectKeys debe convertir TODAS las claves a minúsculas,
   // independientemente del casing original del servidor
   expect(result).toEqual({
-    rows: [{
-      // TOTAL_REVENUE (server) -> total_revenue (cliente)
-      total_revenue: 50000,
-      // Customer_Count (server) -> customer_count (cliente)  
-      customer_count: 125,
-      // AVG_ORDER_VALUE (server) -> avg_order_value (cliente)
-      avg_order_value: 400.5,
-      // max_rating (server) -> max_rating (cliente, ya era lowercase)
-      max_rating: 5,
-      // minScore (server) -> minscore (cliente)
-      minscore: 1.2
-    }]
+    rows: [
+      {
+        // TOTAL_REVENUE (server) -> total_revenue (cliente)
+        total_revenue: 50000,
+        // Customer_Count (server) -> customer_count (cliente)
+        customer_count: 125,
+        // AVG_ORDER_VALUE (server) -> avg_order_value (cliente)
+        avg_order_value: 400.5,
+        // max_rating (server) -> max_rating (cliente, ya era lowercase)
+        max_rating: 5,
+        // minScore (server) -> minscore (cliente)
+        minscore: 1.2,
+      },
+    ],
   });
 
   // Verificar que se hizo la llamada al servidor
   expect(mockFetch).toHaveBeenCalledTimes(1);
-  
-  // El test principal es que normalizeObjectKeys convierte correctamente 
+
+  // El test principal es que normalizeObjectKeys convierte correctamente
   // los diferentes casings que pueden venir de diferentes data warehouses
 });
 
@@ -165,7 +177,7 @@ test('getAggregations - mezcla completa de alias provistos y por defecto', async
     TOTAL_SALES: 150000,
     // Sin alias - servidor genera automáticamente con case específico del DW
     sum_products: 45,
-    // Con alias personalizado - servidor devuelve en mixedCase  
+    // Con alias personalizado - servidor devuelve en mixedCase
     Customer_Average: 99.5,
     // Sin alias - servidor genera automáticamente en lowercase
     max_score: 100,
@@ -175,37 +187,41 @@ test('getAggregations - mezcla completa de alias provistos y por defecto', async
 
   const mockFetch = vi
     .fn()
-    .mockResolvedValueOnce(
-      createMockResponse({ rows: [serverRow] })
-    );
+    .mockResolvedValueOnce(createMockResponse({rows: [serverRow]}));
   vi.stubGlobal('fetch', mockFetch);
 
   const result = await widgetSource.getAggregations({
     aggregations: [
       // Casos con alias personalizado
-      { column: 'sales', operation: AggregationTypes.Sum, alias: 'Total_Sales' },
-      { column: 'customer_rating', operation: AggregationTypes.Avg, alias: 'Customer_Average' },
-      { column: '*', operation: AggregationTypes.Count, alias: 'TOTAL_COUNT' },
+      {column: 'sales', operation: AggregationTypes.Sum, alias: 'Total_Sales'},
+      {
+        column: 'customer_rating',
+        operation: AggregationTypes.Avg,
+        alias: 'Customer_Average',
+      },
+      {column: '*', operation: AggregationTypes.Count, alias: 'TOTAL_COUNT'},
       // Casos sin alias (generados automáticamente)
-      { column: 'products', operation: AggregationTypes.Sum },
-      { column: 'score', operation: AggregationTypes.Max },
+      {column: 'products', operation: AggregationTypes.Sum},
+      {column: 'score', operation: AggregationTypes.Max},
     ],
   });
 
   // TODAS las claves deben estar normalizadas a minúsculas por normalizeObjectKeys
   expect(result).toEqual({
-    rows: [{
-      // Alias personalizado: "Total_Sales" -> servidor "TOTAL_SALES" -> cliente "total_sales" 
-      total_sales: 150000,
-      // Alias personalizado: "Customer_Average" -> servidor "Customer_Average" -> cliente "customer_average"
-      customer_average: 99.5,
-      // Alias personalizado: "TOTAL_COUNT" -> servidor "TOTAL_COUNT" -> cliente "total_count"
-      total_count: 500,
-      // Sin alias: generado automáticamente -> servidor "sum_products" -> cliente "sum_products"
-      sum_products: 45,
-      // Sin alias: generado automáticamente -> servidor "max_score" -> cliente "max_score"
-      max_score: 100,
-    }]
+    rows: [
+      {
+        // Alias personalizado: "Total_Sales" -> servidor "TOTAL_SALES" -> cliente "total_sales"
+        total_sales: 150000,
+        // Alias personalizado: "Customer_Average" -> servidor "Customer_Average" -> cliente "customer_average"
+        customer_average: 99.5,
+        // Alias personalizado: "TOTAL_COUNT" -> servidor "TOTAL_COUNT" -> cliente "total_count"
+        total_count: 500,
+        // Sin alias: generado automáticamente -> servidor "sum_products" -> cliente "sum_products"
+        sum_products: 45,
+        // Sin alias: generado automáticamente -> servidor "max_score" -> cliente "max_score"
+        max_score: 100,
+      },
+    ],
   });
 });
 
@@ -222,22 +238,23 @@ test('getAggregations - string format funciona para remote sources', async () =>
 
   const mockFetch = vi
     .fn()
-    .mockResolvedValueOnce(
-      createMockResponse({ rows: [serverRow] })
-    );
+    .mockResolvedValueOnce(createMockResponse({rows: [serverRow]}));
   vi.stubGlobal('fetch', mockFetch);
 
   // String format permite cualquier SQL personalizado
   const result = await widgetSource.getAggregations({
-    aggregations: 'sum(sales * 1.21) as CUSTOM_METRIC, sum(case when status = \'active\' then 1 else 0 end) as COMPLEX_CALC'
+    aggregations:
+      "sum(sales * 1.21) as CUSTOM_METRIC, sum(case when status = 'active' then 1 else 0 end) as COMPLEX_CALC",
   });
 
   // Las claves del servidor se normalizan a lowercase
   expect(result).toEqual({
-    rows: [{
-      custom_metric: 42.7,
-      complex_calc: 789,
-    }]
+    rows: [
+      {
+        custom_metric: 42.7,
+        complex_calc: 789,
+      },
+    ],
   });
 });
 

--- a/test/widget-sources/widget-remote-source.test.ts
+++ b/test/widget-sources/widget-remote-source.test.ts
@@ -71,15 +71,17 @@ test('getAggregations - normaliza claves y mezcla alias/por defecto', async () =
   });
 
   // normalizeObjectKeys debe forzar lowercase de las claves del servidor
-  // y el cliente debe devolver un objeto plano con esas claves normalizadas.
+  // y el cliente debe devolver un objeto con rows array.
   // Alias provistos y por defecto deben convivir y ser normalizados.
   expect(result).toEqual({
-    // alias provisto "Sum_Pop_High" -> server devolvió SUM_POP_HIGH -> normalizado a minúsculas
-    sum_pop_high: 10,
-    // sin alias -> por defecto avg_pop_low
-    avg_pop_low: 5,
-    // alias provisto COUNT_Records -> server COUNT_records -> minúsculas
-    count_records: 7,
+    rows: [{
+      // alias provisto "Sum_Pop_High" -> server devolvió SUM_POP_HIGH -> normalizado a minúsculas
+      sum_pop_high: 10,
+      // sin alias -> por defecto avg_pop_low
+      avg_pop_low: 5,
+      // alias provisto COUNT_Records -> server COUNT_records -> minúsculas
+      count_records: 7,
+    }]
   });
 
   const params = new URL(mockFetch.mock.lastCall[0]).searchParams.entries();

--- a/test/widget-sources/widget-tileset-source.test.ts
+++ b/test/widget-sources/widget-tileset-source.test.ts
@@ -262,16 +262,16 @@ describe('getExtent', () => {
 describe('getAggregations', () => {
   it('should handle count operation with * column', async () => {
     const result = await source.getAggregations({
-      aggregations: [
-        { column: '*', operation: 'count', alias: 'RECORD_COUNT' },
-      ],
+      aggregations: [{column: '*', operation: 'count', alias: 'RECORD_COUNT'}],
       spatialFilter: MOCK_SPATIAL_FILTER,
     });
 
     expect(result).toEqual({
-      rows: [{
-        RECORD_COUNT: expect.any(Number),
-      }]
+      rows: [
+        {
+          RECORD_COUNT: expect.any(Number),
+        },
+      ],
     });
     expect(result.rows[0].RECORD_COUNT).toBeGreaterThan(0);
   });
@@ -279,9 +279,9 @@ describe('getAggregations', () => {
   it('should return aggregations with specified aliases', async () => {
     const result = await source.getAggregations({
       aggregations: [
-        { column: 'revenue', operation: 'sum', alias: 'Total_Revenue' },
-        { column: 'size_m2', operation: 'avg', alias: 'AVG_Size' },
-        { column: '*', operation: 'count', alias: 'RECORD_COUNT' },
+        {column: 'revenue', operation: 'sum', alias: 'Total_Revenue'},
+        {column: 'size_m2', operation: 'avg', alias: 'AVG_Size'},
+        {column: '*', operation: 'count', alias: 'RECORD_COUNT'},
       ],
       spatialFilter: MOCK_SPATIAL_FILTER,
     });
@@ -289,11 +289,13 @@ describe('getAggregations', () => {
     // Para tileset sources, las agregaciones se calculan localmente
     // y los alias se devuelven exactamente como se especificaron
     expect(result).toEqual({
-      rows: [{
-        Total_Revenue: expect.any(Number),
-        AVG_Size: expect.any(Number),
-        RECORD_COUNT: expect.any(Number),
-      }]
+      rows: [
+        {
+          Total_Revenue: expect.any(Number),
+          AVG_Size: expect.any(Number),
+          RECORD_COUNT: expect.any(Number),
+        },
+      ],
     });
 
     // Verificar que devuelve valores numéricos válidos
@@ -305,20 +307,22 @@ describe('getAggregations', () => {
   it('should generate default aliases when not provided', async () => {
     const result = await source.getAggregations({
       aggregations: [
-        { column: 'revenue', operation: 'sum' }, // sin alias
-        { column: 'size_m2', operation: 'avg' },  // sin alias
-        { column: '*', operation: 'count' },       // sin alias
+        {column: 'revenue', operation: 'sum'}, // sin alias
+        {column: 'size_m2', operation: 'avg'}, // sin alias
+        {column: '*', operation: 'count'}, // sin alias
       ],
       spatialFilter: MOCK_SPATIAL_FILTER,
     });
 
     // Los alias por defecto siguen el patrón operation_column
     expect(result).toEqual({
-      rows: [{
-        sum_revenue: expect.any(Number),
-        avg_size_m2: expect.any(Number),
-        'count_*': expect.any(Number),
-      }]
+      rows: [
+        {
+          sum_revenue: expect.any(Number),
+          avg_size_m2: expect.any(Number),
+          'count_*': expect.any(Number),
+        },
+      ],
     });
   });
 
@@ -327,7 +331,11 @@ describe('getAggregations', () => {
     await expect(async () => {
       await source.getAggregations({
         aggregations: [
-          { column: 'revenue', operation: 'custom' as any, alias: 'custom_result' }
+          {
+            column: 'revenue',
+            operation: 'custom' as any,
+            alias: 'custom_result',
+          },
         ],
         spatialFilter: MOCK_SPATIAL_FILTER,
       });
@@ -338,7 +346,8 @@ describe('getAggregations', () => {
     // Los tilesets no soportan agregaciones basadas en strings porque requieren SQL
     await expect(async () => {
       await source.getAggregations({
-        aggregations: 'sum(revenue) as total_revenue, avg(size_m2) as avg_size' as any,
+        aggregations:
+          'sum(revenue) as total_revenue, avg(size_m2) as avg_size' as any,
         spatialFilter: MOCK_SPATIAL_FILTER,
       });
     }).rejects.toThrow('String-based aggregations not supported for tilesets');
@@ -348,27 +357,29 @@ describe('getAggregations', () => {
     const result = await source.getAggregations({
       aggregations: [
         // Con alias personalizado
-        { column: 'revenue', operation: 'sum', alias: 'CustomRevenue' },
-        { column: 'size_m2', operation: 'avg', alias: 'AVERAGE_SIZE' },
+        {column: 'revenue', operation: 'sum', alias: 'CustomRevenue'},
+        {column: 'size_m2', operation: 'avg', alias: 'AVERAGE_SIZE'},
         // Sin alias (generado automáticamente)
-        { column: 'cartodb_id', operation: 'count' },
-        { column: 'store_id', operation: 'max' },
+        {column: 'cartodb_id', operation: 'count'},
+        {column: 'store_id', operation: 'max'},
         // Combinado con count usando *
-        { column: '*', operation: 'count', alias: 'TotalRecords' },
+        {column: '*', operation: 'count', alias: 'TotalRecords'},
       ],
       spatialFilter: MOCK_SPATIAL_FILTER,
     });
 
     expect(result).toEqual({
-      rows: [{
-        // Alias personalizados se mantienen exactamente como se especificaron
-        CustomRevenue: expect.any(Number),
-        AVERAGE_SIZE: expect.any(Number),
-        TotalRecords: expect.any(Number),
-        // Alias por defecto siguen el patrón operation_column
-        count_cartodb_id: expect.any(Number),
-        max_store_id: expect.any(Number),
-      }]
+      rows: [
+        {
+          // Alias personalizados se mantienen exactamente como se especificaron
+          CustomRevenue: expect.any(Number),
+          AVERAGE_SIZE: expect.any(Number),
+          TotalRecords: expect.any(Number),
+          // Alias por defecto siguen el patrón operation_column
+          count_cartodb_id: expect.any(Number),
+          max_store_id: expect.any(Number),
+        },
+      ],
     });
 
     // Verificar que todos son números válidos
@@ -384,18 +395,20 @@ describe('getAggregations', () => {
     const result = await source.getAggregations({
       aggregations: [
         // Alias vacío debería usar el patrón por defecto
-        { column: 'revenue', operation: 'sum', alias: '' },
-        { column: 'size_m2', operation: 'avg', alias: undefined as any },
+        {column: 'revenue', operation: 'sum', alias: ''},
+        {column: 'size_m2', operation: 'avg', alias: undefined as any},
       ],
       spatialFilter: MOCK_SPATIAL_FILTER,
     });
 
     // Con alias vacío o undefined, debe usar el patrón por defecto
     expect(result).toEqual({
-      rows: [{
-        sum_revenue: expect.any(Number),
-        avg_size_m2: expect.any(Number),
-      }]
+      rows: [
+        {
+          sum_revenue: expect.any(Number),
+          avg_size_m2: expect.any(Number),
+        },
+      ],
     });
   });
 });


### PR DESCRIPTION
# Description

Shortcut

- Story: https://app.shortcut.com/cartoteam/story/505098
- Autolink: [sc-505098]

Create widgets out of pivoted tables where data is pre-aggregated in different numeric columns

Related: https://github.com/CartoDB/cloud-native/pull/21091

## Type of change

- [ ] Fix
- [X ] Feature
- [ ] Refactor
- [ ] Tests
- [ ] Documentation
- [ ] Security
- [ ] Chore
