### PR TITLE
chore(release): v0.5.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,12 @@
 
 ## Unreleased
 
-- fix(fetchMap): getColorAccessor treats colorMap as override of actual domain (#238)
 
 ## 0.5
+
+### 0.5.18
+
+- fix(fetchMap): getColorAccessor treats colorMap as override of actual domain (#238)
 
 ### 0.5.17
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "homepage": "https://github.com/CartoDB/carto-api-client#readme",
   "author": "Don McCurdy <donmccurdy@carto.com>",
   "packageManager": "yarn@4.3.1",
-  "version": "0.5.17",
+  "version": "0.5.18",
   "license": "MIT",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
* https://github.com/CartoDB/carto-api-client/pull/238