### PR TITLE
fix(fetchMap): support quantile colorMap with two colors [sc-511580]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix(fetchMap): support quantile color scale with 2 ranges (#241)
+
 ## 0.5
 
 ### 0.5.19

--- a/src/fetch-map/layer-map.ts
+++ b/src/fetch-map/layer-map.ts
@@ -244,6 +244,9 @@ function domainFromAttribute(
       'global' in attribute.quantiles
         ? attribute.quantiles.global
         : attribute.quantiles;
+
+    // Stats API doesn't provide quantile[2] - which would be effecively [min, median, max]
+    // so let's derive median from Quartiles (quantile[4]), of which second is median
     if (scaleLength === 2 && !quantiles[2] && quantiles[4]?.length === 5) {
       return [quantiles[4][0], quantiles[4][2], quantiles[4][4]];
     }

--- a/src/fetch-map/layer-map.ts
+++ b/src/fetch-map/layer-map.ts
@@ -240,9 +240,16 @@ function domainFromAttribute(
   }
 
   if (scaleType === 'quantile' && attribute.quantiles) {
-    return 'global' in attribute.quantiles
-      ? attribute.quantiles.global[scaleLength]
-      : attribute.quantiles[scaleLength];
+    const quantiles: Record<number, number[]> =
+      'global' in attribute.quantiles
+        ? attribute.quantiles.global
+        : attribute.quantiles;
+    if (scaleLength === 2 && !quantiles[2] && quantiles[4]?.length === 5) {
+      return [quantiles[4][0], quantiles[4][2], quantiles[4][4]];
+    }
+    if (quantiles[scaleLength]) {
+      return quantiles[scaleLength];
+    }
   }
 
   let {min} = attribute;

--- a/test/fetch-map/layer-map.spec.ts
+++ b/test/fetch-map/layer-map.spec.ts
@@ -5,6 +5,12 @@ import {
   getLayerProps,
   _domainFromValues,
 } from '@carto/api-client';
+import {rgb} from 'd3-color';
+
+const hexToRGBA = (c: any) => {
+  const {r, g, b} = rgb(c);
+  return [r, g, b, 255];
+};
 
 describe('layer-map', () => {
   const colors = [
@@ -49,36 +55,11 @@ describe('layer-map', () => {
           },
         },
         d: {properties: {v: 'b'}},
-        expected: [90, 24, 70, 255],
-      },
-      {
-        title: 'colorMap with length 2',
-        colorField: {name: 'v'},
-        colorScale: 'ordinal',
-        colorRange: {
-          colors: colors.slice(0, 2),
-          colorMap: [
-            ['b', colors[0]],
-            ['a', colors[1]],
-          ],
-        },
-        opacity: 1,
-        data: {
-          tilestats: {
-            layers: [
-              {
-                attributes: [
-                  {
-                    attribute: 'v',
-                    categories: [{category: 'a'}, {category: 'b'}],
-                  },
-                ],
-              },
-            ],
-          },
-        },
-        d: {properties: {v: 'b'}},
-        expected: [90, 24, 70, 255],
+        // this case is for colorMap that contains 6 values, but actual (current)
+        // domain is shorter for example thanks to filtering
+        // We expect colorMap to override current attrubute stats and result in first color,
+        // whether attribute stats would map 'b' to second color
+        expected: hexToRGBA(colors[0]),
       },
       {
         title: 'quantize with length 2',
@@ -103,15 +84,17 @@ describe('layer-map', () => {
             ],
           },
         },
-        d: {properties: {v: '0'}},
-        expected: [90, 24, 70, 255],
+        d: {properties: {v: 0.5}},
+        // quantize [0,1] with two colors should emit ranges [-Inf, 0.5) [0.5, Inf]
+        // so we should result with second color
+        expected: hexToRGBA(colors[1]),
       },
       {
         title: 'quantile with length 2',
         colorField: {name: 'v'},
         colorScale: 'quantile',
         colorRange: {
-          colors: colors.slice(0, 2),
+          colors: colors.slice(0, 4),
         },
         opacity: 1,
         data: {
@@ -123,15 +106,19 @@ describe('layer-map', () => {
                     attribute: 'v',
                     min: 0,
                     max: 1,
-                    quantiles: {3: [0, 0.5, 1], 4: [0, 0.33, 0.66, 1]},
+                    quantiles: {
+                      3: [0, 0.33, 0.66, 1],
+                      4: [0, 0.25, 0.5, 0.75, 1],
+                    },
                   },
                 ],
               },
             ],
           },
         },
-        d: {properties: {v: '0'}},
-        expected: [90, 24, 70, 255],
+        d: {properties: {v: '0.5'}},
+        // our data is exactly median, and fits [0.5-0.75> so should be 3rd color
+        expected: hexToRGBA(colors[2]),
       },
       {
         title: 'quantile',
@@ -146,17 +133,18 @@ describe('layer-map', () => {
             layers: [
               {
                 attributes: [
-                  {attribute: 'v', quantiles: {6: [1, 2, 3, 4, 5, 6]}},
+                  {attribute: 'v', quantiles: {6: [1, 2, 3, 4, 5, 6, 7]}},
                 ],
               },
             ],
           },
         },
-        d: {properties: {v: 1}},
-        expected: [90, 24, 70, 255],
+        d: {properties: {v: 2}},
+        // we expect v=2 to land in second range, that is [2-3)
+        expected: hexToRGBA(colors[1]),
       },
       {
-        title: 'quantile (2)',
+        title: 'quantiles, global',
         colorField: {name: 'v'},
         colorScale: 'quantile',
         colorRange: {
@@ -170,7 +158,7 @@ describe('layer-map', () => {
                 attributes: [
                   {
                     attribute: 'v',
-                    quantiles: {global: {6: [1, 2, 3, 4, 5, 6]}},
+                    quantiles: {global: {6: [1, 2, 3, 4, 5, 6, 7]}},
                   },
                 ],
               },
@@ -178,7 +166,8 @@ describe('layer-map', () => {
           },
         },
         d: {properties: {v: 3.5}},
-        expected: [227, 97, 28, 255],
+        // we expect v: 3.5 to land in 3rd range, that is [3, 4) so third color
+        expected: hexToRGBA(colors[2]),
       },
     ];
 

--- a/test/fetch-map/layer-map.spec.ts
+++ b/test/fetch-map/layer-map.spec.ts
@@ -169,6 +169,33 @@ describe('layer-map', () => {
         // we expect v: 3.5 to land in 3rd range, that is [3, 4) so third color
         expected: hexToRGBA(colors[2]),
       },
+      {
+        title: 'hexColumn',
+        colorField: {name: 'v', colorColumn: 'vColor'},
+        colorScale: 'ordinal',
+        colorRange: {
+          colors: [],
+          hexColor: true,
+        },
+        opacity: 1,
+        data: {
+          tilestats: {
+            layers: [
+              {
+                attributes: [
+                  {
+                    attribute: 'v',
+                    categories: [{category: 'foo'}],
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        d: {properties: {v: 'foo', vColor: '#ff00ff'}},
+        // we expect v: 3.5 to land in 3rd range, that is [3, 4) so third color
+        expected: hexToRGBA('#ff00ff'),
+      },
     ];
 
     test.each(COLOR_TESTS)('getColorAccessor $title', (testCase) => {

--- a/test/fetch-map/layer-map.spec.ts
+++ b/test/fetch-map/layer-map.spec.ts
@@ -52,6 +52,88 @@ describe('layer-map', () => {
         expected: [90, 24, 70, 255],
       },
       {
+        title: 'colorMap with length 2',
+        colorField: {name: 'v'},
+        colorScale: 'ordinal',
+        colorRange: {
+          colors: colors.slice(0, 2),
+          colorMap: [
+            ['b', colors[0]],
+            ['a', colors[1]],
+          ],
+        },
+        opacity: 1,
+        data: {
+          tilestats: {
+            layers: [
+              {
+                attributes: [
+                  {
+                    attribute: 'v',
+                    categories: [{category: 'a'}, {category: 'b'}],
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        d: {properties: {v: 'b'}},
+        expected: [90, 24, 70, 255],
+      },
+      {
+        title: 'quantize with length 2',
+        colorField: {name: 'v'},
+        colorScale: 'quantize',
+        colorRange: {
+          colors: colors.slice(0, 2),
+        },
+        opacity: 1,
+        data: {
+          tilestats: {
+            layers: [
+              {
+                attributes: [
+                  {
+                    attribute: 'v',
+                    min: 0,
+                    max: 1,
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        d: {properties: {v: '0'}},
+        expected: [90, 24, 70, 255],
+      },
+      {
+        title: 'quantile with length 2',
+        colorField: {name: 'v'},
+        colorScale: 'quantile',
+        colorRange: {
+          colors: colors.slice(0, 2),
+        },
+        opacity: 1,
+        data: {
+          tilestats: {
+            layers: [
+              {
+                attributes: [
+                  {
+                    attribute: 'v',
+                    min: 0,
+                    max: 1,
+                    quantiles: {3: [0, 0.5, 1], 4: [0, 0.33, 0.66, 1]},
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        d: {properties: {v: '0'}},
+        expected: [90, 24, 70, 255],
+      },
+      {
         title: 'quantile',
         colorField: {name: 'v'},
         colorScale: 'quantile',


### PR DESCRIPTION
fetchMap - support quantile color scale with _two_ colors, deriving median from quantiles[4]

Extra, don't crash when there are no quantiles, just return default domain - `[min,max]`

https://app.shortcut.com/cartoteam/story/511580