### PR TITLE
fix(fetchMap): support point radius aggregation [sc-512284]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix(fetchMap): support point radius aggregation (#241)
+
 ## 0.5
 
 ### 0.5.18

--- a/src/fetch-map/parse-map.ts
+++ b/src/fetch-map/parse-map.ts
@@ -392,7 +392,7 @@ function createChannelProps(
       const {accessor, ...scaleProps} = getSizeAccessor(
         radiusField,
         radiusScale,
-        visConfig.sizeAggregation,
+        visConfig.radiusAggregation,
         radiusRange,
         data
       );

--- a/src/fetch-map/types.ts
+++ b/src/fetch-map/types.ts
@@ -72,6 +72,7 @@ export type VisConfig = {
 
   radius: number;
   radiusRange?: number[];
+  radiusAggregation?: string;
 
   sizeAggregation?: string;
   sizeRange?: number[];


### PR DESCRIPTION
Fix `parseMap` to correctly use `radiusAggregation` field when creating accessor for point radius for aggregated point layer.