### PR TITLE
fix: Export CARTO_SOURCES

### DIFF
--- a/src/sources/index.ts
+++ b/src/sources/index.ts
@@ -140,5 +140,5 @@ export const CARTO_SOURCES = {
   trajectoryTableSource,
   vectorQuerySource,
   vectorTableSource,
-  vectorTilesetSource
+  vectorTilesetSource,
 };

--- a/src/sources/index.ts
+++ b/src/sources/index.ts
@@ -132,13 +132,13 @@ export const CARTO_SOURCES = {
   h3QuerySource,
   h3TableSource,
   h3TilesetSource,
-  rasterSource,
   quadbinQuerySource,
   quadbinTableSource,
   quadbinTilesetSource,
-  vectorQuerySource,
-  vectorTableSource,
-  vectorTilesetSource,
+  rasterSource,
   trajectoryQuerySource,
   trajectoryTableSource,
+  vectorQuerySource,
+  vectorTableSource,
+  vectorTilesetSource
 };

--- a/src/sources/index.ts
+++ b/src/sources/index.ts
@@ -2,6 +2,22 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
+// Import all source functions
+import {boundaryQuerySource} from './boundary-query-source.js';
+import {boundaryTableSource} from './boundary-table-source.js';
+import {h3QuerySource} from './h3-query-source.js';
+import {h3TableSource} from './h3-table-source.js';
+import {h3TilesetSource} from './h3-tileset-source.js';
+import {quadbinQuerySource} from './quadbin-query-source.js';
+import {quadbinTableSource} from './quadbin-table-source.js';
+import {quadbinTilesetSource} from './quadbin-tileset-source.js';
+import {rasterSource} from './raster-source.js';
+import {trajectoryQuerySource} from './trajectory-query-source.js';
+import {trajectoryTableSource} from './trajectory-table-source.js';
+import {vectorQuerySource} from './vector-query-source.js';
+import {vectorTableSource} from './vector-table-source.js';
+import {vectorTilesetSource} from './vector-tileset-source.js';
+
 export {SOURCE_DEFAULTS} from './base-source.js';
 export {RasterBandColorinterp} from './constants.js';
 export type {
@@ -29,83 +45,100 @@ export type {
   RasterBandType,
 } from './types.js';
 
-export {boundaryQuerySource} from './boundary-query-source.js';
+export {boundaryQuerySource};
 export type {
   BoundaryQuerySourceOptions,
   BoundaryQuerySourceResponse,
 } from './boundary-query-source.js';
 
-export {boundaryTableSource} from './boundary-table-source.js';
+export {boundaryTableSource};
 export type {
   BoundaryTableSourceOptions,
   BoundaryTableSourceResponse,
 } from './boundary-table-source.js';
 
-export {h3QuerySource} from './h3-query-source.js';
+export {h3QuerySource};
 export type {
   H3QuerySourceOptions,
   H3QuerySourceResponse,
 } from './h3-query-source.js';
 
-export {h3TableSource} from './h3-table-source.js';
+export {h3TableSource};
 export type {
   H3TableSourceOptions,
   H3TableSourceResponse,
 } from './h3-table-source.js';
 
-export {h3TilesetSource} from './h3-tileset-source.js';
+export {h3TilesetSource};
 export type {
   H3TilesetSourceOptions,
   H3TilesetSourceResponse,
 } from './h3-tileset-source.js';
 
-export {rasterSource} from './raster-source.js';
+export {rasterSource};
 export type {RasterSourceOptions} from './raster-source.js';
 
-export {quadbinQuerySource} from './quadbin-query-source.js';
+export {quadbinQuerySource};
 export type {
   QuadbinQuerySourceOptions,
   QuadbinQuerySourceResponse,
 } from './quadbin-query-source.js';
 
-export {quadbinTableSource} from './quadbin-table-source.js';
+export {quadbinTableSource};
 export type {
   QuadbinTableSourceOptions,
   QuadbinTableSourceResponse,
 } from './quadbin-table-source.js';
 
-export {quadbinTilesetSource} from './quadbin-tileset-source.js';
+export {quadbinTilesetSource};
 export type {
   QuadbinTilesetSourceOptions,
   QuadbinTilesetSourceResponse,
 } from './quadbin-tileset-source.js';
 
-export {vectorQuerySource} from './vector-query-source.js';
+export {vectorQuerySource};
 export type {
   VectorQuerySourceOptions,
   VectorQuerySourceResponse,
 } from './vector-query-source.js';
 
-export {vectorTableSource} from './vector-table-source.js';
+export {vectorTableSource};
 export type {
   VectorTableSourceOptions,
   VectorTableSourceResponse,
 } from './vector-table-source.js';
 
-export {vectorTilesetSource} from './vector-tileset-source.js';
+export {vectorTilesetSource};
 export type {
   VectorTilesetSourceOptions,
   VectorTilesetSourceResponse,
 } from './vector-tileset-source.js';
 
-export {trajectoryQuerySource} from './trajectory-query-source.js';
+export {trajectoryQuerySource};
 export type {
   TrajectoryQuerySourceOptions,
   TrajectoryQuerySourceResponse,
 } from './trajectory-query-source.js';
 
-export {trajectoryTableSource} from './trajectory-table-source.js';
+export {trajectoryTableSource};
 export type {
   TrajectoryTableSourceOptions,
   TrajectoryTableSourceResponse,
 } from './trajectory-table-source.js';
+
+export const CARTO_SOURCES = {
+  boundaryQuerySource,
+  boundaryTableSource,
+  h3QuerySource,
+  h3TableSource,
+  h3TilesetSource,
+  rasterSource,
+  quadbinQuerySource,
+  quadbinTableSource,
+  quadbinTilesetSource,
+  vectorQuerySource,
+  vectorTableSource,
+  vectorTilesetSource,
+  trajectoryQuerySource,
+  trajectoryTableSource,
+};

--- a/test/sources/index.test.ts
+++ b/test/sources/index.test.ts
@@ -12,15 +12,15 @@ describe('sources index', () => {
       'h3QuerySource',
       'h3TableSource',
       'h3TilesetSource',
-      'rasterSource',
       'quadbinQuerySource',
       'quadbinTableSource',
       'quadbinTilesetSource',
-      'vectorQuerySource',
-      'vectorTableSource',
-      'vectorTilesetSource',
+      'rasterSource',
       'trajectoryQuerySource',
       'trajectoryTableSource',
+      'vectorQuerySource',
+      'vectorTableSource',
+      'vectorTilesetSource'
     ];
 
     expectedSources.forEach((sourceName) => {

--- a/test/sources/index.test.ts
+++ b/test/sources/index.test.ts
@@ -1,0 +1,36 @@
+import {describe, expect, test} from 'vitest';
+import {CARTO_SOURCES} from '@carto/api-client';
+
+describe('sources index', () => {
+  test('CARTO_SOURCES exports all source functions', () => {
+    expect(CARTO_SOURCES).toBeDefined();
+    expect(typeof CARTO_SOURCES).toBe('object');
+
+    const expectedSources = [
+      'boundaryQuerySource',
+      'boundaryTableSource',
+      'h3QuerySource',
+      'h3TableSource',
+      'h3TilesetSource',
+      'rasterSource',
+      'quadbinQuerySource',
+      'quadbinTableSource',
+      'quadbinTilesetSource',
+      'vectorQuerySource',
+      'vectorTableSource',
+      'vectorTilesetSource',
+      'trajectoryQuerySource',
+      'trajectoryTableSource',
+    ];
+
+    expectedSources.forEach((sourceName) => {
+      expect(CARTO_SOURCES).toHaveProperty(sourceName);
+      expect(
+        typeof CARTO_SOURCES[sourceName as keyof typeof CARTO_SOURCES]
+      ).toBe('function');
+    });
+
+    expect(Object.keys(CARTO_SOURCES)).toHaveLength(expectedSources.length);
+  });
+});
+

--- a/test/sources/index.test.ts
+++ b/test/sources/index.test.ts
@@ -20,7 +20,7 @@ describe('sources index', () => {
       'trajectoryTableSource',
       'vectorQuerySource',
       'vectorTableSource',
-      'vectorTilesetSource'
+      'vectorTilesetSource',
     ];
 
     expectedSources.forEach((sourceName) => {
@@ -33,4 +33,3 @@ describe('sources index', () => {
     expect(Object.keys(CARTO_SOURCES)).toHaveLength(expectedSources.length);
   });
 });
-


### PR DESCRIPTION
### Background

`CARTO_SOURCES` was removed from the deck.gl/carto package in https://github.com/visgl/deck.gl/pull/9619/files, with the view that it would be exported from api-client instead, but it was never added.

Currently this means https://deck.gl/playground is broken as the source functions are not registered:

```
JSON converter: No registered function vectorTilesetSource({"accessToken
```

### Changes
- Export sources as before
- Test