### PR TITLE
fix(query,fetchMap): Fix queryParameter encoding for POST requests. [sc-513005]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix(query,fetchMap): Fix queryParameter encoding for POST requests. (#247)
+
 ## 0.5
 
 ### 0.5.20

--- a/src/api/query.ts
+++ b/src/api/query.ts
@@ -24,7 +24,10 @@ export type QueryOptions = SourceOptions &
     /** Used to abort the request. */
     signal?: AbortSignal;
   };
-type UrlParameters = {q: string; queryParameters?: string};
+type UrlParameters = {
+  q: string;
+  queryParameters?: Record<string, unknown> | unknown[];
+};
 
 export const query = async function (
   options: QueryOptions
@@ -42,7 +45,7 @@ export const query = async function (
   const urlParameters: UrlParameters = {q: sqlQuery};
 
   if (queryParameters) {
-    urlParameters.queryParameters = JSON.stringify(queryParameters);
+    urlParameters.queryParameters = queryParameters;
   }
 
   const baseUrl = buildQueryUrl({apiBaseUrl, connectionName});

--- a/src/fetch-map/fetch-map.ts
+++ b/src/fetch-map/fetch-map.ts
@@ -70,14 +70,14 @@ async function _fetchTilestats(
   const baseUrl = buildStatsUrl({attribute, apiBaseUrl, ...dataset});
   const client = new URLSearchParams(data.tiles[0]).get('client');
   const headers = {Authorization: `Bearer ${context.accessToken}`};
-  const parameters: Record<string, string> = {};
+  const parameters: Record<string, unknown> = {};
   if (client) {
     parameters.client = client;
   }
   if (type === 'query') {
     parameters.q = source;
     if (queryParameters) {
-      parameters.queryParameters = JSON.stringify(queryParameters);
+      parameters.queryParameters = queryParameters;
     }
   }
   const stats = await requestWithParameters({


### PR DESCRIPTION
Minimal issue reproduction:

```javascript
const PAD = ''.padEnd(8192, ' ');

const SQL_QUERY = `
SELECT *
FROM \`carto-demo-data.demo_tables.retail_stores\` ${PAD}
WHERE storetype = @type AND revenue > @minRevenue`.trim();

const response = await query({
  accessToken: import.meta.env.VITE_CARTO_ACCESS_TOKEN,
  sqlQuery: SQL_QUERY,
  queryParameters: {minRevenue: 100000, type: 'Supermarket'},
  connectionName: 'carto_dw',
  headers: {'cache-control': 'no-cache, max-age=0'},
});
```

At a certain URL length limit (`DEFAULT_MAX_LENGTH_URL`), we switch from GET to POST requests, and encoding of request parameters must be changed accordingly. Currently the logic responsible for encoding parameters is spread across different feature implementations (sources, query, fetchMap...) and they implemented this differently:

```javascript
// query, fetchMap
parameters.queryParameters = JSON.stringify(queryParameters);


// sources
parameters.queryParameters = queryParameters;
```

We only want this per-parameter JSON encoding in GET requests. For POST requests the entire POST body is JSON-encoded, not individual parameters. So we need to remove the feature-specific encoding (in query, fetchMap), where we don't know yet whether the GET or POST methods will be used, and defer JSON encoding to the `createURLWithParameters` function, where we know all parameters present will be encoded in a URL:

https://github.com/CartoDB/carto-api-client/blob/c677be5b745abf66b31c77b1c81586af994c7ac3/src/api/request-with-parameters.ts#L135-L158




#### PR Dependency Tree


* **PR #247** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)