### PR TITLE
fix(parseMap): Fix scale info for custom & logarithmic scales

### DIFF
--- a/src/fetch-map/parse-map.ts
+++ b/src/fetch-map/parse-map.ts
@@ -39,10 +39,10 @@ import type {TilejsonResult} from '../sources/types.js';
 
 export type Scale = {
   type: ScaleType;
-  field: VisualChannelField;
+  field?: VisualChannelField;
 
   /** Natural domain of the scale, as defined by the data  */
-  domain: string[] | number[];
+  domain?: string[] | number[];
 
   /** Domain of the user to construct d3 scale */
   scaleDomain?: string[] | number[];
@@ -277,7 +277,11 @@ function createChannelProps(
           rasterMetadata,
           visualChannels,
         }),
-        scales: {}, // TODO
+        scales: {
+          fillColor: {
+            type: 'identity',
+          },
+        },
       };
     } else {
       const {dataTransform, updateTriggers, ...scaleProps} =

--- a/src/fetch-map/parse-map.ts
+++ b/src/fetch-map/parse-map.ts
@@ -280,14 +280,22 @@ function createChannelProps(
         scales: {}, // TODO
       };
     } else {
-      return {
-        channelProps: getRasterTileLayerStylePropsScaledBand({
+      const {dataTransform, updateTriggers, ...scaleProps} =
+        getRasterTileLayerStylePropsScaledBand({
           layerConfig: config,
           visualChannels,
           rasterMetadata,
-        }),
+        });
+
+      return {
+        channelProps: {
+          dataTransform,
+          updateTriggers,
+        },
         scales: {
-          // TODO
+          ...(scaleProps.type && {
+            fillColor: scaleProps,
+          }),
         },
       };
     }

--- a/src/fetch-map/raster-layer.ts
+++ b/src/fetch-map/raster-layer.ts
@@ -376,20 +376,19 @@ export function domainFromRasterMetadataBand(
   if (scaleType === 'ordinal') {
     return colorRange.colorMap?.map(([value]) => value) || [];
   }
-  if (scaleType === 'custom') {
-    if (colorRange.uiCustomScaleType === 'logarithmic') {
-      return getLog10ScaleSteps({
-        min: band.stats.min,
-        max: band.stats.max,
-        steps: colorRange.colors.length,
-      });
-    } else {
-      // actually custom, read colorMap
-      return colorRange.colorMap?.map(([value]) => value) || [];
-    }
+  if (
+    scaleType === 'custom' &&
+    colorRange.uiCustomScaleType === 'logarithmic'
+  ) {
+    return getLog10ScaleSteps({
+      min: band.stats.min,
+      max: band.stats.max,
+      steps: colorRange.colors.length,
+    });
   }
-  const scaleLength = colorRange.colors.length;
+
   if (scaleType === 'quantile') {
+    const scaleLength = colorRange.colors.length;
     const quantiles = band.stats.quantiles?.[scaleLength];
     if (!quantiles) {
       return [0, 1];
@@ -453,6 +452,11 @@ export function getRasterTileLayerStylePropsScaledBand({
       layerConfig,
       visualChannels,
     }),
+    domain: rasterStyleType === 'ColorRange' ? [bandInfo.stats.min, bandInfo.stats.max] : domain,
+    scaleDomain: scaleFun.domain(),
+    range: colorRange.colors,
+    type: scaleType,
+    field: colorField,
   };
 }
 

--- a/src/fetch-map/types.ts
+++ b/src/fetch-map/types.ts
@@ -31,6 +31,7 @@ export type VisualChannels = {
   heightScale?: ScaleType;
 
   weightField?: VisualChannelField;
+  uniqueValuesColorScale?: ScaleType;
 };
 
 export type ColorRange = {

--- a/test/fetch-map/raster-layer.spec.ts
+++ b/test/fetch-map/raster-layer.spec.ts
@@ -246,7 +246,7 @@ describe('getRasterTileLayerStyleProps', () => {
   });
 
   it('colorRange / quantile', () => {
-    const {dataTransform} = getRasterTileLayerStyleProps({
+    const {dataTransform, ...scaleProps} = getRasterTileLayerStyleProps({
       layerConfig: {
         ...dummyLayerConfig,
         visConfig: {
@@ -268,6 +268,14 @@ describe('getRasterTileLayerStyleProps', () => {
       },
     });
 
+    expect(scaleProps).toMatchObject({
+      type: 'quantile',
+      field: {name: 'band_1', type: 'integer'},
+      domain: [0, 255],
+      scaleDomain: [0, 50, 100, 255],
+      range: ['#ff0000', '#00ff00', '#0000ff'],
+    });
+
     const testValues = [
       {input: 40, expected: [255, 0, 0, 255]},
       {input: 60, expected: [0, 255, 0, 255]},
@@ -283,7 +291,7 @@ describe('getRasterTileLayerStyleProps', () => {
   });
 
   it('colorRange / quantize', () => {
-    const {dataTransform} = getRasterTileLayerStyleProps({
+    const {dataTransform, ...scaleProps} = getRasterTileLayerStyleProps({
       layerConfig: {
         ...dummyLayerConfig,
         visConfig: {
@@ -305,6 +313,14 @@ describe('getRasterTileLayerStyleProps', () => {
       },
     });
 
+    expect(scaleProps).toMatchObject({
+      type: 'quantize',
+      field: {name: 'band_1', type: 'integer'},
+      domain: [0, 255],
+      scaleDomain: [0, 255],
+      range: ['#ff0000', '#00ff00', '#0000ff'],
+    });
+
     const testValues = [
       {input: 10, expected: [255, 0, 0, 255]},
       // { input: 123, expected: [0, 255, 0, 255] },
@@ -321,7 +337,7 @@ describe('getRasterTileLayerStyleProps', () => {
     runFillColorTests(testValues, info);
   });
   it('colorRange / log', () => {
-    const {dataTransform} = getRasterTileLayerStyleProps({
+    const {dataTransform, ...scaleProps} = getRasterTileLayerStyleProps({
       layerConfig: {
         ...dummyLayerConfig,
         visConfig: {
@@ -344,6 +360,14 @@ describe('getRasterTileLayerStyleProps', () => {
       },
     });
 
+    expect(scaleProps).toMatchObject({
+      type: 'custom',
+      field: {name: 'band_1', type: 'integer'},
+      domain: [0, 255],
+      scaleDomain: [10, 100],
+      range: ['#ff0000', '#00ff00', '#0000ff'],
+    });
+
     const testValues = [
       {input: 4, expected: [255, 0, 0, 255]},
       {input: 15, expected: [0, 255, 0, 255]},
@@ -359,7 +383,7 @@ describe('getRasterTileLayerStyleProps', () => {
     runFillColorTests(testValues, info);
   });
   it('uniqueValue / default', () => {
-    const {dataTransform} = getRasterTileLayerStyleProps({
+    const {dataTransform, ...scaleProps} = getRasterTileLayerStyleProps({
       layerConfig: {
         ...dummyLayerConfig,
         visConfig: {
@@ -383,6 +407,14 @@ describe('getRasterTileLayerStyleProps', () => {
       },
     });
 
+    expect(scaleProps).toMatchObject({
+      type: 'ordinal',
+      field: {name: 'band_1', type: 'integer'},
+      domain: [0, 1, 2, 3, 25],
+      scaleDomain: [0, 1, 2, 3, 25],
+      range: defaultQualitativeColor.colors,
+    });
+
     const testValues = [
       {input: 0, expected: defaultQualitativeColor.colors[0]},
       {input: 1, expected: defaultQualitativeColor.colors[1]},
@@ -400,7 +432,7 @@ describe('getRasterTileLayerStyleProps', () => {
     runFillColorTests(testValues, info);
   });
   it('uniqueValue / custom', () => {
-    const {dataTransform} = getRasterTileLayerStyleProps({
+    const {dataTransform, ...scaleProps} = getRasterTileLayerStyleProps({
       layerConfig: {
         ...dummyLayerConfig,
         visConfig: {
@@ -425,6 +457,14 @@ describe('getRasterTileLayerStyleProps', () => {
           type: 'integer',
         },
       },
+    });
+
+    expect(scaleProps).toMatchObject({
+      type: 'ordinal',
+      field: {name: 'band_1', type: 'integer'},
+      domain: [0, 1, 2],
+      scaleDomain: [0, 1, 2],
+      range: ['#ff0000', '#00ff00', '#0000ff'],
     });
 
     const testValues = [


### PR DESCRIPTION
Fixed `fillColor` scale returned for raster layers in in ColorRange mode.

We followed _legacy_ meaning of domain which is totally custom to every scale mode and follows what is returned for normal vector layers, that is:

We return

scaleType | domain | scaleDomain
----------| -------- | -------------
type of scale | true domain of data | domain used to construct d3.scaleXxxx
quantile | [min, q0, q1, q2, ..., max] | [min, q0, q1, q2, ..., max] // why not have exception, but it's what it is
quantize | [min, max] | [min, max]
log10 | [min, max] | [ step0, step1, step2...] // number of steps is colorRange length - 1
custom | [min, max] | [step0, step1, ..., null ] // number of values is number colors in range


For: https://app.shortcut.com/cartoteam/story/510645
