### PR TITLE
chore(release): v0.5.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## 0.5
 
+### 0.5.22
+
+- fix(parseMap): Fix scale info for custom & logarithmic scales (#251)
+
 ### 0.5.21
 
 - fix(query,fetchMap): Fix queryParameter encoding for POST requests. (#247)

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "homepage": "https://github.com/CartoDB/carto-api-client#readme",
   "author": "Don McCurdy <donmccurdy@carto.com>",
   "packageManager": "yarn@4.3.1",
-  "version": "0.5.21",
+  "version": "0.5.22",
   "license": "MIT",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
* https://github.com/CartoDB/carto-api-client/pull/251