### PR TITLE
chore(fetch-map): expose fillInMapDatasets and fillInTileStats

### DIFF
--- a/src/fetch-map/fetch-map.ts
+++ b/src/fetch-map/fetch-map.ts
@@ -95,7 +95,7 @@ async function _fetchTilestats(
   return true;
 }
 
-async function fillInMapDatasets(
+export async function fillInMapDatasets(
   {datasets, keplerMapConfig}: {datasets: Dataset[]; keplerMapConfig: any},
   context: _FetchMapContext
 ) {
@@ -106,7 +106,7 @@ async function fillInMapDatasets(
   return await Promise.all(promises);
 }
 
-async function fillInTileStats(
+export async function fillInTileStats(
   {datasets, keplerMapConfig}: {datasets: Dataset[]; keplerMapConfig: any},
   context: _FetchMapContext
 ) {

--- a/src/fetch-map/index.ts
+++ b/src/fetch-map/index.ts
@@ -3,7 +3,11 @@ export {
   applyLayerGroupFilters as _applyLayerGroupFilters,
 } from './basemap-styles.js';
 export {getRasterTileLayerStyleProps as _getRasterTileLayerStyleProps} from './raster-layer.js';
-export {fetchMap} from './fetch-map.js';
+export {
+  fetchMap,
+  fillInMapDatasets as _fillInMapDatasets,
+  fillInTileStats as _fillInTileStats,
+} from './fetch-map.js';
 export type {FetchMapOptions, FetchMapResult} from './fetch-map.js';
 export type {
   Basemap,


### PR DESCRIPTION
Expose `fillInMapDatasets` and `fillInTileStats` for use in builder