### PR TITLE
fix: Don't fetch fonts when invoked outside browser

### DIFF
--- a/src/fetch-map/fetch-map.ts
+++ b/src/fetch-map/fetch-map.ts
@@ -322,6 +322,7 @@ export async function fetchMap({
   /* global FontFace, window, document */
   if (
     textLayers.length &&
+    typeof window !== 'undefined' &&
     window.FontFace &&
     !document.fonts.check('12px Inter')
   ) {

--- a/src/fetch-map/fetch-map.ts
+++ b/src/fetch-map/fetch-map.ts
@@ -323,7 +323,9 @@ export async function fetchMap({
   if (
     textLayers.length &&
     typeof window !== 'undefined' &&
+    typeof document !== 'undefined' &&
     window.FontFace &&
+    document.fonts &&
     !document.fonts.check('12px Inter')
   ) {
     // Fetch font needed for labels


### PR DESCRIPTION
Fix for https://app.shortcut.com/cartoteam/story/529538/using-server-side-fetchmap-fails-if-there-are-labels-configured#activity-529593

### Changes

- Only fetch fonts when running in browser environment