### PR TITLE
chore(release): v0.5.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## 0.5
 
+### 0.5.24
+
+- fix(fetchMap): Don't fetch fonts when invoked outside browser (#264)
+
 ### 0.5.23
 
 - fix(fetchMap): Add tag-mapId to requests (#255)

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "homepage": "https://github.com/CartoDB/carto-api-client#readme",
   "author": "Don McCurdy <donmccurdy@carto.com>",
   "packageManager": "yarn@4.3.1",
-  "version": "0.5.23",
+  "version": "0.5.24",
   "license": "MIT",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
- https://github.com/CartoDB/carto-api-client/pull/264