### PR TITLE
fix(fetchMap): ordinal scale overflow categories render as Others instead of cycling palette [sc-542369]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-## 0.5
+- fix(fetchMap): ordinal color scale overflow categories render as "Others" instead of cycling palette (#269)
 
 ### 0.5.24
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "homepage": "https://github.com/CartoDB/carto-api-client#readme",
   "author": "Don McCurdy <donmccurdy@carto.com>",
   "packageManager": "yarn@4.3.1",
-  "version": "0.5.24",
+  "version": "0.5.25-alpha.ordinal-palette-fix.0",
   "license": "MIT",
   "publishConfig": {
     "access": "public"
@@ -130,5 +130,6 @@
   "resolutions": {
     "@carto/api-client": "portal:./",
     "rollup": "^4.20.0"
-  }
+  },
+  "stableVersion": "0.5.24"
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "homepage": "https://github.com/CartoDB/carto-api-client#readme",
   "author": "Don McCurdy <donmccurdy@carto.com>",
   "packageManager": "yarn@4.3.1",
-  "version": "0.5.25-alpha.ordinal-palette-fix.0",
+  "version": "0.5.24",
   "license": "MIT",
   "publishConfig": {
     "access": "public"
@@ -130,6 +130,5 @@
   "resolutions": {
     "@carto/api-client": "portal:./",
     "rollup": "^4.20.0"
-  },
-  "stableVersion": "0.5.24"
+  }
 }

--- a/src/fetch-map/layer-map.ts
+++ b/src/fetch-map/layer-map.ts
@@ -237,7 +237,7 @@ function domainFromAttribute(
     return attribute.categories
       .map((c: any) => c.category)
       .filter((c: any) => c !== undefined && c !== null)
-      .slice(0, scaleLength)
+      .slice(0, scaleLength);
   }
 
   if (scaleType === 'quantile' && attribute.quantiles) {

--- a/src/fetch-map/layer-map.ts
+++ b/src/fetch-map/layer-map.ts
@@ -236,7 +236,8 @@ function domainFromAttribute(
     }
     return attribute.categories
       .map((c: any) => c.category)
-      .filter((c: any) => c !== undefined && c !== null);
+      .filter((c: any) => c !== undefined && c !== null)
+      .slice(0, scaleLength)
   }
 
   if (scaleType === 'quantile' && attribute.quantiles) {

--- a/test/fetch-map/layer-map.spec.ts
+++ b/test/fetch-map/layer-map.spec.ts
@@ -170,6 +170,39 @@ describe('layer-map', () => {
         expected: hexToRGBA(colors[2]),
       },
       {
+        title: 'ordinal overflow categories get unknown color',
+        colorField: {name: 'v'},
+        colorScale: 'ordinal',
+        colorRange: {
+          colors: colors.slice(0, 3), // only 3 palette colors
+        },
+        opacity: 1,
+        data: {
+          tilestats: {
+            layers: [
+              {
+                attributes: [
+                  {
+                    attribute: 'v',
+                    categories: [
+                      {category: 'A'},
+                      {category: 'B'},
+                      {category: 'C'},
+                      {category: 'D'},
+                      {category: 'E'},
+                      {category: 'F'},
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        // Category D overflows the 3-color palette, should get grey "Others"
+        d: {properties: {v: 'D'}},
+        expected: [134, 141, 145, 255],
+      },
+      {
         title: 'hexColumn',
         colorField: {name: 'v', colorColumn: 'vColor'},
         colorScale: 'ordinal',


### PR DESCRIPTION
Shortcut: https://app.shortcut.com/cartoteam/story/542369

When a layer uses an ordinal color scale with fewer palette colors than unique categories, overflow categories now get the grey "Others" color instead of cycling back through the palette. This matches the legend behavior.

- Truncate ordinal domain to palette length in `domainFromAttribute` so overflow values hit `scale.unknown()`