### PR TITLE
chore(release): v0.5.25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+### 0.5.25
+
 - fix(fetchMap): ordinal color scale overflow categories render as "Others" instead of cycling palette (#269)
 
 ### 0.5.24

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "homepage": "https://github.com/CartoDB/carto-api-client#readme",
   "author": "Don McCurdy <donmccurdy@carto.com>",
   "packageManager": "yarn@4.3.1",
-  "version": "0.5.24",
+  "version": "0.5.25",
   "license": "MIT",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary

Release v0.5.25 with ordinal palette overflow fix from [sc-542369].

- #269
