### PR TITLE
fix(widgetSources): add offset request option and total for pagination

### DIFF
--- a/src/widget-sources/types.ts
+++ b/src/widget-sources/types.ts
@@ -114,6 +114,11 @@ export interface FeaturesRequestOptions extends BaseRequestOptions {
   limit?: number;
 
   /**
+   * Number of objects to skip in the result set.
+   */
+  offset?: number;
+
+  /**
    * Must match `tileResolution` used when obtaining the `_carto_feature_id`
    * column, typically in a layer's tile requests.
    */
@@ -239,7 +244,10 @@ export type ExtentRequestOptions = BaseRequestOptions;
  * @experimental
  * @internal
  */
-export type FeaturesResponse = {rows: Record<string, unknown>[]};
+export type FeaturesResponse = {
+  rows: Record<string, unknown>[];
+  metadata: {total?: number};
+};
 
 /** Response from {@link WidgetRemoteSource#getFormula}. */
 export type FormulaResponse = {value: number | null};

--- a/src/widget-sources/widget-remote-source.ts
+++ b/src/widget-sources/widget-remote-source.ts
@@ -140,9 +140,8 @@ export abstract class WidgetRemoteSource<
       spatialFiltersMode,
       ...params
     } = options;
-    const {columns, dataType, featureIds, z, limit, tileResolution} = params;
-
-    type FeaturesModelResponse = {rows: Record<string, unknown>[]};
+    const {columns, dataType, featureIds, z, limit, tileResolution, offset} =
+      params;
 
     return executeModel({
       model: 'pick',
@@ -156,12 +155,13 @@ export abstract class WidgetRemoteSource<
         dataType,
         featureIds,
         z,
+        offset,
         limit: limit || 1000,
         tileResolution: tileResolution || DEFAULT_TILE_RESOLUTION,
       },
       opts: {signal, headers: this.props.headers},
       // Avoid `normalizeObjectKeys()`, which changes column names.
-    }).then(({rows}: FeaturesModelResponse) => ({rows}));
+    }).then(({rows, metadata}: FeaturesResponse) => ({rows, metadata}));
   }
 
   async getFormula(options: FormulaRequestOptions): Promise<FormulaResponse> {


### PR DESCRIPTION
Pick API returns the total entity count only when both offset and limit are provided. Add support for the offset option.