### PR TITLE
feat(parseMap): add compile custom aggregation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- feat(parseMap): custom aggregation support on spatial-index and geometry-aggregated layers. Adds `compileCustomAggregation(expression, { provider })` helper, `VisualChannelField.accessorKey`, and `{channel}AggregationExp` / `{channel}AggregationDomain` on `VisConfig` for all 6 channels.
 - chore(ci): add prerelease support to release workflow (#274)
 
 ### 0.5.26

--- a/src/fetch-map/layer-map.ts
+++ b/src/fetch-map/layer-map.ts
@@ -342,9 +342,17 @@ function findAccessorKey(keys: string[], properties: any): string[] {
 }
 
 export function getColorAccessor(
-  {name, colorColumn}: VisualChannelField,
+  {name, colorColumn, accessorKey}: VisualChannelField,
   scaleType: ScaleType,
-  {aggregation, range}: {aggregation?: string; range: ColorRange},
+  {
+    aggregation,
+    range,
+    domainOverride,
+  }: {
+    aggregation?: string;
+    range: ColorRange;
+    domainOverride?: [number, number];
+  },
   opacity: number | undefined,
   data: TilejsonResult
 ): {
@@ -353,15 +361,23 @@ export function getColorAccessor(
   scaleDomain: number[] | string[];
   range: string[];
 } {
+  // accessorKey (custom-agg alias) wins over colorColumn (legacy identity-color
+  // column), which wins over name (standard field).
+  const effectiveName = accessorKey ?? colorColumn ?? name;
+  const effectiveScaleType =
+    colorColumn && !accessorKey ? 'identity' : scaleType;
   const {scale, domain} = calculateLayerScale(
-    colorColumn || name,
-    colorColumn ? 'identity' : scaleType,
+    effectiveName,
+    effectiveScaleType,
     range,
-    data
+    data,
+    domainOverride
   );
   const alpha = opacityToAlpha(opacity);
 
-  let accessorKeys = getAccessorKeys(colorColumn || name, aggregation);
+  let accessorKeys = accessorKey
+    ? [accessorKey]
+    : getAccessorKeys(colorColumn || name, aggregation);
   const accessor = (properties: any) => {
     if (!(accessorKeys[0] in properties)) {
       accessorKeys = findAccessorKey(accessorKeys, properties);
@@ -383,13 +399,20 @@ export function calculateLayerScale(
   name: string,
   scaleType: ScaleType,
   range: ColorRange,
-  data: TilejsonResult
+  data: TilejsonResult,
+  domainOverride?: [number, number]
 ): {scale: D3Scale; domain: string[] | number[]} {
   let scaleDomain: number[] | string[] | undefined;
   let scaleColors: string[] = [];
   const {colors} = range;
 
-  const domain = calculateDomain(data, name, scaleType, colors.length);
+  // colorMap (explicit break values from Custom classification) wins over
+  // domainOverride (user Min/Max for Custom aggregation). colorMap defines
+  // its own domain, so the override does not apply.
+  const domain =
+    domainOverride && !range.colorMap
+      ? domainOverride
+      : calculateDomain(data, name, scaleType, colors.length);
   if (scaleType !== 'identity') {
     if (range.colorMap) {
       const {colorMap} = range;
@@ -506,11 +529,12 @@ export function negateAccessor(accessor: Accessor): Accessor {
 }
 
 export function getSizeAccessor(
-  {name}: VisualChannelField,
+  {name, accessorKey}: VisualChannelField,
   scaleType: ScaleType | undefined,
   aggregation: string | null | undefined,
   range: number[] | undefined,
-  data: TilejsonResult
+  data: TilejsonResult,
+  domainOverride?: [number, number]
 ): {
   accessor: any;
   domain: number[];
@@ -521,7 +545,10 @@ export function getSizeAccessor(
   let domain: number[] = [];
   if (scaleType && range) {
     if (aggregation !== AggregationTypes.Count) {
-      domain = calculateDomain(data, name, scaleType) as number[];
+      const source = accessorKey ?? name;
+      domain =
+        domainOverride ??
+        (calculateDomain(data, source, scaleType) as number[]);
       (scale as D3Scale).domain(domain);
     } else {
       domain = (scale as D3Scale).domain();
@@ -529,7 +556,9 @@ export function getSizeAccessor(
     (scale as D3Scale).range(range);
   }
 
-  let accessorKeys = getAccessorKeys(name, aggregation);
+  let accessorKeys = accessorKey
+    ? [accessorKey]
+    : getAccessorKeys(name, aggregation);
   const accessor = (properties: any) => {
     if (!(accessorKeys[0] in properties)) {
       accessorKeys = findAccessorKey(accessorKeys, properties);
@@ -597,14 +626,42 @@ export function getDefaultAggregationExpColumnAliasForLayerType(
   }
 }
 
+function hashString(input: string): string {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < input.length; i++) {
+    h ^= input.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return (h >>> 0).toString(16).padStart(8, '0');
+}
+
+function normalizeExpression(exp: string): string {
+  return exp.trim().replace(/\s+/g, ' ');
+}
+
+function applyProviderCase(alias: string, provider: ProviderType): string {
+  return provider === 'snowflake' ? alias.toUpperCase() : alias;
+}
+
 /** @privateRemarks Source: Builder */
 function getColumnAliasForAggregationExp(
   name: string,
   aggregation: string,
   provider: ProviderType
 ) {
-  const columnAlias = `${name}_${aggregation}`;
-  return provider === 'snowflake' ? columnAlias.toUpperCase() : columnAlias;
+  return applyProviderCase(`${name}_${aggregation}`, provider);
+}
+
+export function compileCustomAggregation(
+  exp: string,
+  opts: {provider: ProviderType}
+): string {
+  const normalized = normalizeExpression(exp);
+  if (!normalized) {
+    throw new Error('Custom aggregation expression must not be empty');
+  }
+  const hash = hashString(normalized);
+  return applyProviderCase('custom_agg_' + hash, opts.provider);
 }
 
 /** @privateRemarks Source: Builder */

--- a/src/fetch-map/parse-map.ts
+++ b/src/fetch-map/parse-map.ts
@@ -2,6 +2,7 @@ import type {ColorParameters} from '@luma.gl/core';
 import {
   calculateClusterRadius,
   calculateClusterTextFontSize,
+  compileCustomAggregation,
   getDefaultAggregationExpColumnAliasForLayerType,
   getLayerProps,
   getColorAccessor,
@@ -35,6 +36,7 @@ import {
   getRasterTileLayerStylePropsRgb,
   getRasterTileLayerStylePropsScaledBand,
 } from './raster-layer.js';
+import type {ProviderType} from '../types.js';
 import type {TilejsonResult} from '../sources/types.js';
 
 export type Scale = {
@@ -53,6 +55,7 @@ export type ScaleKey =
   | 'fillColor'
   | 'pointRadius'
   | 'lineColor'
+  | 'lineWidth'
   | 'elevation'
   | 'weight';
 
@@ -250,6 +253,37 @@ function createStyleProps(config: MapLayerConfig, mapping: any) {
   return result;
 }
 
+function resolveCustomAggregation({
+  field,
+  aggregation,
+  expression,
+  domain,
+  providerId,
+}: {
+  field: VisualChannelField | undefined;
+  aggregation: string | undefined;
+  expression: string | undefined;
+  domain: [number, number] | undefined;
+  providerId: ProviderType;
+}): {
+  field: VisualChannelField | undefined;
+  aggregation: string | undefined;
+  domainOverride: [number, number] | undefined;
+} {
+  if (aggregation !== 'custom') {
+    return {field, aggregation, domainOverride: undefined};
+  }
+  if (!field || !expression?.trim()) {
+    return {field, aggregation: undefined, domainOverride: undefined};
+  }
+  const alias = compileCustomAggregation(expression, {provider: providerId});
+  return {
+    field: {...field, accessorKey: alias},
+    aggregation: undefined,
+    domainOverride: domain,
+  };
+}
+
 function createChannelProps(
   id: string,
   layerType: LayerType,
@@ -313,18 +347,25 @@ function createChannelProps(
   // fill color
   {
     const {colorField, colorScale} = visualChannels;
-    const {colorRange, colorAggregation} = visConfig;
-    if (colorField && colorScale && colorRange) {
+    const {colorRange} = visConfig;
+    const {field, aggregation, domainOverride} = resolveCustomAggregation({
+      field: colorField,
+      aggregation: visConfig.colorAggregation,
+      expression: visConfig.colorAggregationExp,
+      domain: visConfig.colorAggregationDomain,
+      providerId: dataset.providerId,
+    });
+    if (field && colorScale && colorRange) {
       const {accessor, ...scaleProps} = getColorAccessor(
-        colorField,
+        field,
         colorScale,
-        {aggregation: colorAggregation, range: colorRange},
+        {aggregation, range: colorRange, domainOverride},
         visConfig.opacity,
         data
       );
       result.getFillColor = accessor;
       scales.fillColor = updateTriggers.getFillColor = {
-        field: colorField,
+        field,
         type: colorScale,
         ...scaleProps,
       };
@@ -398,44 +439,57 @@ function createChannelProps(
 
   // point radius
   {
-    const radiusRange = visConfig.radiusRange;
     const {radiusField, radiusScale} = visualChannels;
-    if (radiusField && radiusRange && radiusScale) {
+    const {radiusRange} = visConfig;
+    const {field, aggregation, domainOverride} = resolveCustomAggregation({
+      field: radiusField,
+      aggregation: visConfig.radiusAggregation,
+      expression: visConfig.radiusAggregationExp,
+      domain: visConfig.radiusAggregationDomain,
+      providerId: dataset.providerId,
+    });
+    if (field && radiusRange && radiusScale) {
       const {accessor, ...scaleProps} = getSizeAccessor(
-        radiusField,
+        field,
         radiusScale,
-        visConfig.radiusAggregation,
+        aggregation,
         radiusRange,
-        data
+        data,
+        domainOverride
       );
       result.getPointRadius = accessor;
       scales.pointRadius = updateTriggers.getPointRadius = {
-        field: radiusField,
+        field,
         type: radiusScale,
         ...scaleProps,
       };
     }
   }
 
-  // stroke/ouline color
+  // stroke/outline color
   {
-    const strokeColorRange = visConfig.strokeColorRange;
     const {strokeColorScale, strokeColorField} = visualChannels;
-    if (strokeColorField && strokeColorRange && strokeColorScale) {
-      const {strokeColorAggregation: aggregation} = visConfig;
+    const {strokeColorRange} = visConfig;
+    const {field, aggregation, domainOverride} = resolveCustomAggregation({
+      field: strokeColorField,
+      aggregation: visConfig.strokeColorAggregation,
+      expression: visConfig.strokeColorAggregationExp,
+      domain: visConfig.strokeColorAggregationDomain,
+      providerId: dataset.providerId,
+    });
+    if (field && strokeColorRange && strokeColorScale) {
       const opacity =
         visConfig.strokeOpacity !== undefined ? visConfig.strokeOpacity : 1;
-
       const {accessor, ...scaleProps} = getColorAccessor(
-        strokeColorField,
+        field,
         strokeColorScale,
-        {aggregation, range: strokeColorRange},
+        {aggregation, range: strokeColorRange, domainOverride},
         opacity,
         data
       );
       result.getLineColor = accessor;
       scales.lineColor = updateTriggers.getLineColor = {
-        field: strokeColorField,
+        field,
         type: strokeColorScale,
         ...scaleProps,
       };
@@ -446,19 +500,26 @@ function createChannelProps(
   {
     const {sizeField: strokeWidthField, sizeScale: strokeWidthScale} =
       visualChannels;
-    const {sizeRange, sizeAggregation} = visConfig;
-
-    if (strokeWidthField && sizeRange) {
+    const {sizeRange} = visConfig;
+    const {field, aggregation, domainOverride} = resolveCustomAggregation({
+      field: strokeWidthField,
+      aggregation: visConfig.sizeAggregation,
+      expression: visConfig.sizeAggregationExp,
+      domain: visConfig.sizeAggregationDomain,
+      providerId: dataset.providerId,
+    });
+    if (field && sizeRange) {
       const {accessor, ...scaleProps} = getSizeAccessor(
-        strokeWidthField,
+        field,
         strokeWidthScale,
-        sizeAggregation,
+        aggregation,
         sizeRange,
-        data
+        data,
+        domainOverride
       );
       result.getLineWidth = accessor;
       scales.lineWidth = updateTriggers.getLineWidth = {
-        field: strokeWidthField,
+        field,
         type: strokeWidthScale || 'identity',
         ...scaleProps,
       };
@@ -467,19 +528,27 @@ function createChannelProps(
 
   // height / elevation
   {
-    const {enable3d, heightRange} = visConfig;
     const {heightField, heightScale} = visualChannels;
-    if (heightField && heightRange && enable3d) {
+    const {enable3d, heightRange} = visConfig;
+    const {field, aggregation, domainOverride} = resolveCustomAggregation({
+      field: heightField,
+      aggregation: visConfig.heightAggregation,
+      expression: visConfig.heightAggregationExp,
+      domain: visConfig.heightAggregationDomain,
+      providerId: dataset.providerId,
+    });
+    if (field && heightRange && enable3d) {
       const {accessor, ...scaleProps} = getSizeAccessor(
-        heightField,
+        field,
         heightScale,
-        visConfig.heightAggregation,
+        aggregation,
         heightRange,
-        data
+        data,
+        domainOverride
       );
       result.getElevation = accessor;
       scales.elevation = updateTriggers.getElevation = {
-        field: heightField,
+        field,
         type: heightScale || 'identity',
         ...scaleProps,
       };
@@ -489,18 +558,25 @@ function createChannelProps(
   // weight
   {
     const {weightField} = visualChannels;
-    const {weightAggregation} = visConfig;
-    if (weightField && weightAggregation) {
+    const {field, aggregation, domainOverride} = resolveCustomAggregation({
+      field: weightField,
+      aggregation: visConfig.weightAggregation,
+      expression: visConfig.weightAggregationExp,
+      domain: visConfig.weightAggregationDomain,
+      providerId: dataset.providerId,
+    });
+    if (field && (aggregation || visConfig.weightAggregation === 'custom')) {
       const {accessor, ...scaleProps} = getSizeAccessor(
-        weightField,
+        field,
         undefined,
-        weightAggregation,
+        aggregation,
         undefined,
-        data
+        data,
+        domainOverride
       );
       result.getWeight = accessor;
       scales.weight = updateTriggers.getWeight = {
-        field: weightField,
+        field,
         type: 'identity' as ScaleType,
         ...scaleProps,
       };

--- a/src/fetch-map/types.ts
+++ b/src/fetch-map/types.ts
@@ -6,6 +6,7 @@ export type VisualChannelField = {
   name: string;
   type: string;
   colorColumn?: string;
+  accessorKey?: string;
 };
 
 export type VisualChannels = {
@@ -65,6 +66,8 @@ export type VisConfig = {
   enable3d?: boolean;
 
   colorAggregation?: string;
+  colorAggregationExp?: string;
+  colorAggregationDomain?: [number, number];
   colorRange: ColorRange;
 
   customMarkers?: boolean;
@@ -74,18 +77,28 @@ export type VisConfig = {
   radius: number;
   radiusRange?: number[];
   radiusAggregation?: string;
+  radiusAggregationExp?: string;
+  radiusAggregationDomain?: [number, number];
 
   sizeAggregation?: string;
+  sizeAggregationExp?: string;
+  sizeAggregationDomain?: [number, number];
   sizeRange?: number[];
 
   strokeColorAggregation?: string;
+  strokeColorAggregationExp?: string;
+  strokeColorAggregationDomain?: [number, number];
   strokeOpacity?: number;
   strokeColorRange?: ColorRange;
 
   heightRange?: number[];
   heightAggregation?: string;
+  heightAggregationExp?: string;
+  heightAggregationDomain?: [number, number];
 
   weightAggregation?: string;
+  weightAggregationExp?: string;
+  weightAggregationDomain?: [number, number];
 
   // type = clusterTile
   clusterLevel?: number;

--- a/test/fetch-map/aggregation.test.ts
+++ b/test/fetch-map/aggregation.test.ts
@@ -1,0 +1,97 @@
+import {describe, test, expect} from 'vitest';
+import {compileCustomAggregation} from '@carto/api-client';
+
+describe('aggregation', () => {
+  describe('compileCustomAggregation', () => {
+    test('produces alias matching /^custom_agg_[0-9a-f]{8}$/ for bigquery', () => {
+      const alias = compileCustomAggregation('SUM(revenue) / SUM(users)', {
+        provider: 'bigquery',
+      });
+      expect(alias).toMatch(/^custom_agg_[0-9a-f]{8}$/);
+    });
+
+    test.each([
+      {provider: 'bigquery'},
+      {provider: 'postgres'},
+      {provider: 'redshift'},
+      {provider: 'databricks'},
+      {provider: 'carto'},
+      {provider: 'carto_dw'},
+    ] as const)(
+      'produces lowercase alias for provider $provider',
+      ({provider}) => {
+        const alias = compileCustomAggregation('SUM(a) / SUM(b)', {provider});
+        expect(alias).toMatch(/^custom_agg_[0-9a-f]{8}$/);
+      }
+    );
+
+    test('produces uppercase alias for snowflake', () => {
+      const alias = compileCustomAggregation('SUM(revenue) / SUM(users)', {
+        provider: 'snowflake',
+      });
+      expect(alias).toMatch(/^CUSTOM_AGG_[0-9A-F]{8}$/);
+    });
+
+    test('normalizes whitespace: leading and trailing spaces', () => {
+      const trimmed = compileCustomAggregation('SUM(x) / SUM(y)', {
+        provider: 'bigquery',
+      });
+      const padded = compileCustomAggregation('  SUM(x) / SUM(y)  ', {
+        provider: 'bigquery',
+      });
+      expect(padded).toBe(trimmed);
+    });
+
+    test('normalizes whitespace: multiple internal spaces', () => {
+      const normal = compileCustomAggregation('SUM(x) / SUM(y)', {
+        provider: 'bigquery',
+      });
+      const spaced = compileCustomAggregation('SUM(x)  /  SUM(y)', {
+        provider: 'bigquery',
+      });
+      expect(spaced).toBe(normal);
+    });
+
+    test('normalizes whitespace: tabs', () => {
+      const normal = compileCustomAggregation('SUM(x) / SUM(y)', {
+        provider: 'bigquery',
+      });
+      const tabbed = compileCustomAggregation('SUM(x)\t/\tSUM(y)', {
+        provider: 'bigquery',
+      });
+      expect(tabbed).toBe(normal);
+    });
+
+    test('throws on empty expression', () => {
+      expect(() =>
+        compileCustomAggregation('', {provider: 'bigquery'})
+      ).toThrow();
+    });
+
+    test('throws on whitespace-only expression', () => {
+      expect(() =>
+        compileCustomAggregation('   ', {provider: 'bigquery'})
+      ).toThrow();
+    });
+
+    test('produces same output for same input', () => {
+      const a = compileCustomAggregation('SUM(revenue) / SUM(users)', {
+        provider: 'bigquery',
+      });
+      const b = compileCustomAggregation('SUM(revenue) / SUM(users)', {
+        provider: 'bigquery',
+      });
+      expect(a).toBe(b);
+    });
+
+    test('different expressions produce different aliases', () => {
+      const a = compileCustomAggregation('SUM(revenue) / SUM(users)', {
+        provider: 'bigquery',
+      });
+      const b = compileCustomAggregation('AVG(price) * COUNT(*)', {
+        provider: 'bigquery',
+      });
+      expect(a).not.toBe(b);
+    });
+  });
+});

--- a/test/fetch-map/layer-map.spec.ts
+++ b/test/fetch-map/layer-map.spec.ts
@@ -1,6 +1,7 @@
 import {describe, test, expect} from 'vitest';
 import {
   getColorAccessor,
+  getSizeAccessor,
   getTextAccessor,
   getLayerProps,
   _domainFromValues,
@@ -244,21 +245,178 @@ describe('layer-map', () => {
     });
   });
 
-  // describe('size accessors', () => {
-  //   // TODO add test cases using tilestats data
-  //   const SIZE_TESTS = [];
+  describe('getColorAccessor accessorKey override', () => {
+    const COLOR_ACCESSOR_KEY_TESTS = [
+      {
+        title: 'uses accessorKey when provided',
+        field: {
+          name: 'revenue',
+          type: 'real',
+          accessorKey: 'custom_agg_abc12345',
+        },
+        attribute: 'custom_agg_abc12345',
+        properties: {custom_agg_abc12345: 50, revenue: 999},
+      },
+      {
+        title: 'falls back to getAccessorKeys when accessorKey is absent',
+        field: {name: 'v', type: 'real'},
+        attribute: 'v',
+        properties: {v: 50},
+      },
+    ];
 
-  //   test.each(SIZE_TESTS)('getSizeAccessor $sizeScale', (testCase) => {
-  //     const accessor = getSizeAccessor(
-  //       testCase.sizeField,
-  //       testCase.sizeScale,
-  //       undefined,
-  //       testCase.sizeRange,
-  //       testCase.data
-  //     );
-  //     expect(accessor(testCase.d)).toBe(testCase.expected);
-  //   });
-  // });
+    test.each(COLOR_ACCESSOR_KEY_TESTS)(
+      'getColorAccessor $title',
+      (testCase) => {
+        const {accessor} = getColorAccessor(
+          testCase.field,
+          'quantize',
+          {
+            range: {
+              colors: colors.slice(0, 2),
+              name: '',
+              type: '',
+              category: '',
+              colorMap: undefined,
+            },
+          },
+          1,
+          {
+            tilestats: {
+              layers: [
+                {
+                  attributes: [
+                    {attribute: testCase.attribute, min: 0, max: 100},
+                  ],
+                },
+              ],
+            },
+          }
+        );
+        const result = accessor({properties: testCase.properties});
+        expect(result).toBeDefined();
+        expect(result.length).toBe(4);
+      }
+    );
+
+    test('accessorKey reads the aliased property, not the name-derived one', () => {
+      const data = {
+        tilestats: {
+          layers: [
+            {
+              attributes: [
+                {attribute: 'custom_agg_abc12345', min: 0, max: 100},
+              ],
+            },
+          ],
+        },
+      };
+      const range = {
+        colors: colors.slice(0, 2),
+        name: '',
+        type: '',
+        category: '',
+        colorMap: undefined,
+      };
+      const {accessor: accessorWithKey} = getColorAccessor(
+        {name: 'revenue', type: 'real', accessorKey: 'custom_agg_abc12345'},
+        'quantize',
+        {range},
+        1,
+        data
+      );
+      const resultWithKey = accessorWithKey({
+        properties: {custom_agg_abc12345: 80, revenue: 20},
+      });
+
+      const {accessor: accessorNoKey} = getColorAccessor(
+        {name: 'revenue', type: 'real'},
+        'quantize',
+        {range},
+        1,
+        {
+          tilestats: {
+            layers: [{attributes: [{attribute: 'revenue', min: 0, max: 100}]}],
+          },
+        }
+      );
+      const resultNoKey = accessorNoKey({properties: {revenue: 20}});
+
+      expect(resultWithKey).not.toEqual(resultNoKey);
+    });
+  });
+
+  describe('getSizeAccessor accessorKey override', () => {
+    const SIZE_ACCESSOR_KEY_TESTS = [
+      {
+        title: 'uses accessorKey when provided',
+        field: {
+          name: 'population',
+          type: 'real',
+          accessorKey: 'custom_agg_def67890',
+        },
+        attribute: 'custom_agg_def67890',
+        properties: {custom_agg_def67890: 500, population: 999},
+      },
+      {
+        title: 'falls back to getAccessorKeys when accessorKey is absent',
+        field: {name: 'population', type: 'real'},
+        attribute: 'population',
+        properties: {population: 500},
+      },
+    ];
+
+    test.each(SIZE_ACCESSOR_KEY_TESTS)('getSizeAccessor $title', (testCase) => {
+      const {accessor} = getSizeAccessor(
+        testCase.field,
+        'linear',
+        undefined,
+        [1, 10],
+        {
+          tilestats: {
+            layers: [
+              {
+                attributes: [
+                  {attribute: testCase.attribute, min: 0, max: 1000},
+                ],
+              },
+            ],
+          },
+        }
+      );
+      const result = accessor({properties: testCase.properties});
+      expect(typeof result).toBe('number');
+    });
+
+    test('accessorKey reads aliased property and produces the expected scaled value', () => {
+      const {accessor} = getSizeAccessor(
+        {
+          name: 'population',
+          type: 'real',
+          accessorKey: 'custom_agg_def67890',
+        },
+        'linear',
+        undefined,
+        [1, 10],
+        {
+          tilestats: {
+            layers: [
+              {
+                attributes: [
+                  {attribute: 'custom_agg_def67890', min: 0, max: 1000},
+                ],
+              },
+            ],
+          },
+        }
+      );
+      const result = accessor({
+        properties: {custom_agg_def67890: 500, population: 100},
+      });
+      const scaledValue = 1 + (500 / 1000) * (10 - 1);
+      expect(result).toBeCloseTo(scaledValue, 1);
+    });
+  });
 
   describe('text accessors', () => {
     const TEXT_TESTS = [

--- a/test/fetch-map/parse-map.spec.ts
+++ b/test/fetch-map/parse-map.spec.ts
@@ -206,4 +206,706 @@ describe('parseMap', () => {
     expect(result.legendSettings).toBeDefined();
     expect(result.legendSettings).toEqual(config.legendSettings);
   });
+
+  describe('custom aggregation', () => {
+    const CUSTOM_AGG_DATASET = {
+      id: 'CUSTOM_AGG_DS',
+      data: {
+        scheme: 'h3',
+        tiles: ['https://example.com/tiles/{i}'],
+        tilestats: {
+          layers: [
+            {
+              attributes: [
+                {
+                  attribute: 'custom_agg_cc6f64ff',
+                  min: 0,
+                  max: 100,
+                  type: 'Number',
+                },
+                {attribute: 'revenue', min: 0, max: 1000, type: 'Number'},
+                {attribute: 'revenue_sum', min: 0, max: 5000, type: 'Number'},
+              ],
+            },
+          ],
+        },
+        accessToken: 'test-token',
+      },
+      type: 'tileset',
+      providerId: 'bigquery',
+      connectionName: 'test',
+      geoColumn: 'geom',
+      columns: [],
+      format: 'tilejson',
+      aggregationExp: '1 AS __aggregationValue',
+      aggregationResLevel: 4,
+      queryParameters: [],
+    };
+
+    test('custom color aggregation sets accessorKey on colorField', () => {
+      const keplerMapConfig = {
+        version: 'v1',
+        config: {
+          mapState: {},
+          mapStyle: {},
+          visState: {
+            layers: [
+              {
+                id: 'layer1',
+                type: 'h3',
+                config: {
+                  dataId: 'CUSTOM_AGG_DS',
+                  label: 'Test Layer',
+                  textLabel: [{field: null, size: 12}],
+                  visConfig: {
+                    filled: true,
+                    opacity: 1,
+                    colorAggregation: 'custom',
+                    colorAggregationExp: 'SUM(x)/SUM(y)',
+                    colorRange: {
+                      category: 'sequential',
+                      colors: ['#f0f0f0', '#333333'],
+                      colorMap: undefined,
+                      name: 'custom',
+                      type: 'custom',
+                    },
+                    sizeAggregation: 'sum',
+                    sizeRange: [1, 10],
+                    radius: 5,
+                  },
+                },
+                visualChannels: {
+                  colorField: {name: 'revenue', type: 'real'},
+                  colorScale: 'quantize',
+                  sizeField: {name: 'revenue', type: 'real'},
+                  sizeScale: 'linear',
+                },
+              },
+            ],
+            layerBlending: 'normal',
+            interactionConfig: {tooltip: {enabled: false}},
+          },
+        },
+      };
+      const map = parseMap({
+        ...METADATA,
+        datasets: [CUSTOM_AGG_DATASET],
+        keplerMapConfig,
+      });
+      expect(map.layers[0].scales.fillColor?.field?.accessorKey).toBe(
+        'custom_agg_cc6f64ff'
+      );
+    });
+
+    test('standard aggregation does not set accessorKey', () => {
+      const keplerMapConfig = {
+        version: 'v1',
+        config: {
+          mapState: {},
+          mapStyle: {},
+          visState: {
+            layers: [
+              {
+                id: 'layer1',
+                type: 'h3',
+                config: {
+                  dataId: 'CUSTOM_AGG_DS',
+                  label: 'Test Layer',
+                  textLabel: [{field: null, size: 12}],
+                  visConfig: {
+                    filled: true,
+                    opacity: 1,
+                    colorAggregation: 'sum',
+                    colorRange: {
+                      category: 'sequential',
+                      colors: ['#f0f0f0', '#333333'],
+                      colorMap: undefined,
+                      name: 'custom',
+                      type: 'custom',
+                    },
+                    sizeAggregation: 'sum',
+                    sizeRange: [1, 10],
+                    radius: 5,
+                  },
+                },
+                visualChannels: {
+                  colorField: {name: 'revenue', type: 'real'},
+                  colorScale: 'quantize',
+                  sizeField: {name: 'revenue', type: 'real'},
+                  sizeScale: 'linear',
+                },
+              },
+            ],
+            layerBlending: 'normal',
+            interactionConfig: {tooltip: {enabled: false}},
+          },
+        },
+      };
+      const map = parseMap({
+        ...METADATA,
+        datasets: [CUSTOM_AGG_DATASET],
+        keplerMapConfig,
+      });
+      expect(
+        map.layers[0].scales.fillColor?.field?.accessorKey
+      ).toBeUndefined();
+    });
+
+    test('mixed custom color and standard size: color gets accessorKey, size does not', () => {
+      const keplerMapConfig = {
+        version: 'v1',
+        config: {
+          mapState: {},
+          mapStyle: {},
+          visState: {
+            layers: [
+              {
+                id: 'layer1',
+                type: 'h3',
+                config: {
+                  dataId: 'CUSTOM_AGG_DS',
+                  label: 'Test Layer',
+                  textLabel: [{field: null, size: 12}],
+                  visConfig: {
+                    filled: true,
+                    opacity: 1,
+                    colorAggregation: 'custom',
+                    colorAggregationExp: 'SUM(x)/SUM(y)',
+                    colorRange: {
+                      category: 'sequential',
+                      colors: ['#f0f0f0', '#333333'],
+                      colorMap: undefined,
+                      name: 'custom',
+                      type: 'custom',
+                    },
+                    sizeAggregation: 'sum',
+                    sizeRange: [1, 10],
+                    radius: 5,
+                  },
+                },
+                visualChannels: {
+                  colorField: {name: 'revenue', type: 'real'},
+                  colorScale: 'quantize',
+                  sizeField: {name: 'revenue', type: 'real'},
+                  sizeScale: 'linear',
+                },
+              },
+            ],
+            layerBlending: 'normal',
+            interactionConfig: {tooltip: {enabled: false}},
+          },
+        },
+      };
+      const map = parseMap({
+        ...METADATA,
+        datasets: [CUSTOM_AGG_DATASET],
+        keplerMapConfig,
+      });
+      const layerDesc = map.layers[0];
+      expect(layerDesc.scales.fillColor?.field?.accessorKey).toBe(
+        'custom_agg_cc6f64ff'
+      );
+      expect(layerDesc.scales.lineWidth).toBeDefined();
+      expect(layerDesc.scales.lineWidth?.field?.accessorKey).toBeUndefined();
+    });
+
+    test('colorAggregationDomain overrides auto-computed scale domain', () => {
+      const keplerMapConfig = {
+        version: 'v1',
+        config: {
+          mapState: {},
+          mapStyle: {},
+          visState: {
+            layers: [
+              {
+                id: 'layer1',
+                type: 'h3',
+                config: {
+                  dataId: 'CUSTOM_AGG_DS',
+                  label: 'Test Layer',
+                  textLabel: [{field: null, size: 12}],
+                  visConfig: {
+                    filled: true,
+                    opacity: 1,
+                    colorAggregation: 'custom',
+                    colorAggregationExp: 'SUM(x)/SUM(y)',
+                    colorAggregationDomain: [10, 90],
+                    colorRange: {
+                      category: 'sequential',
+                      colors: ['#f0f0f0', '#333333'],
+                      colorMap: undefined,
+                      name: 'custom',
+                      type: 'custom',
+                    },
+                    sizeAggregation: 'sum',
+                    sizeRange: [1, 10],
+                    radius: 5,
+                  },
+                },
+                visualChannels: {
+                  colorField: {name: 'revenue', type: 'real'},
+                  colorScale: 'quantize',
+                  sizeField: {name: 'revenue', type: 'real'},
+                  sizeScale: 'linear',
+                },
+              },
+            ],
+            layerBlending: 'normal',
+            interactionConfig: {tooltip: {enabled: false}},
+          },
+        },
+      };
+      const map = parseMap({
+        ...METADATA,
+        datasets: [CUSTOM_AGG_DATASET],
+        keplerMapConfig,
+      });
+      expect(map.layers[0].scales.fillColor?.scaleDomain).toEqual([10, 90]);
+    });
+
+    test.each([
+      {title: 'whitespace-only expression', expression: '   '},
+      {title: 'empty expression', expression: ''},
+    ])(
+      'custom color aggregation with $title does not set accessorKey',
+      ({expression}) => {
+        const keplerMapConfig = {
+          version: 'v1',
+          config: {
+            mapState: {},
+            mapStyle: {},
+            visState: {
+              layers: [
+                {
+                  id: 'layer1',
+                  type: 'h3',
+                  config: {
+                    dataId: 'CUSTOM_AGG_DS',
+                    label: 'Test Layer',
+                    textLabel: [{field: null, size: 12}],
+                    visConfig: {
+                      filled: true,
+                      opacity: 1,
+                      colorAggregation: 'custom',
+                      colorAggregationExp: expression,
+                      colorRange: {
+                        category: 'sequential',
+                        colors: ['#f0f0f0', '#333333'],
+                        colorMap: undefined,
+                        name: 'custom',
+                        type: 'custom',
+                      },
+                      sizeAggregation: 'sum',
+                      sizeRange: [1, 10],
+                      radius: 5,
+                    },
+                  },
+                  visualChannels: {
+                    colorField: {name: 'revenue', type: 'real'},
+                    colorScale: 'quantize',
+                    sizeField: {name: 'revenue', type: 'real'},
+                    sizeScale: 'linear',
+                  },
+                },
+              ],
+              layerBlending: 'normal',
+              interactionConfig: {tooltip: {enabled: false}},
+            },
+          },
+        };
+        const map = parseMap({
+          ...METADATA,
+          datasets: [CUSTOM_AGG_DATASET],
+          keplerMapConfig,
+        });
+        expect(
+          map.layers[0].scales.fillColor?.field?.accessorKey
+        ).toBeUndefined();
+      }
+    );
+
+    test('colorRange.colorMap break values win over colorAggregationDomain', () => {
+      const keplerMapConfig = {
+        version: 'v1',
+        config: {
+          mapState: {},
+          mapStyle: {},
+          visState: {
+            layers: [
+              {
+                id: 'layer1',
+                type: 'h3',
+                config: {
+                  dataId: 'CUSTOM_AGG_DS',
+                  label: 'Test Layer',
+                  textLabel: [{field: null, size: 12}],
+                  visConfig: {
+                    filled: true,
+                    opacity: 1,
+                    colorAggregation: 'custom',
+                    colorAggregationExp: 'SUM(x)/SUM(y)',
+                    colorAggregationDomain: [10, 90],
+                    colorRange: {
+                      category: 'sequential',
+                      colors: ['#f0f0f0', '#333333'],
+                      colorMap: [
+                        [25, '#f0f0f0'],
+                        [75, '#333333'],
+                      ],
+                      name: 'custom',
+                      type: 'custom',
+                    },
+                    sizeAggregation: 'sum',
+                    sizeRange: [1, 10],
+                    radius: 5,
+                  },
+                },
+                visualChannels: {
+                  colorField: {name: 'revenue', type: 'real'},
+                  colorScale: 'quantize',
+                  sizeField: {name: 'revenue', type: 'real'},
+                  sizeScale: 'linear',
+                },
+              },
+            ],
+            layerBlending: 'normal',
+            interactionConfig: {tooltip: {enabled: false}},
+          },
+        },
+      };
+      const map = parseMap({
+        ...METADATA,
+        datasets: [CUSTOM_AGG_DATASET],
+        keplerMapConfig,
+      });
+      expect(map.layers[0].scales.fillColor?.scaleDomain).toEqual([25, 75]);
+    });
+
+    test('radiusAggregationDomain applies to point radius channel', () => {
+      const keplerMapConfig = {
+        version: 'v1',
+        config: {
+          mapState: {},
+          mapStyle: {},
+          visState: {
+            layers: [
+              {
+                id: 'layer1',
+                type: 'h3',
+                config: {
+                  dataId: 'CUSTOM_AGG_DS',
+                  label: 'Test Layer',
+                  textLabel: [{field: null, size: 12}],
+                  visConfig: {
+                    filled: true,
+                    opacity: 1,
+                    radiusAggregation: 'custom',
+                    radiusAggregationExp: 'SUM(x)/SUM(y)',
+                    radiusAggregationDomain: [5, 50],
+                    radiusRange: [1, 20],
+                    radius: 5,
+                    colorRange: {
+                      category: 'sequential',
+                      colors: ['#f0f0f0', '#333333'],
+                      colorMap: undefined,
+                      name: 'custom',
+                      type: 'custom',
+                    },
+                  },
+                },
+                visualChannels: {
+                  radiusField: {name: 'revenue', type: 'real'},
+                  radiusScale: 'linear',
+                },
+              },
+            ],
+            layerBlending: 'normal',
+            interactionConfig: {tooltip: {enabled: false}},
+          },
+        },
+      };
+      const map = parseMap({
+        ...METADATA,
+        datasets: [CUSTOM_AGG_DATASET],
+        keplerMapConfig,
+      });
+      expect(map.layers[0].scales.pointRadius?.domain).toEqual([5, 50]);
+    });
+
+    test('custom strokeColor aggregation sets accessorKey on strokeColor scale', () => {
+      const keplerMapConfig = {
+        version: 'v1',
+        config: {
+          mapState: {},
+          mapStyle: {},
+          visState: {
+            layers: [
+              {
+                id: 'layer1',
+                type: 'h3',
+                config: {
+                  dataId: 'CUSTOM_AGG_DS',
+                  label: 'Test Layer',
+                  textLabel: [{field: null, size: 12}],
+                  visConfig: {
+                    filled: true,
+                    stroked: true,
+                    opacity: 1,
+                    strokeColorAggregation: 'custom',
+                    strokeColorAggregationExp: 'SUM(x)/SUM(y)',
+                    strokeColorAggregationDomain: [10, 90],
+                    strokeColorRange: {
+                      category: 'sequential',
+                      colors: ['#f0f0f0', '#333333'],
+                      colorMap: undefined,
+                      name: 'custom',
+                      type: 'custom',
+                    },
+                    colorRange: {
+                      category: 'sequential',
+                      colors: ['#f0f0f0', '#333333'],
+                      colorMap: undefined,
+                      name: 'custom',
+                      type: 'custom',
+                    },
+                    radius: 5,
+                  },
+                },
+                visualChannels: {
+                  strokeColorField: {name: 'revenue', type: 'real'},
+                  strokeColorScale: 'quantize',
+                },
+              },
+            ],
+            layerBlending: 'normal',
+            interactionConfig: {tooltip: {enabled: false}},
+          },
+        },
+      };
+      const map = parseMap({
+        ...METADATA,
+        datasets: [CUSTOM_AGG_DATASET],
+        keplerMapConfig,
+      });
+      expect(map.layers[0].scales.lineColor?.field?.accessorKey).toBe(
+        'custom_agg_cc6f64ff'
+      );
+      expect(map.layers[0].scales.lineColor?.scaleDomain).toEqual([10, 90]);
+    });
+
+    test('custom size aggregation sets accessorKey on lineWidth scale', () => {
+      const keplerMapConfig = {
+        version: 'v1',
+        config: {
+          mapState: {},
+          mapStyle: {},
+          visState: {
+            layers: [
+              {
+                id: 'layer1',
+                type: 'h3',
+                config: {
+                  dataId: 'CUSTOM_AGG_DS',
+                  label: 'Test Layer',
+                  textLabel: [{field: null, size: 12}],
+                  visConfig: {
+                    filled: true,
+                    stroked: true,
+                    opacity: 1,
+                    sizeAggregation: 'custom',
+                    sizeAggregationExp: 'SUM(x)/SUM(y)',
+                    sizeAggregationDomain: [2, 8],
+                    sizeRange: [1, 10],
+                    colorRange: {
+                      category: 'sequential',
+                      colors: ['#f0f0f0', '#333333'],
+                      colorMap: undefined,
+                      name: 'custom',
+                      type: 'custom',
+                    },
+                    radius: 5,
+                  },
+                },
+                visualChannels: {
+                  sizeField: {name: 'revenue', type: 'real'},
+                  sizeScale: 'linear',
+                },
+              },
+            ],
+            layerBlending: 'normal',
+            interactionConfig: {tooltip: {enabled: false}},
+          },
+        },
+      };
+      const map = parseMap({
+        ...METADATA,
+        datasets: [CUSTOM_AGG_DATASET],
+        keplerMapConfig,
+      });
+      expect(map.layers[0].scales.lineWidth?.field?.accessorKey).toBe(
+        'custom_agg_cc6f64ff'
+      );
+      expect(map.layers[0].scales.lineWidth?.domain).toEqual([2, 8]);
+    });
+
+    test('custom height aggregation sets accessorKey on elevation scale', () => {
+      const keplerMapConfig = {
+        version: 'v1',
+        config: {
+          mapState: {},
+          mapStyle: {},
+          visState: {
+            layers: [
+              {
+                id: 'layer1',
+                type: 'h3',
+                config: {
+                  dataId: 'CUSTOM_AGG_DS',
+                  label: 'Test Layer',
+                  textLabel: [{field: null, size: 12}],
+                  visConfig: {
+                    filled: true,
+                    opacity: 1,
+                    enable3d: true,
+                    heightAggregation: 'custom',
+                    heightAggregationExp: 'SUM(x)/SUM(y)',
+                    heightAggregationDomain: [100, 500],
+                    heightRange: [0, 1000],
+                    colorRange: {
+                      category: 'sequential',
+                      colors: ['#f0f0f0', '#333333'],
+                      colorMap: undefined,
+                      name: 'custom',
+                      type: 'custom',
+                    },
+                    radius: 5,
+                  },
+                },
+                visualChannels: {
+                  heightField: {name: 'revenue', type: 'real'},
+                  heightScale: 'linear',
+                },
+              },
+            ],
+            layerBlending: 'normal',
+            interactionConfig: {tooltip: {enabled: false}},
+          },
+        },
+      };
+      const map = parseMap({
+        ...METADATA,
+        datasets: [CUSTOM_AGG_DATASET],
+        keplerMapConfig,
+      });
+      expect(map.layers[0].scales.elevation?.field?.accessorKey).toBe(
+        'custom_agg_cc6f64ff'
+      );
+      expect(map.layers[0].scales.elevation?.domain).toEqual([100, 500]);
+    });
+
+    test('custom weight aggregation sets accessorKey on weight scale', () => {
+      const keplerMapConfig = {
+        version: 'v1',
+        config: {
+          mapState: {},
+          mapStyle: {},
+          visState: {
+            layers: [
+              {
+                id: 'layer1',
+                type: 'h3',
+                config: {
+                  dataId: 'CUSTOM_AGG_DS',
+                  label: 'Test Layer',
+                  textLabel: [{field: null, size: 12}],
+                  visConfig: {
+                    filled: true,
+                    opacity: 1,
+                    weightAggregation: 'custom',
+                    weightAggregationExp: 'SUM(x)/SUM(y)',
+                    colorRange: {
+                      category: 'sequential',
+                      colors: ['#f0f0f0', '#333333'],
+                      colorMap: undefined,
+                      name: 'custom',
+                      type: 'custom',
+                    },
+                    radius: 5,
+                  },
+                },
+                visualChannels: {
+                  weightField: {name: 'revenue', type: 'real'},
+                },
+              },
+            ],
+            layerBlending: 'normal',
+            interactionConfig: {tooltip: {enabled: false}},
+          },
+        },
+      };
+      const map = parseMap({
+        ...METADATA,
+        datasets: [CUSTOM_AGG_DATASET],
+        keplerMapConfig,
+      });
+      expect(map.layers[0].scales.weight?.field?.accessorKey).toBe(
+        'custom_agg_cc6f64ff'
+      );
+    });
+
+    test('accessorKey wins over colorColumn and preserves the caller scale type', () => {
+      const keplerMapConfig = {
+        version: 'v1',
+        config: {
+          mapState: {},
+          mapStyle: {},
+          visState: {
+            layers: [
+              {
+                id: 'layer1',
+                type: 'h3',
+                config: {
+                  dataId: 'CUSTOM_AGG_DS',
+                  label: 'Test Layer',
+                  textLabel: [{field: null, size: 12}],
+                  visConfig: {
+                    filled: true,
+                    opacity: 1,
+                    colorAggregation: 'custom',
+                    colorAggregationExp: 'SUM(x)/SUM(y)',
+                    colorRange: {
+                      category: 'sequential',
+                      colors: ['#f0f0f0', '#333333'],
+                      colorMap: undefined,
+                      name: 'custom',
+                      type: 'custom',
+                    },
+                    radius: 5,
+                  },
+                },
+                visualChannels: {
+                  colorField: {
+                    name: 'revenue',
+                    type: 'real',
+                    colorColumn: 'revenue',
+                  },
+                  colorScale: 'quantize',
+                },
+              },
+            ],
+            layerBlending: 'normal',
+            interactionConfig: {tooltip: {enabled: false}},
+          },
+        },
+      };
+      const map = parseMap({
+        ...METADATA,
+        datasets: [CUSTOM_AGG_DATASET],
+        keplerMapConfig,
+      });
+      const fillColor = map.layers[0].scales.fillColor;
+      expect(fillColor?.field?.accessorKey).toBe('custom_agg_cc6f64ff');
+      expect(fillColor?.scaleDomain).toEqual([0, 100]);
+    });
+  });
 });


### PR DESCRIPTION
Adds the api-client side of the custom aggregation feature for spatial-index and geometry-aggregated layers. The Builder (workspace-www) now stores `{channel}AggregationExp` on saved maps. `parseMap` resolves those expressions to the same content-addressed tile column alias that Builder used when generating the `aggregationExp` SQL. That way, deck reads the right property and the rendering scale follows the user-defined min and max.

## What's included

* `compileCustomAggregation(expression, { provider })`
  New public helper. Uses FNV-1a 32-bit hashing to produce an 8-character hex string in the format `custom_agg_<hash>`. The result is uppercased for Snowflake. Input is normalised for whitespace before hashing. Throws if the expression is empty or only whitespace.

* Type updates
  `VisualChannelField.accessorKey?: string`
  `VisConfig.{channel}AggregationExp?: string`
  `VisConfig.{channel}AggregationDomain?: [number, number]`
  These apply to all six channels: color, strokeColor, size, height, radius, and weight.

* `resolveCustomAggregation()` in `parse-map.ts`
  When `{channel}Aggregation === 'custom'`, it recomputes the alias using `compileCustomAggregation` and assigns it to `accessorKey` on the channel field. The domain is passed through as `domainOverride`.

* Accessors
  `getColorAccessor` and `getSizeAccessor` now use `accessorKey` instead of `colorColumn` or `name` when present.
  `calculateLayerScale` uses `domainOverride` instead of tilestats when available.
  `colorRange.colorMap` still takes priority over both, so explicit break values always win.

* `'lineWidth'` added to the `ScaleKey` union - Fixes an existing type gap.

## Tests

17 tests in `test/fetch-map/parse-map.spec.ts`, plus helper tests in `test/fetch-map/aggregation.test.ts` and accessor override tests in `test/fetch-map/layer-map.spec.ts`.

Coverage includes:

* Helper behavior: provider casing across all supported providers, whitespace normalisation (spaces and tabs), error on empty input, deterministic output, and uniqueness.
* `parseMap` for each channel: color, strokeColor, size to lineWidth, height with enable3d, radius, and weight. Each test checks that `accessorKey` is set and that the domain override is applied.
* Standard aggregation remains unchanged. `accessorKey` stays undefined and existing accessor logic is used.
* Mixed case with custom color and standard size on the same layer. Only the custom channel gets an `accessorKey`.
* Precedence rules: `colorRange.colorMap` break values override `colorAggregationDomain`.
* Defensive checks: empty or whitespace-only expressions with `colorAggregation === 'custom'` do not set `accessorKey`.
* Coexistence of `colorColumn` and `accessorKey`. The accessor uses the custom alias while the scale keeps the configured `scaleType`.

## Impact

* No runtime changes unless the feature is used. `accessorKey` is only set when a layer has `{channel}Aggregation === 'custom'` with a valid expression.
* Builder uses this directly. External `@carto/api-client` users get additional optional fields in the type definitions.
