### PR TITLE
chore(deps): bump typescript to ~6.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "thenby": "^1.3.4",
     "tinybench": "^5.0.1",
     "tsup": "^8.3.6",
-    "typescript": "~5.9.2",
+    "typescript": "~6.0.3",
     "typescript-eslint": "^8.26.1",
     "vite": "^7.0.0",
     "vitest": "3.2.4"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "lib": ["es2022", "DOM", "DOM.Iterable"],
     "types": ["vite/client"],
     "jsx": "react",
-    "strict": true
+    "strict": true,
+    "ignoreDeprecations": "6.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -277,7 +277,7 @@ __metadata:
     thenby: "npm:^1.3.4"
     tinybench: "npm:^5.0.1"
     tsup: "npm:^8.3.6"
-    typescript: "npm:~5.9.2"
+    typescript: "npm:~6.0.3"
     typescript-eslint: "npm:^8.26.1"
     vite: "npm:^7.0.0"
     vitest: "npm:3.2.4"
@@ -5926,23 +5926,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:~5.9.2":
-  version: 5.9.2
-  resolution: "typescript@npm:5.9.2"
+"typescript@npm:~6.0.3":
+  version: 6.0.3
+  resolution: "typescript@npm:6.0.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/cd635d50f02d6cf98ed42de2f76289701c1ec587a363369255f01ed15aaf22be0813226bff3c53e99d971f9b540e0b3cc7583dbe05faded49b1b0bed2f638a18
+  checksum: 10c0/4a25ff5045b984370f48f196b3a0120779b1b343d40b9a68d114ea5e5fff099809b2bb777576991a63a5cd59cf7bffd96ff6fe10afcefbcb8bd6fb96ad4b6606
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A~5.9.2#optional!builtin<compat/typescript>":
-  version: 5.9.2
-  resolution: "typescript@patch:typescript@npm%3A5.9.2#optional!builtin<compat/typescript>::version=5.9.2&hash=379a07"
+"typescript@patch:typescript@npm%3A~6.0.3#optional!builtin<compat/typescript>":
+  version: 6.0.3
+  resolution: "typescript@patch:typescript@npm%3A6.0.3#optional!builtin<compat/typescript>::version=6.0.3&hash=379a07"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/66fc07779427a7c3fa97da0cf2e62595eaff2cea4594d45497d294bfa7cb514d164f0b6ce7a5121652cf44c0822af74e29ee579c771c405e002d1f23cf06bfde
+  checksum: 10c0/eed465bd04b344517bd91eb232fd0187d93e34625c65ec93777449e29157c6c2accae409474a68a867b90465224d4908f9bce78ad763c159cacd7263ae24b5fc
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Bumps TypeScript devDependency from `~5.9.2` to `~6.0.3`, the current latest.

- Update `typescript` in [package.json](package.json) from `~5.9.2` → `~6.0.3`
- Add `"ignoreDeprecations": "6.0"` in [tsconfig.json](tsconfig.json) so the build still passes (see note below)

Build, tests (`yarn test`), and lint (`yarn lint`) all pass.

## Note on `ignoreDeprecations`

TypeScript 6.0 reports `baseUrl` as a deprecation error. Our own [tsconfig.json](tsconfig.json) does not set `baseUrl`, but `tsup` hardcodes `baseUrl: compilerOptions.baseUrl || "."` when generating `.d.ts` bundles, so the option ends up in the effective compiler options regardless. The `ignoreDeprecations: "6.0"` flag silences the error.

This is a temporary workaround. `tsup` is no longer actively maintained, so a follow-up should migrate the build to a maintained alternative (e.g. [`tsdown`](https://github.com/sxzz/tsdown)). Once the build no longer goes through tsup, the `ignoreDeprecations` flag can be removed.

## Known peer warning

`typescript-eslint@8.43.0` declares a TS peer range of `>=4.8.4 <6.0.0`, which produces a `yarn install` warning. The warning is benign — linting still works — and will go away once typescript-eslint releases a TS 6 compatible version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)