### PR TITLE
feat(fetchMap): Support zoom dependent point styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## Unreleased
+
+- feat(fetchMap): Support zoom-dependent point styling (#287)
+- feat(fetchMap): Support autoLabels (#288)
+
 ### 0.5.27
 
 - feat(parseMap): custom aggregation support on spatial-index and geometry-aggregated layers. Adds `compileCustomAggregation(expression, { provider })` helper, `VisualChannelField.accessorKey`, and `{channel}AggregationExp` / `{channel}AggregationDomain` on `VisConfig` for all 6 channels.

--- a/src/fetch-map/layer-map.ts
+++ b/src/fetch-map/layer-map.ts
@@ -514,10 +514,14 @@ export function getMaxMarkerSize(
   visConfig: VisConfig,
   visualChannels: VisualChannels
 ): number {
-  const {radiusRange, radius} = visConfig;
+  const {radiusRange, radius, sizeMaxPixels} = visConfig;
   const {radiusField, sizeField} = visualChannels;
   const field = radiusField || sizeField;
-  return Math.ceil(radiusRange && field ? radiusRange[1] : radius);
+  // When sizeMaxPixels is set, the render is clamped to that value — size
+  // the atlas to match so it stays crisp at the largest possible render.
+  // Otherwise fall back to the configured render size.
+  const baseSize = radiusRange && field ? radiusRange[1] : radius;
+  return Math.ceil(sizeMaxPixels ?? baseSize);
 }
 
 type Accessor = number | ((d: any, i: any) => number);

--- a/src/fetch-map/layer-map.ts
+++ b/src/fetch-map/layer-map.ts
@@ -517,9 +517,6 @@ export function getMaxMarkerSize(
   const {radiusRange, radius, sizeMaxPixels} = visConfig;
   const {radiusField, sizeField} = visualChannels;
   const field = radiusField || sizeField;
-  // When sizeMaxPixels is set, the render is clamped to that value — size
-  // the atlas to match so it stays crisp at the largest possible render.
-  // Otherwise fall back to the configured render size.
   const baseSize = radiusRange && field ? radiusRange[1] : radius;
   return Math.ceil(sizeMaxPixels ?? baseSize);
 }

--- a/src/fetch-map/parse-map.ts
+++ b/src/fetch-map/parse-map.ts
@@ -128,6 +128,7 @@ export function getLayerDescriptor({
       ...createInteractionProps(interactionConfig),
       ...styleProps,
       ...channelProps,
+      ...createZoomScaleProps(config, visualChannels),
       ...createParametersProp(layerBlending, styleProps.parameters || {}), // Must come after style
       ...createLoadOptions(data.accessToken),
     },
@@ -206,6 +207,44 @@ function createInteractionProps(interactionConfig: any) {
     autoHighlight: pickable,
     pickable,
   };
+}
+
+// When `radiusScaleWithZoom` is enabled and the radius isn't driven by a data
+// field, render the point in deck.gl's `common` coordinate space so it scales
+// proportionally with zoom. At `radiusReferenceZoom`, 1 common unit equals
+// 2^referenceZoom pixels — dividing by that factor gives a size that matches
+// the configured `radius` pixels at the reference zoom and grows/shrinks from
+// there. Applied to both the circle (`pointRadius*`) and icon (`iconSize*`)
+// sub-layers so `pointType` switching just works.
+function createZoomScaleProps(
+  config: MapLayerConfig,
+  visualChannels: VisualChannels
+): Record<string, any> {
+  const {visConfig} = config;
+  if (
+    !visConfig.radiusScaleWithZoom ||
+    visualChannels.radiusField ||
+    visualChannels.sizeField
+  ) {
+    return {};
+  }
+  const referenceZoom = visConfig.radiusReferenceZoom ?? 12;
+  const scale = Math.pow(2, -referenceZoom);
+  const result: Record<string, any> = {
+    pointRadiusUnits: 'common',
+    pointRadiusScale: scale,
+    iconSizeUnits: 'common',
+    iconSizeScale: scale,
+  };
+  if (visConfig.sizeMinPixels !== undefined) {
+    result.pointRadiusMinPixels = visConfig.sizeMinPixels;
+    result.iconSizeMinPixels = visConfig.sizeMinPixels;
+  }
+  if (visConfig.sizeMaxPixels !== undefined) {
+    result.pointRadiusMaxPixels = visConfig.sizeMaxPixels;
+    result.iconSizeMaxPixels = visConfig.sizeMaxPixels;
+  }
+  return result;
 }
 
 function mapProps(source: any, target: any, mapping: any) {

--- a/src/fetch-map/parse-map.ts
+++ b/src/fetch-map/parse-map.ts
@@ -223,8 +223,7 @@ function createZoomScaleProps(
   }
   // When `radiusScaleWithZoom` is enabled, render the point in `common`
   // coordinate space so it scales proportionally with zoom.
-  const referenceZoom = visConfig.radiusReferenceZoom ?? 12;
-  const scale = Math.pow(2, -referenceZoom);
+  const scale = Math.pow(2, -(visConfig.radiusReferenceZoom as number));
   const result: Record<string, any> = {
     pointRadiusUnits: 'common',
     pointRadiusScale: scale,

--- a/src/fetch-map/parse-map.ts
+++ b/src/fetch-map/parse-map.ts
@@ -209,13 +209,6 @@ function createInteractionProps(interactionConfig: any) {
   };
 }
 
-// When `radiusScaleWithZoom` is enabled and the radius isn't driven by a data
-// field, render the point in deck.gl's `common` coordinate space so it scales
-// proportionally with zoom. At `radiusReferenceZoom`, 1 common unit equals
-// 2^referenceZoom pixels — dividing by that factor gives a size that matches
-// the configured `radius` pixels at the reference zoom and grows/shrinks from
-// there. Applied to both the circle (`pointRadius*`) and icon (`iconSize*`)
-// sub-layers so `pointType` switching just works.
 function createZoomScaleProps(
   config: MapLayerConfig,
   visualChannels: VisualChannels
@@ -228,6 +221,8 @@ function createZoomScaleProps(
   ) {
     return {};
   }
+  // When `radiusScaleWithZoom` is enabled, render the point in `common`
+  // coordinate space so it scales proportionally with zoom.
   const referenceZoom = visConfig.radiusReferenceZoom ?? 12;
   const scale = Math.pow(2, -referenceZoom);
   const result: Record<string, any> = {

--- a/src/fetch-map/types.ts
+++ b/src/fetch-map/types.ts
@@ -80,6 +80,18 @@ export type VisConfig = {
   radiusAggregationExp?: string;
   radiusAggregationDomain?: [number, number];
 
+  // pixel bounds applied to the point (circle or icon sub-layer) when its
+  // rendered size can vary — e.g. via a zoom-dependent scale. Kept generic so
+  // a single pair of bounds covers both pointType variants.
+  sizeMinPixels?: number;
+  sizeMaxPixels?: number;
+
+  // Zoom-dependent point sizing. When enabled, the point renders at `radius`
+  // pixels at `radiusReferenceZoom` and scales proportionally with zoom
+  // (implemented via deck.gl's `common` radius units).
+  radiusScaleWithZoom?: boolean;
+  radiusReferenceZoom?: number;
+
   sizeAggregation?: string;
   sizeAggregationExp?: string;
   sizeAggregationDomain?: [number, number];

--- a/src/fetch-map/types.ts
+++ b/src/fetch-map/types.ts
@@ -80,15 +80,8 @@ export type VisConfig = {
   radiusAggregationExp?: string;
   radiusAggregationDomain?: [number, number];
 
-  // pixel bounds applied to the point (circle or icon sub-layer) when its
-  // rendered size can vary — e.g. via a zoom-dependent scale. Kept generic so
-  // a single pair of bounds covers both pointType variants.
   sizeMinPixels?: number;
   sizeMaxPixels?: number;
-
-  // Zoom-dependent point sizing. When enabled, the point renders at `radius`
-  // pixels at `radiusReferenceZoom` and scales proportionally with zoom
-  // (implemented via deck.gl's `common` radius units).
   radiusScaleWithZoom?: boolean;
   radiusReferenceZoom?: number;
 

--- a/test/fetch-map/parse-map.spec.ts
+++ b/test/fetch-map/parse-map.spec.ts
@@ -908,4 +908,169 @@ describe('parseMap', () => {
       expect(fillColor?.scaleDomain).toEqual([0, 100]);
     });
   });
+
+  describe('zoom-dependent point sizing (radiusScaleWithZoom)', () => {
+    const ZOOM_SCALE_DATASET = {
+      id: 'ZOOM_SCALE_DS',
+      data: {
+        tiles: ['https://example.com/tiles/{z}/{x}/{y}'],
+        tilestats: {
+          layers: [
+            {
+              attributes: [
+                {attribute: 'revenue', min: 0, max: 1000, type: 'Number'},
+              ],
+            },
+          ],
+        },
+      },
+      type: 'tileset',
+    };
+
+    const buildLayerConfig = (
+      visConfigOverrides: Record<string, any> = {},
+      visualChannels: Record<string, any> = {}
+    ) => ({
+      version: 'v1',
+      config: {
+        mapState: {},
+        mapStyle: {},
+        visState: {
+          layers: [
+            {
+              id: 'layer1',
+              type: 'tileset',
+              config: {
+                dataId: 'ZOOM_SCALE_DS',
+                label: 'Test Layer',
+                textLabel: [{field: null, size: 12}],
+                visConfig: {
+                  filled: true,
+                  opacity: 1,
+                  colorRange: {
+                    category: 'sequential',
+                    colors: ['#f0f0f0', '#333333'],
+                    colorMap: undefined,
+                    name: 'custom',
+                    type: 'custom',
+                  },
+                  radius: 5,
+                  ...visConfigOverrides,
+                },
+              },
+              visualChannels,
+            },
+          ],
+          layerBlending: 'normal',
+          interactionConfig: {tooltip: {enabled: false}},
+        },
+      },
+    });
+
+    test('radiusScaleWithZoom enabled emits common-unit scale for point and icon, defaulting referenceZoom to 12', () => {
+      const map = parseMap({
+        ...METADATA,
+        datasets: [ZOOM_SCALE_DATASET],
+        keplerMapConfig: buildLayerConfig({radiusScaleWithZoom: true}),
+      });
+      const props = map.layers[0].props;
+      const expectedScale = Math.pow(2, -12);
+      expect(props.pointRadiusUnits).toBe('common');
+      expect(props.pointRadiusScale).toBe(expectedScale);
+      expect(props.iconSizeUnits).toBe('common');
+      expect(props.iconSizeScale).toBe(expectedScale);
+    });
+
+    test('custom radiusReferenceZoom uses 2^-referenceZoom for the scale', () => {
+      const map = parseMap({
+        ...METADATA,
+        datasets: [ZOOM_SCALE_DATASET],
+        keplerMapConfig: buildLayerConfig({
+          radiusScaleWithZoom: true,
+          radiusReferenceZoom: 10,
+        }),
+      });
+      const props = map.layers[0].props;
+      const expectedScale = Math.pow(2, -10);
+      expect(props.pointRadiusScale).toBe(expectedScale);
+      expect(props.iconSizeScale).toBe(expectedScale);
+    });
+
+    test('sizeMinPixels and sizeMaxPixels are mirrored onto pointRadius and iconSize props', () => {
+      const map = parseMap({
+        ...METADATA,
+        datasets: [ZOOM_SCALE_DATASET],
+        keplerMapConfig: buildLayerConfig({
+          radiusScaleWithZoom: true,
+          sizeMinPixels: 4,
+          sizeMaxPixels: 32,
+        }),
+      });
+      const props = map.layers[0].props;
+      expect(props.pointRadiusMinPixels).toBe(4);
+      expect(props.pointRadiusMaxPixels).toBe(32);
+      expect(props.iconSizeMinPixels).toBe(4);
+      expect(props.iconSizeMaxPixels).toBe(32);
+    });
+
+    test('min/max pixel props are not set when sizeMinPixels/sizeMaxPixels are undefined', () => {
+      const map = parseMap({
+        ...METADATA,
+        datasets: [ZOOM_SCALE_DATASET],
+        keplerMapConfig: buildLayerConfig({radiusScaleWithZoom: true}),
+      });
+      const props = map.layers[0].props;
+      expect(props.pointRadiusMinPixels).toBeUndefined();
+      expect(props.pointRadiusMaxPixels).toBeUndefined();
+      expect(props.iconSizeMinPixels).toBeUndefined();
+      expect(props.iconSizeMaxPixels).toBeUndefined();
+    });
+
+    test('radiusScaleWithZoom disabled leaves pointRadiusUnits at the pixel default', () => {
+      const map = parseMap({
+        ...METADATA,
+        datasets: [ZOOM_SCALE_DATASET],
+        keplerMapConfig: buildLayerConfig(),
+      });
+      const props = map.layers[0].props;
+      expect(props.pointRadiusUnits).toBe('pixels');
+      expect(props.pointRadiusScale).toBeUndefined();
+      expect(props.iconSizeUnits).toBeUndefined();
+      expect(props.iconSizeScale).toBeUndefined();
+    });
+
+    test('radiusField present disables zoom scaling (radius is data-driven)', () => {
+      const map = parseMap({
+        ...METADATA,
+        datasets: [ZOOM_SCALE_DATASET],
+        keplerMapConfig: buildLayerConfig(
+          {radiusScaleWithZoom: true, radiusRange: [1, 20]},
+          {
+            radiusField: {name: 'revenue', type: 'real'},
+            radiusScale: 'linear',
+          }
+        ),
+      });
+      const props = map.layers[0].props;
+      expect(props.pointRadiusUnits).toBe('pixels');
+      expect(props.pointRadiusScale).toBeUndefined();
+    });
+
+    test('sizeField present disables zoom scaling', () => {
+      const map = parseMap({
+        ...METADATA,
+        datasets: [ZOOM_SCALE_DATASET],
+        keplerMapConfig: buildLayerConfig(
+          {radiusScaleWithZoom: true, sizeRange: [1, 10]},
+          {
+            sizeField: {name: 'revenue', type: 'real'},
+            sizeScale: 'linear',
+          }
+        ),
+      });
+      const props = map.layers[0].props;
+      expect(props.pointRadiusUnits).toBe('pixels');
+      expect(props.pointRadiusScale).toBeUndefined();
+    });
+  });
 });

--- a/test/fetch-map/parse-map.spec.ts
+++ b/test/fetch-map/parse-map.spec.ts
@@ -967,11 +967,14 @@ describe('parseMap', () => {
       },
     });
 
-    test('radiusScaleWithZoom enabled emits common-unit scale for point and icon, defaulting referenceZoom to 12', () => {
+    test('radiusScaleWithZoom enabled emits common-unit scale for point and icon', () => {
       const map = parseMap({
         ...METADATA,
         datasets: [ZOOM_SCALE_DATASET],
-        keplerMapConfig: buildLayerConfig({radiusScaleWithZoom: true}),
+        keplerMapConfig: buildLayerConfig({
+          radiusScaleWithZoom: true,
+          radiusReferenceZoom: 12,
+        }),
       });
       const props = map.layers[0].props;
       const expectedScale = Math.pow(2, -12);
@@ -1002,6 +1005,7 @@ describe('parseMap', () => {
         datasets: [ZOOM_SCALE_DATASET],
         keplerMapConfig: buildLayerConfig({
           radiusScaleWithZoom: true,
+          radiusReferenceZoom: 12,
           sizeMinPixels: 4,
           sizeMaxPixels: 32,
         }),
@@ -1017,7 +1021,7 @@ describe('parseMap', () => {
       const map = parseMap({
         ...METADATA,
         datasets: [ZOOM_SCALE_DATASET],
-        keplerMapConfig: buildLayerConfig({radiusScaleWithZoom: true}),
+        keplerMapConfig: buildLayerConfig({radiusScaleWithZoom: true, radiusReferenceZoom: 12}),
       });
       const props = map.layers[0].props;
       expect(props.pointRadiusMinPixels).toBeUndefined();

--- a/test/fetch-map/parse-map.spec.ts
+++ b/test/fetch-map/parse-map.spec.ts
@@ -1021,7 +1021,10 @@ describe('parseMap', () => {
       const map = parseMap({
         ...METADATA,
         datasets: [ZOOM_SCALE_DATASET],
-        keplerMapConfig: buildLayerConfig({radiusScaleWithZoom: true, radiusReferenceZoom: 12}),
+        keplerMapConfig: buildLayerConfig({
+          radiusScaleWithZoom: true,
+          radiusReferenceZoom: 12,
+        }),
       });
       const props = map.layers[0].props;
       expect(props.pointRadiusMinPixels).toBeUndefined();


### PR DESCRIPTION
Supporting changes for https://github.com/CartoDB/cloud-native/pull/24066

**Added**

- `createZoomScaleProps` helper in `parse-map.ts` — emits `pointRadiusUnits='common'` + `pointRadiusScale=2^-referenceZoom` (and `iconSize*` equivalents) when the visConfig flag is set, gated off when there's a `radiusField` or `sizeField`
- `radiusScaleWithZoom`, `radiusReferenceZoom`, `sizeMinPixels`, `sizeMaxPixels` on `VisConfig` type
- `getMaxMarkerSize` extended to clamp the atlas size to `sizeMaxPixels` so icons stay crisp at maximum render size
- Round-trip tests covering the four new visConfig fields and the two gating conditions