### PR TITLE
feat(fetchMap): Support autoLabels

### DIFF
--- a/src/fetch-map/parse-map.ts
+++ b/src/fetch-map/parse-map.ts
@@ -667,7 +667,27 @@ function createChannelProps(
     const getSecondaryText =
       secondaryField && getTextAccessor(secondaryField, data);
 
-    result.pointType = `${result.pointType}+text`;
+    // For line/polygon tileset layers, deck.gl's VectorTileLayer can synthesize
+    // point labels at line midpoints / polygon centroids via `autoLabels`. The
+    // optional `uniqueIdProperty` dedupes features that span multiple tiles so
+    // each feature gets one label instead of one-per-tile.
+    const geometry = data.tilestats?.layers?.[0]?.geometry;
+    const isLineOrPolygon =
+      geometry === 'Polygon' ||
+      geometry === 'MultiPolygon' ||
+      geometry === 'Line' ||
+      geometry === 'LineString' ||
+      geometry === 'MultiLineString';
+    if (
+      isLineOrPolygon &&
+      (layerType === 'tileset' || layerType === 'mvt')
+    ) {
+      const uniqueIdProperty = visConfig.textLabelUniqueIdField;
+      result.autoLabels = uniqueIdProperty ? {uniqueIdProperty} : true;
+      result.pointType = 'text';
+    } else {
+      result.pointType = `${result.pointType}+text`;
+    }
     result.textCharacterSet = 'auto';
     result.textFontFamily = 'Inter, sans';
     result.textFontSettings = {sdf: true};

--- a/src/fetch-map/parse-map.ts
+++ b/src/fetch-map/parse-map.ts
@@ -678,10 +678,7 @@ function createChannelProps(
       geometry === 'Line' ||
       geometry === 'LineString' ||
       geometry === 'MultiLineString';
-    if (
-      isLineOrPolygon &&
-      (layerType === 'tileset' || layerType === 'mvt')
-    ) {
+    if (isLineOrPolygon && (layerType === 'tileset' || layerType === 'mvt')) {
       const uniqueIdProperty = visConfig.textLabelUniqueIdField;
       result.autoLabels = uniqueIdProperty ? {uniqueIdProperty} : true;
       result.pointType = 'text';

--- a/src/fetch-map/types.ts
+++ b/src/fetch-map/types.ts
@@ -108,6 +108,7 @@ export type VisConfig = {
   colorBands?: RasterLayerConfigColorBand[];
 
   uniqueValuesColorRange?: ColorRange;
+  textLabelUniqueIdField?: string | null;
 };
 
 export type TextLabel = {

--- a/test/fetch-map/parse-map.spec.ts
+++ b/test/fetch-map/parse-map.spec.ts
@@ -926,7 +926,9 @@ describe('parseMap', () => {
       type: 'tileset',
     });
 
-    const buildLayerConfig = (visConfigOverrides: Record<string, any> = {}) => ({
+    const buildLayerConfig = (
+      visConfigOverrides: Record<string, any> = {}
+    ) => ({
       version: 'v1',
       config: {
         mapState: {},

--- a/test/fetch-map/parse-map.spec.ts
+++ b/test/fetch-map/parse-map.spec.ts
@@ -908,4 +908,110 @@ describe('parseMap', () => {
       expect(fillColor?.scaleDomain).toEqual([0, 100]);
     });
   });
+
+  describe('autoLabels for tileset textLabel', () => {
+    const buildTilesetDataset = (geometry: string) => ({
+      id: 'AUTOLABEL_DS',
+      data: {
+        tiles: ['https://example.com/tiles/{z}/{x}/{y}'],
+        tilestats: {
+          layers: [
+            {
+              attributes: [{attribute: 'name', categories: []}],
+              geometry,
+            },
+          ],
+        },
+      },
+      type: 'tileset',
+    });
+
+    const buildLayerConfig = (visConfigOverrides: Record<string, any> = {}) => ({
+      version: 'v1',
+      config: {
+        mapState: {},
+        mapStyle: {},
+        visState: {
+          layers: [
+            {
+              id: 'layer1',
+              type: 'tileset',
+              config: {
+                dataId: 'AUTOLABEL_DS',
+                label: 'Test Layer',
+                textLabel: [{field: {name: 'name', type: 'string'}, size: 12}],
+                visConfig: {
+                  filled: true,
+                  opacity: 1,
+                  colorRange: {
+                    category: 'sequential',
+                    colors: ['#f0f0f0', '#333333'],
+                    colorMap: undefined,
+                    name: 'custom',
+                    type: 'custom',
+                  },
+                  radius: 5,
+                  ...visConfigOverrides,
+                },
+              },
+              visualChannels: {},
+            },
+          ],
+          layerBlending: 'normal',
+          interactionConfig: {tooltip: {enabled: false}},
+        },
+      },
+    });
+
+    test('Polygon tileset with uniqueIdField sets autoLabels with uniqueIdProperty and pointType=text', () => {
+      const map = parseMap({
+        ...METADATA,
+        datasets: [buildTilesetDataset('Polygon')],
+        keplerMapConfig: buildLayerConfig({textLabelUniqueIdField: 'fid'}),
+      });
+      expect(map.layers[0].props.autoLabels).toEqual({uniqueIdProperty: 'fid'});
+      expect(map.layers[0].props.pointType).toBe('text');
+    });
+
+    test.each([
+      ['LineString'],
+      ['MultiLineString'],
+      ['Line'],
+      ['MultiPolygon'],
+    ])(
+      '%s tileset without uniqueIdField sets autoLabels=true and pointType=text',
+      (geometry) => {
+        const map = parseMap({
+          ...METADATA,
+          datasets: [buildTilesetDataset(geometry)],
+          keplerMapConfig: buildLayerConfig(),
+        });
+        expect(map.layers[0].props.autoLabels).toBe(true);
+        expect(map.layers[0].props.pointType).toBe('text');
+      }
+    );
+
+    test('Point tileset preserves circle+text pointType and does not set autoLabels', () => {
+      const map = parseMap({
+        ...METADATA,
+        datasets: [buildTilesetDataset('Point')],
+        keplerMapConfig: buildLayerConfig({textLabelUniqueIdField: 'fid'}),
+      });
+      expect(map.layers[0].props.autoLabels).toBeUndefined();
+      expect(map.layers[0].props.pointType).toBe('circle+text');
+    });
+
+    test('Polygon tileset without a textLabel field does not set autoLabels', () => {
+      const keplerMapConfig = buildLayerConfig();
+      keplerMapConfig.config.visState.layers[0].config.textLabel = [
+        {field: null, size: 12} as any,
+      ];
+      const map = parseMap({
+        ...METADATA,
+        datasets: [buildTilesetDataset('Polygon')],
+        keplerMapConfig,
+      });
+      expect(map.layers[0].props.autoLabels).toBeUndefined();
+    });
+  });
 });


### PR DESCRIPTION
Supporting changes for https://github.com/CartoDB/cloud-native/pull/24194

**Added**

- `textLabelUniqueIdField` added to `VisConfig` type
- Pass through `textLabelUniqueIdField`
- Configure `pointType`
- tests