### PR TITLE
feat(widgetSources): featureIds/geometryType for feature-selection filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- feat(widgetSources): support `featureIds` / `geometryType` request options to filter widget aggregations by a feature selection without relying on the synthetic `_carto_feature_id` column
+
 ### 0.5.29
 
 - feat(sources): Support featureBbox parameter (#289)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- feat(widgetSources): support `featureIds` / `geometryType` request options to filter widget aggregations by a feature selection without relying on the synthetic `_carto_feature_id` column
+- feat(widgetSources): support `featureIds` / `geometryType` request options to filter widget aggregations by a feature selection without relying on the synthetic `_carto_feature_id` column (#294)
 
 ### 0.5.29
 

--- a/src/widget-sources/types.ts
+++ b/src/widget-sources/types.ts
@@ -22,6 +22,12 @@ export interface ViewState {
   longitude: number;
 }
 
+/**
+ * Topology of the features referenced by {@link BaseRequestOptions#featureIds}.
+ * Must match the geometry type of the layer the features were picked from.
+ */
+export type WidgetFeatureGeometryType = 'points' | 'lines' | 'polygons';
+
 /** Common options for {@link WidgetRemoteSource} requests. */
 export interface BaseRequestOptions {
   signal?: AbortSignal;
@@ -30,6 +36,23 @@ export interface BaseRequestOptions {
   /** Overrides source filters, if any. */
   filters?: Filters;
   filterOwner?: string;
+  /**
+   * Restricts the request to a selection of features, identified by their
+   * `_carto_feature_id` (a hash of geometry). Unlike {@link filters}, this does
+   * not require `_carto_feature_id` to exist as a column on the source: the
+   * server regenerates the hash on-the-fly and AND-s the resulting predicate
+   * onto the existing source filters.
+   *
+   * Capped at 1000 IDs server-side. {@link geometryType} is required whenever
+   * `featureIds` is provided.
+   */
+  featureIds?: string[];
+  /**
+   * Geometry topology of the features in {@link featureIds}, required whenever
+   * `featureIds` is provided. Used by the server to regenerate the feature-id
+   * hash for the correct geometry type.
+   */
+  geometryType?: WidgetFeatureGeometryType;
 }
 
 export type CategoryOrderBy =

--- a/src/widget-sources/types.ts
+++ b/src/widget-sources/types.ts
@@ -123,7 +123,7 @@ export interface FeaturesRequestOptions extends BaseRequestOptions {
   columns: string[];
 
   /** Topology of objects to be picked. */
-  dataType: 'points' | 'lines' | 'polygons';
+  dataType: WidgetFeatureGeometryType;
 
   /** Zoom level, required if using 'points' data type. */
   z?: number;

--- a/src/widget-sources/widget-remote-source.ts
+++ b/src/widget-sources/widget-remote-source.ts
@@ -20,6 +20,7 @@ import type {
   TableResponse,
   TimeSeriesRequestOptions,
   TimeSeriesResponse,
+  WidgetFeatureGeometryType,
 } from './types.js';
 import {assert, normalizeObjectKeys} from '../utils.js';
 import {DEFAULT_TILE_RESOLUTION} from '../constants-internal.js';
@@ -32,6 +33,31 @@ import {requestWithParameters} from '../api/request-with-parameters.js';
 import type {APIErrorContext} from '../api/carto-api-error.js';
 
 export type WidgetRemoteSourceProps = WidgetSourceProps;
+
+/** Maximum number of feature IDs accepted server-side per request. */
+const FEATURE_IDS_LIMIT = 1000;
+
+/**
+ * Validates and normalizes feature-selection options shared by widget
+ * requests. Returns the model params to forward, or an empty object when no
+ * selection is requested. `geometryType` is mandatory whenever `featureIds`
+ * is provided, mirroring the server-side contract.
+ */
+function getFeatureSelectionParams(options: {
+  featureIds?: string[];
+  geometryType?: WidgetFeatureGeometryType;
+}): {featureIds?: string[]; geometryType?: WidgetFeatureGeometryType} {
+  const {featureIds, geometryType} = options;
+  if (!featureIds || featureIds.length === 0) {
+    return {};
+  }
+  assert(geometryType, 'geometryType is required when featureIds are provided');
+  assert(
+    featureIds.length <= FEATURE_IDS_LIMIT,
+    `featureIds is limited to ${FEATURE_IDS_LIMIT} values, received ${featureIds.length}`
+  );
+  return {featureIds, geometryType};
+}
 
 /**
  * Source for Widget API requests.
@@ -110,6 +136,7 @@ export abstract class WidgetRemoteSource<
         operationColumn: operationColumn || column,
         othersThreshold,
         orderBy,
+        ...getFeatureSelectionParams(options),
       },
       opts: {signal, headers: this.props.headers},
     });
@@ -193,6 +220,7 @@ export abstract class WidgetRemoteSource<
         column: column ?? '*',
         operation: operation ?? AggregationTypes.Count,
         operationExp,
+        ...getFeatureSelectionParams(options),
       },
       opts: {signal, headers: this.props.headers},
     }).then((res: FormulaModelResponse) => normalizeObjectKeys(res.rows[0]));
@@ -220,7 +248,7 @@ export abstract class WidgetRemoteSource<
         spatialFiltersMode,
         spatialFilter,
       },
-      params: {column, operation, ticks},
+      params: {column, operation, ticks, ...getFeatureSelectionParams(options)},
       opts: {signal, headers: this.props.headers},
     }).then((res: HistogramModelResponse) => normalizeObjectKeys(res.rows));
 
@@ -257,7 +285,7 @@ export abstract class WidgetRemoteSource<
         spatialFiltersMode,
         spatialFilter,
       },
-      params: {column},
+      params: {column, ...getFeatureSelectionParams(options)},
       opts: {signal, headers: this.props.headers},
     }).then((res: RangeModelResponse) => normalizeObjectKeys(res.rows[0]));
   }
@@ -292,6 +320,7 @@ export abstract class WidgetRemoteSource<
         yAxisColumn,
         yAxisJoinOperation,
         limit: HARD_LIMIT,
+        ...getFeatureSelectionParams(options),
       },
       opts: {signal, headers: this.props.headers},
     })
@@ -328,6 +357,7 @@ export abstract class WidgetRemoteSource<
         sortDirection,
         limit,
         offset,
+        ...getFeatureSelectionParams(options),
       },
       opts: {signal, headers: this.props.headers},
     }).then((res: TableModelResponse) => ({
@@ -388,6 +418,7 @@ export abstract class WidgetRemoteSource<
         splitByCategory,
         splitByCategoryLimit,
         splitByCategoryValues,
+        ...getFeatureSelectionParams(options),
       },
       opts: {signal, headers: this.props.headers},
     }).then((res: TimeSeriesModelResponse) => ({
@@ -417,6 +448,7 @@ export abstract class WidgetRemoteSource<
       },
       params: {
         aggregations,
+        ...getFeatureSelectionParams(options),
       },
       opts: {signal, headers: this.props.headers},
     }).then((res: AggregationsResponse) => ({

--- a/test/widget-sources/widget-remote-source.test.ts
+++ b/test/widget-sources/widget-remote-source.test.ts
@@ -838,3 +838,118 @@ test('getExtent', async () => {
     })
   );
 });
+
+/******************************************************************************
+ * feature selection (featureIds / geometryType)
+ */
+
+test('getFormula - forwards featureIds and geometryType', async () => {
+  const widgetSource = new WidgetTestSource({
+    accessToken: '<token>',
+    connectionName: 'carto_dw',
+  });
+
+  const mockFetch = vi
+    .fn()
+    .mockResolvedValueOnce(createMockResponse({rows: [{value: 123}]}));
+  vi.stubGlobal('fetch', mockFetch);
+
+  await widgetSource.getFormula({
+    column: 'store_type',
+    operation: 'count',
+    featureIds: ['a', 'b', 'c'],
+    geometryType: 'points',
+  });
+
+  const params = new URL(mockFetch.mock.lastCall[0]).searchParams.entries();
+  expect(Object.fromEntries(params)).toMatchObject({
+    params: JSON.stringify({
+      column: 'store_type',
+      operation: 'count',
+      featureIds: ['a', 'b', 'c'],
+      geometryType: 'points',
+    }),
+  });
+});
+
+test('getCategories - forwards featureIds and geometryType', async () => {
+  const widgetSource = new WidgetTestSource({
+    accessToken: '<token>',
+    connectionName: 'carto_dw',
+  });
+
+  const mockFetch = vi.fn().mockResolvedValueOnce(
+    createMockResponse({
+      rows: [{name: 'a', value: 1}],
+    })
+  );
+  vi.stubGlobal('fetch', mockFetch);
+
+  await widgetSource.getCategories({
+    column: 'store_type',
+    operation: 'count',
+    featureIds: ['a', 'b'],
+    geometryType: 'polygons',
+  });
+
+  const params = new URL(mockFetch.mock.lastCall[0]).searchParams.entries();
+  expect(Object.fromEntries(params)).toMatchObject({
+    params: JSON.stringify({
+      column: 'store_type',
+      operation: 'count',
+      operationColumn: 'store_type',
+      featureIds: ['a', 'b'],
+      geometryType: 'polygons',
+    }),
+  });
+});
+
+test('getFormula - omits feature selection params when featureIds absent', async () => {
+  const widgetSource = new WidgetTestSource({
+    accessToken: '<token>',
+    connectionName: 'carto_dw',
+  });
+
+  const mockFetch = vi
+    .fn()
+    .mockResolvedValueOnce(createMockResponse({rows: [{value: 123}]}));
+  vi.stubGlobal('fetch', mockFetch);
+
+  await widgetSource.getFormula({column: 'store_type', operation: 'count'});
+
+  const params = new URL(mockFetch.mock.lastCall[0]).searchParams.entries();
+  expect(Object.fromEntries(params)).toMatchObject({
+    params: JSON.stringify({column: 'store_type', operation: 'count'}),
+  });
+});
+
+test('getFormula - requires geometryType when featureIds provided', async () => {
+  const widgetSource = new WidgetTestSource({
+    accessToken: '<token>',
+    connectionName: 'carto_dw',
+  });
+
+  await expect(
+    widgetSource.getFormula({
+      column: 'store_type',
+      operation: 'count',
+      featureIds: ['a', 'b'],
+    })
+  ).rejects.toThrow(/geometryType is required/);
+});
+
+test('getFormula - rejects more than 1000 featureIds', async () => {
+  const widgetSource = new WidgetTestSource({
+    accessToken: '<token>',
+    connectionName: 'carto_dw',
+  });
+
+  await expect(
+    widgetSource.getFormula({
+      column: 'store_type',
+      operation: 'count',
+      featureIds: Array.from({length: 1001}, (_, i) => String(i)),
+      geometryType: 'points',
+    })
+  ).rejects.toThrow(/limited to 1000/);
+});


### PR DESCRIPTION
Shortcut: https://app.shortcut.com/cartoteam/story/555371

## Summary

Adds optional `featureIds` / `geometryType` request options on the remote widget sources so widget aggregations can be filtered by a picked feature selection, without going through the synthetic `_carto_feature_id` column.

- new `WidgetFeatureGeometryType` type; `featureIds?` / `geometryType?` on `BaseRequestOptions`
- forwarded into model params for formula, category, histogram, range, scatter, table, timeSeries, aggregations
- `geometryType` required when `featureIds` is set; `featureIds` capped at 1000
