### PR TITLE
feat(fetchMap): Support line & polygon stroke dash styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- feat(fetchMap): Support line & polygon stroke dash styles (#297)
+
 ### 0.5.32
 
 - fix(parseMap): custom-aggregated channels no longer render a flat fixed color when the saved map has a null visual-channel field; the field is synthesized from the compiled aggregation alias, which also restores the channel's scale for legends (#328)

--- a/src/fetch-map/layer-map.ts
+++ b/src/fetch-map/layer-map.ts
@@ -32,6 +32,7 @@ import type {
   ColorRange,
   CustomMarkersRange,
   Dataset,
+  LineStyleRange,
   MapLayerConfig,
   VisConfig,
   VisualChannelField,
@@ -508,6 +509,25 @@ export function getIconUrlAccessor(
     return mapping[propertyValue] || unknownIcon;
   };
   return normalizeAccessor(accessor, data);
+}
+
+export function getLineStyleAccessor(
+  field: VisualChannelField,
+  range: LineStyleRange,
+  data: any
+) {
+  const fallback = range.othersDashArray ?? [0, 0];
+  const mapping: Record<string, [number, number]> = {};
+  for (const {value, dashArray} of range.dashArrayMap) {
+    mapping[value] = dashArray;
+  }
+  const accessor = (properties: any) =>
+    mapping[properties[field.name]] ?? fallback;
+  return {
+    accessor: normalizeAccessor(accessor, data),
+    domain: range.dashArrayMap.map(({value}) => value),
+    range: range.dashArrayMap.map(({dashArray}) => dashArray),
+  };
 }
 
 export function getMaxMarkerSize(

--- a/src/fetch-map/parse-map.ts
+++ b/src/fetch-map/parse-map.ts
@@ -578,22 +578,24 @@ function createChannelProps(
   {
     // A line is always stroked; a polygon border only when `stroked`. Points are excluded.
     const strokeVisible = isLine || (isPolygon && Boolean(visConfig.stroked));
-    if (
-      isVectorTile &&
-      strokeVisible &&
-      visConfig.lineStyle &&
-      visConfig.lineStyle !== 'solid'
-    ) {
-      if (visConfig.lineStyle === 'dotted') {
-        result.lineCapRounded = true;
-      }
-      result.lineStyle = visConfig.lineStyle;
-      if (visConfig.dashArray) {
-        result.dashArray = visConfig.dashArray;
-      }
-
+    if (isVectorTile && strokeVisible) {
       const {lineStyleField, lineStyleScale} = visualChannels;
       const {lineStyleRange} = visConfig;
+
+      // Fixed preset (used when no column drives the style).
+      if (visConfig.lineStyle && visConfig.lineStyle !== 'solid') {
+        if (visConfig.lineStyle === 'dotted') {
+          result.lineCapRounded = true;
+        }
+        result.lineStyle = visConfig.lineStyle;
+        if (visConfig.dashArray) {
+          result.dashArray = visConfig.dashArray;
+          result.getDashArray = visConfig.dashArray;
+        }
+      }
+
+      // Data-driven — mirrors getLineColor/getFillColor: computed whenever the field/scale/range
+      // are set, independent of the fixed `lineStyle`. Overrides the constant accessor above.
       if (lineStyleField && lineStyleScale && lineStyleRange) {
         const {accessor, ...scaleProps} = getLineStyleAccessor(
           lineStyleField,
@@ -601,13 +603,19 @@ function createChannelProps(
           data
         );
         result.getDashArray = accessor;
-        scales.lineStyle = {
+        scales.lineStyle = updateTriggers.getDashArray = {
           field: lineStyleField,
           type: lineStyleScale,
           ...scaleProps,
         };
-      } else if (visConfig.dashArray) {
-        result.getDashArray = visConfig.dashArray;
+        // Round caps so per-category dotted values ([0, gap]) render as dots, not squares.
+        const dashArrays = [
+          ...lineStyleRange.dashArrayMap.map(({dashArray}) => dashArray),
+          ...(lineStyleRange.othersDashArray ? [lineStyleRange.othersDashArray] : []),
+        ];
+        if (dashArrays.some(([dash]) => dash === 0)) {
+          result.lineCapRounded = true;
+        }
       }
     }
   }

--- a/src/fetch-map/parse-map.ts
+++ b/src/fetch-map/parse-map.ts
@@ -10,6 +10,7 @@ import {
   getTextAccessor,
   opacityToAlpha,
   getIconUrlAccessor,
+  getLineStyleAccessor,
   negateAccessor,
   getMaxMarkerSize,
   type LayerType,
@@ -48,7 +49,8 @@ export type Scale = {
 
   /** Domain of the user to construct d3 scale */
   scaleDomain?: string[] | number[];
-  range?: string[] | number[];
+  // `number[][]` carries per-category `[dash, gap]` tuples for the `lineStyle` scale.
+  range?: string[] | number[] | number[][];
 };
 
 export type ScaleKey =
@@ -57,7 +59,8 @@ export type ScaleKey =
   | 'lineColor'
   | 'lineWidth'
   | 'elevation'
-  | 'weight';
+  | 'weight'
+  | 'lineStyle';
 
 export type Scales = Partial<Record<ScaleKey, Scale>>;
 
@@ -381,6 +384,14 @@ function createChannelProps(
 
   const scales: Record<string, Scale> = {};
 
+  const isVectorTile = layerType === 'mvt' || layerType === 'tileset';
+  const geometry = data.tilestats?.layers?.[0]?.geometry;
+  const isLine =
+    geometry === 'Line' ||
+    geometry === 'LineString' ||
+    geometry === 'MultiLineString';
+  const isPolygon = geometry === 'Polygon' || geometry === 'MultiPolygon';
+
   // fill color
   {
     const {colorField, colorScale} = visualChannels;
@@ -563,6 +574,44 @@ function createChannelProps(
     }
   }
 
+  // stroke dash style — only VectorTileLayer (mvt/tileset) carries dashes; H3/Quadbin excluded.
+  {
+    // A line is always stroked; a polygon border only when `stroked`. Points are excluded.
+    const strokeVisible = isLine || (isPolygon && Boolean(visConfig.stroked));
+    if (
+      isVectorTile &&
+      strokeVisible &&
+      visConfig.lineStyle &&
+      visConfig.lineStyle !== 'solid'
+    ) {
+      if (visConfig.lineStyle === 'dotted') {
+        result.lineCapRounded = true;
+      }
+      result.lineStyle = visConfig.lineStyle;
+      if (visConfig.dashArray) {
+        result.dashArray = visConfig.dashArray;
+      }
+
+      const {lineStyleField, lineStyleScale} = visualChannels;
+      const {lineStyleRange} = visConfig;
+      if (lineStyleField && lineStyleScale && lineStyleRange) {
+        const {accessor, ...scaleProps} = getLineStyleAccessor(
+          lineStyleField,
+          lineStyleRange,
+          data
+        );
+        result.getDashArray = accessor;
+        scales.lineStyle = {
+          field: lineStyleField,
+          type: lineStyleScale,
+          ...scaleProps,
+        };
+      } else if (visConfig.dashArray) {
+        result.getDashArray = visConfig.dashArray;
+      }
+    }
+  }
+
   // height / elevation
   {
     const {heightField, heightScale} = visualChannels;
@@ -708,14 +757,7 @@ function createChannelProps(
     // point labels at line midpoints / polygon centroids via `autoLabels`. The
     // optional `uniqueIdProperty` dedupes features that span multiple tiles so
     // each feature gets one label instead of one-per-tile.
-    const geometry = data.tilestats?.layers?.[0]?.geometry;
-    const isLineOrPolygon =
-      geometry === 'Polygon' ||
-      geometry === 'MultiPolygon' ||
-      geometry === 'Line' ||
-      geometry === 'LineString' ||
-      geometry === 'MultiLineString';
-    if (isLineOrPolygon && (layerType === 'tileset' || layerType === 'mvt')) {
+    if ((isLine || isPolygon) && isVectorTile) {
       const uniqueIdProperty = visConfig.textLabelUniqueIdField;
       result.autoLabels = uniqueIdProperty ? {uniqueIdProperty} : true;
       result.pointType = 'text';

--- a/src/fetch-map/parse-map.ts
+++ b/src/fetch-map/parse-map.ts
@@ -611,7 +611,9 @@ function createChannelProps(
         // Round caps so per-category dotted values ([0, gap]) render as dots, not squares.
         const dashArrays = [
           ...lineStyleRange.dashArrayMap.map(({dashArray}) => dashArray),
-          ...(lineStyleRange.othersDashArray ? [lineStyleRange.othersDashArray] : []),
+          ...(lineStyleRange.othersDashArray
+            ? [lineStyleRange.othersDashArray]
+            : []),
         ];
         if (dashArrays.some(([dash]) => dash === 0)) {
           result.lineCapRounded = true;

--- a/src/fetch-map/types.ts
+++ b/src/fetch-map/types.ts
@@ -28,6 +28,9 @@ export type VisualChannels = {
   strokeColorField?: VisualChannelField;
   strokeColorScale?: ScaleType;
 
+  lineStyleField?: VisualChannelField;
+  lineStyleScale?: ScaleType;
+
   heightField?: VisualChannelField;
   heightScale?: ScaleType;
 
@@ -50,6 +53,16 @@ export type CustomMarkersRange = {
     markerUrl?: string;
   }[];
   othersMarker?: string;
+};
+
+// Per-category mapping for by-column stroke styles. `dashArray` is the [dash, gap]
+// tuple that flows to deck.gl's `getDashArray`.
+export type LineStyleRange = {
+  dashArrayMap: {
+    value: string;
+    dashArray: [number, number];
+  }[];
+  othersDashArray?: [number, number];
 };
 
 export type ColorBand = 'red' | 'green' | 'blue' | 'alpha';
@@ -95,6 +108,12 @@ export type VisConfig = {
   strokeColorAggregationDomain?: [number, number];
   strokeOpacity?: number;
   strokeColorRange?: ColorRange;
+  stroked?: boolean;
+
+  // `dashArray` is [dash, gap] relative to stroke width. Dotted is [0, gap] + lineCapRounded.
+  lineStyle?: 'solid' | 'dashed' | 'dotted';
+  dashArray?: [number, number];
+  lineStyleRange?: LineStyleRange | null;
 
   heightRange?: number[];
   heightAggregation?: string;

--- a/test/fetch-map/layer-map.spec.ts
+++ b/test/fetch-map/layer-map.spec.ts
@@ -3,6 +3,7 @@ import {
   getColorAccessor,
   getSizeAccessor,
   getTextAccessor,
+  getLineStyleAccessor,
   getLayerProps,
   _domainFromValues,
 } from '@carto/api-client';
@@ -451,6 +452,46 @@ describe('layer-map', () => {
         expect(accessor(testCase.data)).toBe(testCase.expected);
       }
     );
+  });
+
+  describe('getLineStyleAccessor', () => {
+    const field = {name: 'road_type', type: 'string'};
+    const data = {
+      tilestats: {
+        layers: [{attributes: [{attribute: 'road_type', categories: []}]}],
+      },
+    };
+
+    test('maps each category to its dash array, returning the scale domain/range', () => {
+      const {accessor, domain, range} = getLineStyleAccessor(
+        field,
+        {
+          dashArrayMap: [
+            {value: 'a', dashArray: [4, 2]},
+            {value: 'b', dashArray: [1, 1]},
+          ],
+          othersDashArray: [8, 8],
+        },
+        data
+      );
+      expect(accessor({properties: {road_type: 'a'}})).toEqual([4, 2]);
+      expect(accessor({properties: {road_type: 'b'}})).toEqual([1, 1]);
+      expect(accessor({properties: {road_type: 'z'}})).toEqual([8, 8]);
+      expect(domain).toEqual(['a', 'b']);
+      expect(range).toEqual([
+        [4, 2],
+        [1, 1],
+      ]);
+    });
+
+    test('falls back to solid [0, 0] when othersDashArray is absent', () => {
+      const {accessor} = getLineStyleAccessor(
+        field,
+        {dashArrayMap: [{value: 'a', dashArray: [4, 2]}]},
+        data
+      );
+      expect(accessor({properties: {road_type: 'unknown'}})).toEqual([0, 0]);
+    });
   });
 
   test('throws error for deprecated layer types', () => {

--- a/test/fetch-map/parse-map.spec.ts
+++ b/test/fetch-map/parse-map.spec.ts
@@ -1465,6 +1465,33 @@ describe('parseMap', () => {
       });
     });
 
+    test('by-column mode renders even when the fixed lineStyle is solid (round caps for dotted values)', () => {
+      const {props, scales} = parse(
+        'LineString',
+        {
+          lineStyle: 'solid',
+          lineStyleRange: {
+            dashArrayMap: [
+              {value: 'a', dashArray: [4, 2]},
+              {value: 'b', dashArray: [0, 3]},
+            ],
+          },
+        },
+        {
+          lineStyleField: {name: 'road_type', type: 'string'},
+          lineStyleScale: 'ordinal',
+        }
+      );
+      expect(typeof props.getDashArray).toBe('function');
+      expect(props.getDashArray({properties: {road_type: 'b'}})).toEqual([0, 3]);
+      expect(props.lineStyle).toBeUndefined(); // fixed preset stays solid → no flat prop
+      expect(props.lineCapRounded).toBe(true); // a [0, gap] value ⇒ round dots
+      expect(scales.lineStyle).toMatchObject({
+        field: {name: 'road_type', type: 'string'},
+        type: 'ordinal',
+      });
+    });
+
     test('non-vector-tile layer type receives no dashes', () => {
       const {props} = parse(
         'LineString',

--- a/test/fetch-map/parse-map.spec.ts
+++ b/test/fetch-map/parse-map.spec.ts
@@ -1300,4 +1300,179 @@ describe('parseMap', () => {
       expect(map.layers[0].props.autoLabels).toBeUndefined();
     });
   });
+
+  describe('stroke dash style', () => {
+    const buildDataset = (geometry: string) => ({
+      id: 'STROKE_DS',
+      data: {
+        tiles: ['https://example.com/tiles/{z}/{x}/{y}'],
+        tilestats: {
+          layers: [
+            {
+              attributes: [
+                {
+                  attribute: 'road_type',
+                  categories: [{category: 'a'}, {category: 'b'}],
+                },
+              ],
+              geometry,
+            },
+          ],
+        },
+      },
+      type: 'tileset',
+    });
+
+    const buildLayerConfig = (
+      visConfigOverrides: Record<string, any> = {},
+      visualChannels: Record<string, any> = {},
+      type = 'tileset'
+    ) => ({
+      version: 'v1',
+      config: {
+        mapState: {},
+        mapStyle: {},
+        visState: {
+          layers: [
+            {
+              id: 'layer1',
+              type,
+              config: {
+                dataId: 'STROKE_DS',
+                label: 'Test Layer',
+                textLabel: [{field: null, size: 12}],
+                visConfig: {
+                  filled: true,
+                  opacity: 1,
+                  colorRange: {
+                    category: 'sequential',
+                    colors: ['#f0f0f0', '#333333'],
+                    colorMap: undefined,
+                    name: 'custom',
+                    type: 'custom',
+                  },
+                  radius: 5,
+                  ...visConfigOverrides,
+                },
+              },
+              visualChannels,
+            },
+          ],
+          layerBlending: 'normal',
+          interactionConfig: {tooltip: {enabled: false}},
+        },
+      },
+    });
+
+    const parse = (
+      geometry: string,
+      ...args: Parameters<typeof buildLayerConfig>
+    ) =>
+      parseMap({
+        ...METADATA,
+        datasets: [buildDataset(geometry)],
+        keplerMapConfig: buildLayerConfig(...args),
+      }).layers[0];
+
+    test('single-mode dashed line sets a constant getDashArray and the flat lineStyle/dashArray fields (no scale)', () => {
+      const {props, scales} = parse('LineString', {
+        lineStyle: 'dashed',
+        dashArray: [4, 2],
+      });
+      expect(props.getDashArray).toEqual([4, 2]);
+      expect(props.lineStyle).toBe('dashed');
+      expect(props.dashArray).toEqual([4, 2]);
+      expect(props.lineCapRounded).toBeUndefined();
+      expect(scales.lineStyle).toBeUndefined();
+    });
+
+    test('dotted line sets lineCapRounded', () => {
+      const {props} = parse('LineString', {
+        lineStyle: 'dotted',
+        dashArray: [0, 3],
+      });
+      expect(props.lineCapRounded).toBe(true);
+      expect(props.getDashArray).toEqual([0, 3]);
+    });
+
+    test('solid line emits no dash props (deck.gl default renders solid)', () => {
+      const {props} = parse('LineString', {lineStyle: 'solid'});
+      expect(props.getDashArray).toBeUndefined();
+      expect(props.lineStyle).toBeUndefined();
+      expect(props.lineCapRounded).toBeUndefined();
+    });
+
+    test('polygon border needs stroked to receive dashes', () => {
+      expect(
+        parse('Polygon', {lineStyle: 'dashed', dashArray: [4, 2]}).props
+          .getDashArray
+      ).toBeUndefined();
+      expect(
+        parse('Polygon', {
+          lineStyle: 'dashed',
+          dashArray: [4, 2],
+          stroked: true,
+        }).props.getDashArray
+      ).toEqual([4, 2]);
+    });
+
+    test('points never receive dashes even when stroked', () => {
+      const {props} = parse('Point', {
+        lineStyle: 'dashed',
+        dashArray: [4, 2],
+        stroked: true,
+      });
+      expect(props.getDashArray).toBeUndefined();
+    });
+
+    test('by-column mode builds a per-feature accessor and a lineStyle scale', () => {
+      const {props, scales} = parse(
+        'LineString',
+        {
+          lineStyle: 'dashed',
+          dashArray: [4, 2],
+          lineStyleRange: {
+            dashArrayMap: [
+              {value: 'a', dashArray: [4, 2]},
+              {value: 'b', dashArray: [1, 1]},
+            ],
+            othersDashArray: [8, 8],
+          },
+        },
+        {
+          lineStyleField: {name: 'road_type', type: 'string'},
+          lineStyleScale: 'ordinal',
+        }
+      );
+      expect(typeof props.getDashArray).toBe('function');
+      expect(props.getDashArray({properties: {road_type: 'a'}})).toEqual([
+        4, 2,
+      ]);
+      expect(props.getDashArray({properties: {road_type: 'b'}})).toEqual([
+        1, 1,
+      ]);
+      expect(props.getDashArray({properties: {road_type: 'z'}})).toEqual([
+        8, 8,
+      ]);
+      expect(scales.lineStyle).toEqual({
+        field: {name: 'road_type', type: 'string'},
+        type: 'ordinal',
+        domain: ['a', 'b'],
+        range: [
+          [4, 2],
+          [1, 1],
+        ],
+      });
+    });
+
+    test('non-vector-tile layer type receives no dashes', () => {
+      const {props} = parse(
+        'LineString',
+        {lineStyle: 'dashed', dashArray: [4, 2]},
+        {},
+        'h3'
+      );
+      expect(props.getDashArray).toBeUndefined();
+    });
+  });
 });

--- a/test/fetch-map/parse-map.spec.ts
+++ b/test/fetch-map/parse-map.spec.ts
@@ -1483,7 +1483,9 @@ describe('parseMap', () => {
         }
       );
       expect(typeof props.getDashArray).toBe('function');
-      expect(props.getDashArray({properties: {road_type: 'b'}})).toEqual([0, 3]);
+      expect(props.getDashArray({properties: {road_type: 'b'}})).toEqual([
+        0, 3,
+      ]);
       expect(props.lineStyle).toBeUndefined(); // fixed preset stays solid → no flat prop
       expect(props.lineCapRounded).toBe(true); // a [0, gap] value ⇒ round dots
       expect(scales.lineStyle).toMatchObject({


### PR DESCRIPTION
Story: [sc-555860](https://app.shortcut.com/cartoteam/story/555860)

## What

Adds line & polygon **stroke dash style** support to `fetchMap`/`parseMap`.

For VectorTileLayer (`mvt`/`tileset`) layers with a non-solid stroke, `parseMap` now emits:
- `getDashArray` — constant `[dash, gap]` in single mode, or a per-feature accessor in by-column mode
- `lineCapRounded: true` for `dotted`
- `scales.lineStyle` for by-column mode
- flat `lineStyle` / `dashArray` descriptor fields

New public surface:
- `VisConfig`: `lineStyle` (`'solid' | 'dashed' | 'dotted'`), `dashArray`, `lineStyleRange`, `stroked`
- `VisualChannels`: `lineStyleField`, `lineStyleScale`
- `getLineStyleAccessor` helper (mirrors `getIconUrlAccessor`)
- `'lineStyle'` added to the `ScaleKey` union; `Scale.range` widened to carry `[dash, gap]` tuples

## Why

A map whose vis-config stores a non-solid `lineStyle` previously rendered solid when loaded via `fetchMap`, because the dash props were never computed. This wires them through.

## How it renders

Data only — api-client supplies props/accessors and never instantiates deck.gl classes. The consumer attaches `PathStyleExtension({ dash: true })`; an unset `getDashArray` (deck.gl default `[0,0]`) renders solid.

## Tests

Unit tests for `getLineStyleAccessor` (`layer-map.spec`) and `parseMap` wiring (`parse-map.spec`): single/by-column dashed, dotted (`lineCapRounded`), solid no-op, polygon-needs-`stroked`, points excluded, non-vector-tile excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)