### PR TITLE
feat(auth): session auth mode for same-origin proxy deployments [sc-556407]

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,7 +1,3 @@
-// deck.gl
-// SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
-
 /**
  * How requests to the CARTO APIs are authenticated.
  *
@@ -77,8 +73,20 @@ export function rewriteUrlForSessionMode(
   url: string,
   apiBaseUrl: string
 ): string {
+  let origin: string;
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      return url;
+    }
+    origin = parsed.origin;
+  } catch {
+    // Relative URL — already same-origin, nothing to rewrite.
+    return url;
+  }
+  // Keep the path+query as a raw slice rather than re-serializing through
+  // URL: tile URL templates contain literal placeholders ({z}/{x}/{y}) that
+  // URL#pathname would percent-encode, breaking template substitution.
   const base = apiBaseUrl.replace(/\/+$/, '');
-  // Use a replacement function so any `$`-patterns in apiBaseUrl (`$&`, `$1`,
-  // …) are treated literally rather than interpreted by String.replace.
-  return url.replace(/^https?:\/\/[^/?#]+/, () => base);
+  return base + url.slice(origin.length);
 }

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -77,5 +77,8 @@ export function rewriteUrlForSessionMode(
   url: string,
   apiBaseUrl: string
 ): string {
-  return url.replace(/^https?:\/\/[^/?#]+/, apiBaseUrl.replace(/\/+$/, ''));
+  const base = apiBaseUrl.replace(/\/+$/, '');
+  // Use a replacement function so any `$`-patterns in apiBaseUrl (`$&`, `$1`,
+  // …) are treated literally rather than interpreted by String.replace.
+  return url.replace(/^https?:\/\/[^/?#]+/, () => base);
 }

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,0 +1,81 @@
+// deck.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+/**
+ * How requests to the CARTO APIs are authenticated.
+ *
+ * - `'token'` (default): every request carries `Authorization: Bearer <accessToken>`.
+ * - `'session'`: requests carry NO Authorization header and are sent with
+ *   `credentials: 'same-origin'`. Authentication is delegated to the server
+ *   behind `apiBaseUrl` — typically a same-origin proxy that attaches the
+ *   credential server-side from a session cookie. Used by CARTO hosted apps
+ *   (`apiBaseUrl: '/app/_proxy/<slug>'`) and other single-origin deployments
+ *   where the access token must never be exposed to JavaScript.
+ */
+export type AuthMode = 'token' | 'session';
+
+/**
+ * Authentication options shared by sources, queries, widget sources and
+ * fetchMap:
+ *
+ * - token mode (default): `accessToken` is required.
+ * - session mode: `authMode: 'session'` and no `accessToken`.
+ *
+ * Validated at request time by {@link buildAuthHeaders}.
+ */
+export type AuthOptions = {
+  /** Carto platform access token. Required unless `authMode` is `'session'`. */
+  accessToken?: string;
+  /** @default 'token' */
+  authMode?: AuthMode;
+};
+
+/**
+ * Builds the Authorization headers for a request: a Bearer header in token
+ * mode, no auth headers at all in session mode (the server-side session
+ * middleware must see the header absent to engage). Also validates the
+ * options, so every request path fails fast on a misconfiguration.
+ */
+export function buildAuthHeaders(options: AuthOptions): Record<string, string> {
+  if (options.authMode === 'session') {
+    if (options.accessToken) {
+      throw new Error(
+        `accessToken must not be provided with authMode: 'session' — ` +
+          `authentication is delegated to the server behind apiBaseUrl`
+      );
+    }
+    return {};
+  }
+  if (!options.accessToken) {
+    throw new Error(
+      `accessToken is required (or pass authMode: 'session' to authenticate ` +
+        `via a same-origin session instead)`
+    );
+  }
+  return {Authorization: `Bearer ${options.accessToken}`};
+}
+
+/**
+ * `fetch()` credentials for the given auth mode. Session mode must send the
+ * cookie explicitly; token mode preserves today's behavior (unset).
+ */
+export function getAuthCredentials(
+  authMode?: AuthMode
+): RequestCredentials | undefined {
+  return authMode === 'session' ? 'same-origin' : undefined;
+}
+
+/**
+ * Rewrites an absolute CARTO API URL (e.g. a tilejson `tiles[]` template or
+ * the map-instantiation `dataUrl`, which always point at the tenant API host)
+ * onto the configured `apiBaseUrl`. In session mode the browser cannot reach
+ * the API host directly — every request must go through the same-origin
+ * proxy that `apiBaseUrl` points at. Relative URLs are returned unchanged.
+ */
+export function rewriteUrlForSessionMode(
+  url: string,
+  apiBaseUrl: string
+): string {
+  return url.replace(/^https?:\/\/[^/?#]+/, apiBaseUrl.replace(/\/+$/, ''));
+}

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -3,6 +3,13 @@
 // Copyright (c) vis.gl contributors
 
 export {
+  buildAuthHeaders,
+  getAuthCredentials,
+  rewriteUrlForSessionMode,
+  type AuthMode,
+  type AuthOptions,
+} from './auth.js';
+export {
   CartoAPIError,
   type APIErrorContext,
   type APIRequestType,

--- a/src/api/query.ts
+++ b/src/api/query.ts
@@ -9,6 +9,7 @@ import type {
   QueryResult,
 } from '../sources/types.js';
 import {buildQueryUrl} from './endpoints.js';
+import {buildAuthHeaders, getAuthCredentials} from './auth.js';
 import {requestWithParameters} from './request-with-parameters.js';
 import type {APIErrorContext} from './carto-api-error.js';
 import {getClient} from '../client.js';
@@ -50,7 +51,7 @@ export const query = async function (
 
   const baseUrl = buildQueryUrl({apiBaseUrl, connectionName});
   const headers = {
-    Authorization: `Bearer ${options.accessToken}`,
+    ...buildAuthHeaders(options),
     ...options.headers,
   };
   const parameters = {
@@ -74,5 +75,6 @@ export const query = async function (
     maxLengthURL,
     localCache,
     signal: options.signal,
+    credentials: getAuthCredentials(options.authMode),
   });
 };

--- a/src/api/request-with-parameters.ts
+++ b/src/api/request-with-parameters.ts
@@ -145,7 +145,10 @@ function createCacheKey(
 const RELATIVE_ORIGIN = 'https://relative.invalid';
 
 function parseBaseUrl(baseUrlString: string): {url: URL; isRelative: boolean} {
-  const isRelative = baseUrlString.startsWith('/');
+  // Protocol-relative URLs ('//host/...') carry a host and must not be treated
+  // as relative, or the host would be lost when resolved against RELATIVE_ORIGIN.
+  const isRelative =
+    baseUrlString.startsWith('/') && !baseUrlString.startsWith('//');
   return {
     url: new URL(baseUrlString, isRelative ? RELATIVE_ORIGIN : undefined),
     isRelative,

--- a/src/api/request-with-parameters.ts
+++ b/src/api/request-with-parameters.ts
@@ -24,6 +24,7 @@ export async function requestWithParameters<T = any>({
   maxLengthURL = DEFAULT_MAX_LENGTH_URL,
   localCache,
   signal,
+  credentials,
 }: {
   baseUrl: string;
   parameters?: Record<string, unknown>;
@@ -32,6 +33,8 @@ export async function requestWithParameters<T = any>({
   maxLengthURL?: number;
   localCache?: LocalCacheOptions;
   signal?: AbortSignal;
+  /** Forwarded to `fetch()`. Session auth mode passes 'same-origin'. */
+  credentials?: RequestCredentials;
 }): Promise<T> {
   // Parameters added to all requests issued with `requestWithParameters()`.
   // These parameters override parameters already in the base URL, but not
@@ -68,8 +71,9 @@ export async function requestWithParameters<T = any>({
           body: JSON.stringify(parameters),
           headers,
           signal,
+          ...(credentials && {credentials}),
         })
-      : fetch(url, {headers, signal});
+      : fetch(url, {headers, signal, ...(credentials && {credentials})});
 
   let response: Response | undefined;
   let responseJson: unknown;
@@ -133,6 +137,26 @@ function createCacheKey(
 }
 
 /**
+ * Base URLs may be relative (e.g. a same-origin proxy like
+ * '/app/_proxy/<slug>/v3/...' used with session auth mode). `new URL()`
+ * requires an origin, so relative URLs are resolved against a marker origin
+ * that is stripped back off before returning.
+ */
+const RELATIVE_ORIGIN = 'https://relative.invalid';
+
+function parseBaseUrl(baseUrlString: string): {url: URL; isRelative: boolean} {
+  const isRelative = baseUrlString.startsWith('/');
+  return {
+    url: new URL(baseUrlString, isRelative ? RELATIVE_ORIGIN : undefined),
+    isRelative,
+  };
+}
+
+function serializeBaseUrl(url: URL, isRelative: boolean): string {
+  return isRelative ? `${url.pathname}${url.search}` : url.toString();
+}
+
+/**
  * Appends query string parameters to a URL. Existing URL parameters are kept,
  * unless there is a conflict, in which case the new parameters override
  * those already in the URL.
@@ -141,7 +165,7 @@ function createURLWithParameters(
   baseUrlString: string,
   parameters: Record<string, unknown>
 ): string {
-  const baseUrl = new URL(baseUrlString);
+  const {url: baseUrl, isRelative} = parseBaseUrl(baseUrlString);
   for (const [key, value] of Object.entries(parameters)) {
     if (isPureObject(value) || Array.isArray(value)) {
       baseUrl.searchParams.set(key, JSON.stringify(value));
@@ -154,20 +178,20 @@ function createURLWithParameters(
       }
     }
   }
-  return baseUrl.toString();
+  return serializeBaseUrl(baseUrl, isRelative);
 }
 
 /**
  * Deletes query string parameters from a URL.
  */
 function excludeURLParameters(baseUrlString: string, parameters: string[]) {
-  const baseUrl = new URL(baseUrlString);
+  const {url: baseUrl, isRelative} = parseBaseUrl(baseUrlString);
   for (const param of parameters) {
     if (baseUrl.searchParams.has(param)) {
       baseUrl.searchParams.delete(param);
     }
   }
-  return baseUrl.toString();
+  return serializeBaseUrl(baseUrl, isRelative);
 }
 
 /**

--- a/src/fetch-map/parse-map.ts
+++ b/src/fetch-map/parse-map.ts
@@ -754,7 +754,13 @@ function createChannelProps(
   };
 }
 
-function createLoadOptions(accessToken: string) {
+function createLoadOptions(accessToken?: string) {
+  // No token (e.g. a source created with authMode: 'session', where tile URLs
+  // are same-origin and authenticated by a session cookie): attach no
+  // Authorization header rather than a literal 'Bearer undefined'.
+  if (!accessToken) {
+    return {loadOptions: {fetch: {credentials: 'same-origin'}}};
+  }
   return {
     loadOptions: {fetch: {headers: {Authorization: `Bearer ${accessToken}`}}},
   };

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,11 @@ export * from './types.js';
 export {
   type APIErrorContext,
   type APIRequestType,
+  type AuthMode,
+  type AuthOptions,
+  buildAuthHeaders,
+  getAuthCredentials,
+  rewriteUrlForSessionMode,
   CartoAPIError,
   type QueryOptions,
   buildPublicMapUrl, // Internal, but required for fetchMap().

--- a/src/models/common.ts
+++ b/src/models/common.ts
@@ -1,4 +1,9 @@
 import {InvalidColumnError} from '../utils.js';
+import {
+  buildAuthHeaders,
+  getAuthCredentials,
+  type AuthMode,
+} from '../api/auth.js';
 
 /** @privateRemarks Source: @carto/react-api */
 export interface ModelRequestOptions {
@@ -55,10 +60,12 @@ export function dealWithApiError({
 export async function makeCall({
   url,
   accessToken,
+  authMode,
   opts,
 }: {
   url: string;
-  accessToken: string;
+  accessToken?: string;
+  authMode?: AuthMode;
   opts: ModelRequestOptions;
 }) {
   let response;
@@ -67,10 +74,13 @@ export async function makeCall({
   try {
     response = await fetch(url.toString(), {
       headers: {
-        Authorization: `Bearer ${accessToken}`,
+        ...buildAuthHeaders({accessToken, authMode}),
         ...(isPost && {'Content-Type': 'application/json'}),
         ...opts.headers,
       },
+      ...(getAuthCredentials(authMode) && {
+        credentials: getAuthCredentials(authMode),
+      }),
       ...(isPost && {
         method: opts?.method,
         body: opts?.body,

--- a/src/models/model.ts
+++ b/src/models/model.ts
@@ -1,4 +1,5 @@
 import {DEFAULT_GEO_COLUMN} from '../constants-internal.js';
+import type {AuthMode} from '../api/auth.js';
 import type {
   Filter,
   FilterLogicalOperator,
@@ -33,7 +34,8 @@ export interface ModelSource {
   type: MapType;
   apiVersion: ApiVersion;
   apiBaseUrl: string;
-  accessToken: string;
+  accessToken?: string;
+  authMode?: AuthMode;
   clientId: string;
   connectionName: string;
   data: string;
@@ -123,6 +125,7 @@ export function executeModel(props: {
   return makeCall({
     url,
     accessToken: source.accessToken,
+    authMode: source.authMode,
     opts: {
       ...opts,
       method: isGet ? 'GET' : 'POST',

--- a/src/models/model.ts
+++ b/src/models/model.ts
@@ -74,11 +74,12 @@ export function executeModel(props: {
   );
 
   const {model, source, params, opts} = props;
-  const {type, apiVersion, apiBaseUrl, accessToken, connectionName, clientId} =
-    source;
+  const {type, apiVersion, apiBaseUrl, connectionName, clientId} = source;
 
   assert(apiBaseUrl, 'executeModel: missing apiBaseUrl');
-  assert(accessToken, 'executeModel: missing accessToken');
+  // Auth (token vs session mode) is validated centrally by buildAuthHeaders,
+  // invoked from makeCall below — no separate accessToken assertion here, so
+  // that session mode (no accessToken) is not rejected before the request.
   assert(apiVersion === V3, 'executeModel: SQL Model API requires CARTO 3+');
   assert(type !== 'tileset', 'executeModel: Tilesets not supported');
 

--- a/src/sources/base-source.ts
+++ b/src/sources/base-source.ts
@@ -5,6 +5,11 @@
 import {DEFAULT_API_BASE_URL} from '../constants.js';
 import {DEFAULT_MAX_LENGTH_URL} from '../constants-internal.js';
 import {buildSourceUrl} from '../api/endpoints.js';
+import {
+  buildAuthHeaders,
+  getAuthCredentials,
+  rewriteUrlForSessionMode,
+} from '../api/auth.js';
 import {requestWithParameters} from '../api/request-with-parameters.js';
 import type {
   SourceOptionalOptions,
@@ -43,10 +48,12 @@ export async function baseSource<UrlParameters extends Record<string, unknown>>(
   }
   const baseUrl = buildSourceUrl(mergedOptions);
   const {clientId, maxLengthURL, localCache} = mergedOptions;
+  const sessionMode = options.authMode === 'session';
   const headers = {
-    Authorization: `Bearer ${options.accessToken}`,
+    ...buildAuthHeaders(options),
     ...options.headers,
   };
+  const credentials = getAuthCredentials(options.authMode);
   const parameters = {client: clientId, ...options.tags, ...urlParameters};
 
   const errorContext: APIErrorContext = {
@@ -63,14 +70,21 @@ export async function baseSource<UrlParameters extends Record<string, unknown>>(
       errorContext,
       maxLengthURL,
       localCache,
+      credentials,
     });
 
-  const dataUrl = tilejson.url[0];
+  let dataUrl = tilejson.url[0];
   if (cache) {
     cache.value = parseInt(
       new URL(dataUrl).searchParams.get('cache') || '',
       10
     );
+  }
+  if (sessionMode) {
+    // The instantiation response points at the tenant API host, which the
+    // browser cannot reach directly in session mode — route it through the
+    // same-origin proxy behind apiBaseUrl.
+    dataUrl = rewriteUrlForSessionMode(dataUrl, mergedOptions.apiBaseUrl);
   }
   errorContext.requestType = 'Map data';
 
@@ -81,8 +95,17 @@ export async function baseSource<UrlParameters extends Record<string, unknown>>(
     errorContext,
     maxLengthURL,
     localCache,
+    credentials,
   });
-  if (accessToken) {
+  if (sessionMode) {
+    // Tile URL templates also point at the tenant API host. Rewrite them onto
+    // the proxy, and deliberately leave `json.accessToken` unset: consumers
+    // (e.g. deck.gl tile layers) must not attach an Authorization header —
+    // the session credential rides on the same-origin cookie instead.
+    json.tiles = json.tiles?.map((template) =>
+      rewriteUrlForSessionMode(template, mergedOptions.apiBaseUrl)
+    );
+  } else if (accessToken) {
     json.accessToken = accessToken;
   }
   if (schema) {

--- a/src/sources/types.ts
+++ b/src/sources/types.ts
@@ -3,12 +3,10 @@
 // Copyright (c) vis.gl contributors
 
 import type {Filters, SchemaField, QueryParameters} from '../types.js';
+import type {AuthOptions} from '../api/auth.js';
 import type {RasterBandColorinterp} from './constants.js';
 
-export type SourceRequiredOptions = {
-  /** Carto platform access token. */
-  accessToken: string;
-
+export type SourceRequiredOptions = AuthOptions & {
   /** Data warehouse connection name in Carto platform. */
   connectionName: string;
 };
@@ -466,7 +464,13 @@ export type RasterMetadata = {
 };
 
 export type TilejsonResult = Tilejson & {
-  accessToken: string;
+  /**
+   * Access token used to fetch the tiles. Absent when the source was created
+   * with `authMode: 'session'` — tile URLs are then rewritten onto the
+   * configured `apiBaseUrl` and authenticated by the server (session cookie),
+   * so consumers must not attach an Authorization header.
+   */
+  accessToken?: string;
   schema: SchemaField[];
 };
 

--- a/src/widget-sources/widget-remote-source.ts
+++ b/src/widget-sources/widget-remote-source.ts
@@ -30,6 +30,7 @@ import {AggregationTypes, ApiVersion} from '../constants.js';
 import {getApplicableFilters} from '../filters.js';
 import {OTHERS_CATEGORY_NAME} from './constants.js';
 import {requestWithParameters} from '../api/request-with-parameters.js';
+import {buildAuthHeaders, getAuthCredentials} from '../api/auth.js';
 import type {APIErrorContext} from '../api/carto-api-error.js';
 
 export type WidgetRemoteSourceProps = WidgetSourceProps;
@@ -88,6 +89,7 @@ export abstract class WidgetRemoteSource<
       apiBaseUrl: props.apiBaseUrl as string,
       clientId: props.clientId as string,
       accessToken: props.accessToken,
+      authMode: props.authMode,
       connectionName: props.connectionName,
       filters: getApplicableFilters(filterOwner, filters || props.filters),
       filtersLogicalOperator: props.filtersLogicalOperator,
@@ -486,7 +488,7 @@ export abstract class WidgetRemoteSource<
     }
 
     const headers = {
-      Authorization: `Bearer ${this.props.accessToken}`,
+      ...buildAuthHeaders(this.props),
       ...this.props.headers,
     };
 
@@ -511,6 +513,7 @@ export abstract class WidgetRemoteSource<
       signal,
       errorContext,
       parameters,
+      credentials: getAuthCredentials(this.props.authMode),
     }).then(({extent: {xmin, ymin, xmax, ymax}}) => ({
       bbox: [xmin, ymin, xmax, ymax],
     }));

--- a/test/api/auth.test.ts
+++ b/test/api/auth.test.ts
@@ -1,7 +1,3 @@
-// deck.gl
-// SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
-
 import {describe, expect, test} from 'vitest';
 import {
   buildAuthHeaders,

--- a/test/api/auth.test.ts
+++ b/test/api/auth.test.ts
@@ -1,0 +1,66 @@
+// deck.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {describe, expect, test} from 'vitest';
+import {
+  buildAuthHeaders,
+  getAuthCredentials,
+  rewriteUrlForSessionMode,
+} from '@carto/api-client';
+
+describe('buildAuthHeaders', () => {
+  test('token mode returns a Bearer header', () => {
+    expect(buildAuthHeaders({accessToken: 'abc'})).toEqual({
+      Authorization: 'Bearer abc',
+    });
+    expect(buildAuthHeaders({accessToken: 'abc', authMode: 'token'})).toEqual({
+      Authorization: 'Bearer abc',
+    });
+  });
+
+  test('session mode returns no headers', () => {
+    expect(buildAuthHeaders({authMode: 'session'})).toEqual({});
+  });
+
+  test('throws without a token in token mode', () => {
+    expect(() => buildAuthHeaders({})).toThrowError(/accessToken is required/);
+  });
+
+  test('throws when a token is passed in session mode', () => {
+    expect(() =>
+      buildAuthHeaders({accessToken: 'abc', authMode: 'session'})
+    ).toThrowError(/must not be provided/);
+  });
+});
+
+describe('getAuthCredentials', () => {
+  test('session mode requests same-origin credentials', () => {
+    expect(getAuthCredentials('session')).toBe('same-origin');
+    expect(getAuthCredentials('token')).toBeUndefined();
+    expect(getAuthCredentials(undefined)).toBeUndefined();
+  });
+});
+
+describe('rewriteUrlForSessionMode', () => {
+  test('replaces scheme and host with the configured base', () => {
+    expect(
+      rewriteUrlForSessionMode(
+        'https://gcp-us-east1.api.carto.com/v3/maps/conn/table/{z}/{x}/{y}?name=a',
+        '/app/_proxy/my-app'
+      )
+    ).toBe('/app/_proxy/my-app/v3/maps/conn/table/{z}/{x}/{y}?name=a');
+  });
+
+  test('strips trailing slashes from the base', () => {
+    expect(rewriteUrlForSessionMode('https://host.com/v3/sql', '/proxy/')).toBe(
+      '/proxy/v3/sql'
+    );
+  });
+
+  test('leaves relative URLs unchanged', () => {
+    expect(rewriteUrlForSessionMode('/v3/sql?q=1', '/proxy')).toBe(
+      '/v3/sql?q=1'
+    );
+  });
+});

--- a/test/api/auth.test.ts
+++ b/test/api/auth.test.ts
@@ -63,4 +63,10 @@ describe('rewriteUrlForSessionMode', () => {
       '/v3/sql?q=1'
     );
   });
+
+  test('treats $-patterns in the base literally', () => {
+    expect(
+      rewriteUrlForSessionMode('https://host.com/v3/sql', '/proxy/$&/$1')
+    ).toBe('/proxy/$&/$1/v3/sql');
+  });
 });

--- a/test/sources/base-source.test.ts
+++ b/test/sources/base-source.test.ts
@@ -1,6 +1,6 @@
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 import {setClient, vectorTableSource} from '@carto/api-client';
-import {MOCK_INIT_RESPONSE} from '../__mock-fetch.js';
+import {MOCK_INIT_RESPONSE, stubGlobalFetchForSource} from '../__mock-fetch.js';
 
 describe('baseSource', () => {
   beforeEach(() => {
@@ -36,5 +36,52 @@ describe('baseSource', () => {
     expect(calls[3][0]).toMatch(`client=${clientIds[1]}`);
     expect(calls[4][0]).toMatch(`client=${clientIds[2]}`);
     expect(calls[5][0]).toMatch(`client=${clientIds[2]}`);
+  });
+
+  test('authMode: session — no auth header, same-origin credentials, proxied tile URLs', async () => {
+    const mockFetch = stubGlobalFetchForSource();
+
+    const result = await vectorTableSource({
+      connectionName: 'carto_dw',
+      authMode: 'session',
+      apiBaseUrl: '/app/_proxy/my-app',
+      tableName: 'test',
+    });
+
+    const calls = mockFetch.mock.calls;
+    expect(calls.length).toBe(2);
+    for (const [url, init] of calls) {
+      expect((init as RequestInit).credentials).toBe('same-origin');
+      expect(
+        ((init as RequestInit).headers as Record<string, string>).Authorization
+      ).toBeUndefined();
+      expect(String(url)).not.toMatch(/access_token/);
+    }
+    // Map instantiation goes to the configured (proxy) base.
+    expect(String(calls[0][0])).toMatch(/^\/app\/_proxy\/my-app\/v3\/maps\//);
+    // The tilejson dataUrl (absolute, returned by the server) is rewritten.
+    expect(String(calls[1][0])).toMatch(/^\/app\/_proxy\/my-app/);
+
+    // Tile templates rewritten onto the proxy; no accessToken on the result.
+    expect(result.tiles).toEqual([
+      '/app/_proxy/my-app/{z}/{x}/{y}?formatTiles=binary',
+    ]);
+    expect(result.accessToken).toBeUndefined();
+  });
+
+  test('authMode: token (default) — Bearer header, no credentials override', async () => {
+    await vectorTableSource({
+      connectionName: 'carto_dw',
+      accessToken: '<token>',
+      tableName: 'test',
+    });
+    const calls = vi.mocked(fetch).mock.calls;
+    expect(calls.length).toBeGreaterThan(0);
+    for (const [, init] of calls) {
+      expect((init.headers as Record<string, string>).Authorization).toBe(
+        'Bearer <token>'
+      );
+      expect(init.credentials).toBeUndefined();
+    }
   });
 });


### PR DESCRIPTION
## Why

Some deployments must never expose a CARTO access token to JavaScript: the credential lives server-side and requests are authenticated by a session cookie behind a same-origin proxy. The first consumer is **CARTO hosted apps**, where every API call goes through `/app/_proxy/<slug>/v3/...` and the platform attaches the viewer's credential server-side. The same shape serves selfhosted single-origin deployments and embedded contexts.

Today the client requires an `accessToken` and attaches `Authorization: Bearer …` unconditionally, which defeats that model (a session proxy must see the header *absent* to engage).

## What

Additive `authMode?: 'token' | 'session'` on the shared auth options (sources, `query`, widget sources, models). Default `'token'` preserves today's behavior exactly. With `authMode: 'session'`:

- **No Authorization header** is sent on any request. All header construction now goes through a single `buildAuthHeaders()` helper (was 6 inline sites), which also validates the options: token mode without a token, or session mode *with* a token, throws a clear error instead of sending `Bearer undefined`.
- **`credentials: 'same-origin'`** is passed to `fetch()` (new `credentials` passthrough in `requestWithParameters`).
- **Tilejson post-processing rewrites URLs onto `apiBaseUrl`**: the map-instantiation `dataUrl` and the `tiles[]` templates point at the tenant API host, which the browser can't reach directly in this mode. `TilejsonResult.accessToken` is left unset (type now optional) so consumers don't fabricate a bearer; `createLoadOptions` (fetchMap/parse-map) now omits the Authorization header when no token is present instead of emitting a literal `Bearer undefined`.
- **Relative `apiBaseUrl` support** in `requestWithParameters` URL helpers (`new URL()` previously threw on `/app/_proxy/...` bases).

New exports: `buildAuthHeaders`, `getAuthCredentials`, `rewriteUrlForSessionMode`, `AuthMode`, `AuthOptions`.

Out of scope (follow-up): full session-mode support inside `fetchMap` for Builder maps — it already tolerates a missing token; deep rewriting of dataset tile URLs there is a larger surface.

## Usage

```ts
const data = await vectorTableSource({
  connectionName: 'carto_dw',
  tableName: 'my_table',
  apiBaseUrl: '/app/_proxy/my-app', // same-origin proxy
  authMode: 'session',              // no token in JS
});
```

## Testing

- New `test/api/auth.test.ts` covering the helpers and validation errors.
- `base-source.test.ts`: session mode asserts no Authorization header, `same-origin` credentials, instantiation + dataUrl routed through the proxy base, `tiles[]` rewritten, no `accessToken` on the result; plus a token-mode regression test.
- Full suite: 56 files / 449 tests passing, typecheck and lint clean.

## Notes for review

- `TilejsonResult.accessToken` changed `string` → `string | undefined` (set only in token mode, as before). Strict downstream consumers may need a guard.
- `buildAuthHeaders` introduces a client-side error for a missing token (previously the request went out as `Bearer undefined` and failed server-side with a 401) — strictly better DX, but it is a behavior change for misconfigured callers.
- deck.gl's CARTO tile layers currently build `Authorization: Bearer ${tileJSON.accessToken}` unconditionally; with this PR's unset token they'd send `Bearer undefined`. The hosted-apps proxy tolerates that server-side, and a one-line conditional fix to @deck.gl/carto is planned as a companion.

[sc-556407]