### PR TITLE
feat(sources): use inlined tilejson document when available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- feat(sources): opt into `inlineTilejson` on map instantiation and use the embedded tilejson document when present, skipping the follow-up tilejson request — one round trip less per source. Falls back to fetching the URL on servers that don't support it (maps-api sc-556572). (#300)
 - feat(widgetSources): support `featureIds` / `geometryType` request options to filter widget aggregations by a feature selection without relying on the synthetic `_carto_feature_id` column (#294)
 
 ### 0.5.29

--- a/src/sources/base-source.ts
+++ b/src/sources/base-source.ts
@@ -54,7 +54,16 @@ export async function baseSource<UrlParameters extends Record<string, unknown>>(
     ...options.headers,
   };
   const credentials = getAuthCredentials(options.authMode);
-  const parameters = {client: clientId, ...options.tags, ...urlParameters};
+  // Opt into the server embedding the tilejson document in the instantiation
+  // response (maps-api sc-556572) so the follow-up GET below can be skipped.
+  // Safe against servers that don't support it: the unknown query param is
+  // ignored and `tilejson.data` is simply absent, falling back to the fetch.
+  const parameters = {
+    client: clientId,
+    inlineTilejson: true,
+    ...options.tags,
+    ...urlParameters,
+  };
 
   const errorContext: APIErrorContext = {
     requestType: 'Map instantiation',
@@ -86,17 +95,24 @@ export async function baseSource<UrlParameters extends Record<string, unknown>>(
     // same-origin proxy behind apiBaseUrl.
     dataUrl = rewriteUrlForSessionMode(dataUrl, mergedOptions.apiBaseUrl);
   }
-  errorContext.requestType = 'Map data';
-
-  const json = await requestWithParameters<TilejsonResult>({
-    baseUrl: dataUrl,
-    parameters: {client: clientId},
-    headers,
-    errorContext,
-    maxLengthURL,
-    localCache,
-    credentials,
-  });
+  // When the server inlined the tilejson document, use it directly and skip
+  // the follow-up request — one round trip less per source. Otherwise fetch it
+  // from the URL (older servers, or endpoints that don't inline).
+  let json: TilejsonResult;
+  if (tilejson.data) {
+    json = tilejson.data;
+  } else {
+    errorContext.requestType = 'Map data';
+    json = await requestWithParameters<TilejsonResult>({
+      baseUrl: dataUrl,
+      parameters: {client: clientId},
+      headers,
+      errorContext,
+      maxLengthURL,
+      localCache,
+      credentials,
+    });
+  }
   if (sessionMode) {
     // Tile URL templates also point at the tenant API host. Rewrite them onto
     // the proxy, and deliberately leave `json.accessToken` unset: consumers

--- a/src/sources/base-source.ts
+++ b/src/sources/base-source.ts
@@ -100,7 +100,12 @@ export async function baseSource<UrlParameters extends Record<string, unknown>>(
   // from the URL (older servers, or endpoints that don't inline).
   let json: TilejsonResult;
   if (tilejson.data) {
-    json = tilejson.data;
+    // Shallow-copy before the sessionMode/accessToken/schema rewrites below:
+    // tilejson.data is embedded in the (cacheable) instantiation response, so
+    // mutating it in place would corrupt the cached object for later calls
+    // (e.g. double-rewriting tile URLs in sessionMode). The downstream mutations
+    // are all top-level property reassignments, so a shallow copy is enough.
+    json = {...tilejson.data};
   } else {
     errorContext.requestType = 'Map data';
     json = await requestWithParameters<TilejsonResult>({

--- a/src/sources/base-source.ts
+++ b/src/sources/base-source.ts
@@ -58,9 +58,11 @@ export async function baseSource<UrlParameters extends Record<string, unknown>>(
   // response (maps-api sc-556572) so the follow-up GET below can be skipped.
   // Safe against servers that don't support it: the unknown query param is
   // ignored and `tilejson.data` is simply absent, falling back to the fetch.
+  // On by default, but overridable (`inlineTilejson: false`) so consumers keep
+  // a kill switch that doesn't require downgrading the client.
   const parameters = {
     client: clientId,
-    inlineTilejson: true,
+    inlineTilejson: options.inlineTilejson ?? true,
     ...options.tags,
     ...urlParameters,
   };

--- a/src/sources/types.ts
+++ b/src/sources/types.ts
@@ -223,7 +223,10 @@ export type TilejsonMapInstantiation = {
   nrows: number;
   size?: number;
   schema: SchemaField[];
-  tilejson: {url: string[]};
+  // `data` is the inlined tilejson document, present only when the request
+  // opts in with `inlineTilejson` and the server supports it (maps-api
+  // sc-556572). When present, clients can skip the follow-up GET to `url`.
+  tilejson: {url: string[]; data?: TilejsonResult};
 };
 
 export type TileResolution = 0.25 | 0.5 | 1 | 2 | 4;

--- a/src/sources/types.ts
+++ b/src/sources/types.ts
@@ -13,6 +13,13 @@ export type SourceRequiredOptions = AuthOptions & {
 
 export type SourceOptionalOptions = {
   /**
+   * Ask the server to embed the tilejson document in the instantiation
+   * response, skipping the follow-up request (default: `true`). Set `false`
+   * to force the classic two-request flow.
+   */
+  inlineTilejson?: boolean;
+
+  /**
    * Base URL of the CARTO Maps API.
    *
    * Example for account located in EU-west region: `https://gcp-eu-west1.api.carto.com`

--- a/test/sources/vector-table-source.test.ts
+++ b/test/sources/vector-table-source.test.ts
@@ -1,6 +1,9 @@
 import {WidgetTableSource, vectorTableSource} from '@carto/api-client';
 import {describe, vi, test, expect} from 'vitest';
-import {stubGlobalFetchForSource} from '../__mock-fetch.js';
+import {
+  MOCK_TILESET_RESPONSE,
+  stubGlobalFetchForSource,
+} from '../__mock-fetch.js';
 
 describe('vectorTableSource', () => {
   test('default', async () => {
@@ -74,6 +77,43 @@ describe('vectorTableSource', () => {
 
     const [[initURL]] = vi.mocked(fetch).mock.calls;
     expect(initURL).not.toContain('featureBbox');
+  });
+
+  test('requests inlineTilejson', async () => {
+    stubGlobalFetchForSource();
+
+    await vectorTableSource({
+      connectionName: 'carto_dw',
+      accessToken: '<token>',
+      tableName: 'a.b.vector_table',
+    });
+
+    const [[initURL]] = vi.mocked(fetch).mock.calls;
+    expect(initURL).toMatch(/inlineTilejson=true/);
+  });
+
+  test('inlineTilejson — uses embedded document and skips the follow-up request', async () => {
+    const inlinedTilejson = {
+      ...MOCK_TILESET_RESPONSE,
+      tiles: ['https://xyz.com/{z}/{x}/{y}?formatTiles=binary&cache=abc123'],
+    };
+    stubGlobalFetchForSource({
+      tilejson: {
+        url: ['https://xyz.com?format=tilejson&cache=abc123'],
+        data: inlinedTilejson,
+      },
+    });
+
+    const tilejson = await vectorTableSource({
+      connectionName: 'carto_dw',
+      accessToken: '<token>',
+      tableName: 'a.b.vector_table',
+    });
+
+    // Only the instantiation request — the tilejson GET is skipped.
+    expect(vi.mocked(fetch)).toHaveBeenCalledTimes(1);
+    expect(tilejson.tiles).toEqual(inlinedTilejson.tiles);
+    expect(tilejson.accessToken).toBe('<token>');
   });
 
   test('widgetSource', async () => {

--- a/test/sources/vector-table-source.test.ts
+++ b/test/sources/vector-table-source.test.ts
@@ -116,6 +116,37 @@ describe('vectorTableSource', () => {
     expect(tilejson.accessToken).toBe('<token>');
   });
 
+  test('inlineTilejson — does not mutate the cached embedded document', async () => {
+    // Build the embedded document as a standalone literal (not spread from the
+    // shared MOCK_TILESET_RESPONSE, which other tests mutate via the fetch path)
+    // so its `accessToken` is definitively absent before the call.
+    const inlinedTilejson: Record<string, unknown> = {
+      tilejson: '2.2.0',
+      tiles: ['https://xyz.com/{z}/{x}/{y}?formatTiles=binary&cache=abc123'],
+      tilestats: {layers: []},
+      schema: [],
+    };
+    stubGlobalFetchForSource({
+      tilejson: {
+        url: ['https://xyz.com?format=tilejson&cache=abc123'],
+        data: inlinedTilejson,
+      },
+    });
+
+    const result = await vectorTableSource({
+      connectionName: 'carto_dw',
+      accessToken: '<token>',
+      tableName: 'a.b.vector_table',
+    });
+
+    // The returned source carries the token, but the embedded document — which
+    // rides inside the (cacheable) instantiation response — must be left
+    // untouched so a reused response isn't corrupted (the accessToken rewrite
+    // happens on a copy, not the original).
+    expect(result.accessToken).toBe('<token>');
+    expect(inlinedTilejson.accessToken).toBeUndefined();
+  });
+
   test('widgetSource', async () => {
     stubGlobalFetchForSource();
 

--- a/test/sources/vector-table-source.test.ts
+++ b/test/sources/vector-table-source.test.ts
@@ -92,6 +92,20 @@ describe('vectorTableSource', () => {
     expect(initURL).toMatch(/inlineTilejson=true/);
   });
 
+  test('inlineTilejson: false forces the classic two-request flow', async () => {
+    stubGlobalFetchForSource();
+
+    await vectorTableSource({
+      connectionName: 'carto_dw',
+      accessToken: '<token>',
+      tableName: 'a.b.vector_table',
+      inlineTilejson: false,
+    });
+
+    const [[initURL]] = vi.mocked(fetch).mock.calls;
+    expect(initURL).toMatch(/inlineTilejson=false/);
+  });
+
   test('inlineTilejson — uses embedded document and skips the follow-up request', async () => {
     const inlinedTilejson = {
       ...MOCK_TILESET_RESPONSE,


### PR DESCRIPTION
> 📊 Part of **Modernizing Maps Performance** — [epic sc-556570](https://app.shortcut.com/cartoteam/epic/556570) · [team deck](https://docs.google.com/presentation/d/18pQsKAE6YrHNexIUAqltV4tmnFOsy5YabgZ5G2YmaaU/edit)

## What

Map sources currently make two requests to render: **instantiate**, then **GET the tilejson** document the instantiation response points at (`tilejson.url`). This adds the client half of an opt-in optimization: when the server embeds the tilejson document in the instantiation response, use it directly and skip the follow-up request — **one round trip less per source on every map load**.

`baseSource` now:
1. Sends `inlineTilejson=true` on every instantiation request.
2. When the response carries `tilejson.data`, uses it directly instead of fetching `tilejson.url`.

## Why it's safe to merge ahead of the server

The change is fully backward-compatible in both directions:

- **Old server / non-inlining endpoint:** the unknown `inlineTilejson` query param is ignored and `tilejson.data` is absent, so the existing fetch-the-URL path runs exactly as today.
- **New server:** `tilejson.data` is present and the second request is skipped.

So this can ship before, after, or alongside the server change with no coordination required.

## Notes

- Session-mode proxy rewriting of the tile templates applies to the inlined document the same as the fetched one (the `sessionMode` block runs on `json` regardless of branch).
- The `cache.value` extraction still reads `?cache=` from `tilejson.url[0]` (always present); the server emits the same cache hash inside the inlined tile templates, so tiles fetched via the inlined path stay cache-consistent with the URL path.
- `inlineTilejson` is on by default here (the client always needs the tilejson document, so inlining is strictly a win). Easy to gate behind an option if you'd prefer it opt-in — let me know.

## Server side

maps-api embeds the document when called with `?inlineTilejson=true`: **CartoDB/cloud-native#25462** (sc-556572). Verified there that the inlined document is byte-identical to what a client fetches from `tilejson.url`, including the tile cache hash.

## Test plan

- New tests in `vector-table-source.test.ts`: the instantiation request carries `inlineTilejson=true`; when the response includes `tilejson.data`, `fetch` is called only once (follow-up skipped) and the returned tilejson is the embedded document.
- Full suite green (56 files, 452 tests, no type errors), lint clean.