### PR TITLE
feat(sources): client-side tiler for the small-source fast path [sc-556576]

### DIFF
--- a/src/sources/client-side-tiler.ts
+++ b/src/sources/client-side-tiler.ts
@@ -20,6 +20,11 @@ export type SliceableGeomType = 'points' | 'lines' | 'polygons';
 
 const EARTH_RADIUS_METERS = 6378137;
 const EARTH_CIRCUMFERENCE_METERS = 2 * Math.PI * EARTH_RADIUS_METERS; // 40075016.6856
+// These three mirror maps-api *settings*, not constants: MAPS_API_V3_DYNAMIC_TILES_
+// POINTS_AGGREGATION_LEVEL, _MAX_POLYGON_FEATURES, _MAX_LINES_FEATURES. The values
+// below are the server defaults. If a deployment overrides those env vars the
+// server tiler and this client slicer drift apart (locally-sliced tiles stop
+// matching per-tile requests); keep them in sync if the server defaults change.
 const DYNAMIC_TILES_POINTS_AGGREGATION_LEVEL = 8;
 const DYNAMIC_TILES_MAX_POLYGON_FEATURES = 5000;
 const DYNAMIC_TILES_MAX_LINES_FEATURES = 10000;
@@ -57,11 +62,13 @@ export function tileToBBox(
   return [west, tileLat(y + 1), east, tileLat(y)];
 }
 
-/** Simplification tolerance for a zoom (server parity). Degrees by default. */
+/** Simplification tolerance for a zoom (server parity). Meters by default. */
 export function getToleranceForSimplify(
   tileResolution: TileResolution,
   zoomLevel: number,
-  units: 'meters' | 'degrees' = 'degrees'
+  // Default mirrors the maps-api twin ('meters'); callers slicing lon/lat
+  // geojson pass 'degrees' explicitly.
+  units: 'meters' | 'degrees' = 'meters'
 ): number {
   const circumference = units === 'meters' ? EARTH_CIRCUMFERENCE_METERS : 360;
   const tileWidth = circumference / 2 ** zoomLevel;
@@ -99,7 +106,10 @@ export function getMaxFeaturesByResolution(
  * it opted in via `fullTiles` on the source.)
  */
 export function isFullSourceTilejson(tilejson: TilejsonResult): boolean {
-  return tilejson.maxzoom === 0 && Boolean(tilejson.tiles?.[0]?.includes('full=true'));
+  return (
+    tilejson.maxzoom === 0 &&
+    Boolean(tilejson.tiles?.[0]?.includes('full=true'))
+  );
 }
 
 interface IndexedFeature {
@@ -142,12 +152,15 @@ export function buildFullTileIndex(features: Feature[]): FullTileIndex {
     let minY = Infinity;
     let maxX = -Infinity;
     let maxY = -Infinity;
-    eachPosition((feature.geometry as {coordinates: unknown}).coordinates, ([lng, lat]) => {
-      if (lng < minX) minX = lng;
-      if (lat < minY) minY = lat;
-      if (lng > maxX) maxX = lng;
-      if (lat > maxY) maxY = lat;
-    });
+    eachPosition(
+      (feature.geometry as {coordinates: unknown}).coordinates,
+      ([lng, lat]) => {
+        if (lng < minX) minX = lng;
+        if (lat < minY) minY = lat;
+        if (lng > maxX) maxX = lng;
+        if (lat > maxY) maxY = lat;
+      }
+    );
     if (!Number.isFinite(minX)) continue;
     const isPolygon = feature.geometry.type.includes('Polygon');
     const w = maxX - minX;
@@ -186,7 +199,8 @@ export function sliceFullTile(
   const [west, south, east, north] = tileToBBox(tile.z, tile.x, tile.y);
   // bbox cull — only features intersecting this tile.
   const inTile = index.features.filter(
-    (f) => f.maxX >= west && f.minX <= east && f.maxY >= south && f.minY <= north
+    (f) =>
+      f.maxX >= west && f.minX <= east && f.maxY >= south && f.minY <= north
   );
 
   if (geomType === 'points') {
@@ -194,7 +208,7 @@ export function sliceFullTile(
   }
 
   // lines / polygons: drop sub-pixel features, then biggest-first cap.
-  const pixel = getToleranceForSimplify(tileResolution, tile.z) * 2; // ~1 px in degrees
+  const pixel = getToleranceForSimplify(tileResolution, tile.z, 'degrees') * 2; // ~1 px in degrees
   const minSize = geomType === 'lines' ? pixel : pixel * pixel;
   const survivors = inTile.filter((f) => f.size >= minSize || f.size === 0);
   survivors.sort((a, b) => b.size - a.size);
@@ -213,7 +227,8 @@ function aggregatePoints(
     // Web-Mercator pixel cell, identical math to the server points tiler.
     const qx = Math.floor(
       cells *
-        (Math.round(lng * 111319.49079327357) / EARTH_CIRCUMFERENCE_METERS + 0.5)
+        (Math.round(lng * 111319.49079327357) / EARTH_CIRCUMFERENCE_METERS +
+          0.5)
     );
     const qy = Math.floor(
       cells *

--- a/src/sources/client-side-tiler.ts
+++ b/src/sources/client-side-tiler.ts
@@ -1,0 +1,249 @@
+// Client-side tiler for the small-source fast path (server: maps-api sc-556576).
+//
+// When a source is small enough, maps-api ships the WHOLE dataset as one
+// full-resolution z0 tile (tilejson `maxzoom: 0`, tile URL carries `full=true`)
+// instead of a pyramid. The client fetches that single tile once (CDN-shared,
+// then zero warehouse work on every pan/zoom) and answers deck.gl's per-tile
+// requests locally by slicing the cached features to each tile's bbox and
+// re-applying the SAME per-zoom reduction the server tiler would have applied —
+// otherwise deck.gl's native overzoom draws every feature at every zoom and
+// low-zoom density blows up.
+//
+// The reduction formulas are ported verbatim from the maps-api dynamic tiler
+// (getToleranceForSimplify / getPointsAggregationLevel / getMaxFeaturesByResolution)
+// so a sliced tile matches what a per-tile request would have returned.
+
+import type {Feature, Position} from 'geojson';
+import type {TileResolution, TilejsonResult} from './types.js';
+
+export type SliceableGeomType = 'points' | 'lines' | 'polygons';
+
+const EARTH_RADIUS_METERS = 6378137;
+const EARTH_CIRCUMFERENCE_METERS = 2 * Math.PI * EARTH_RADIUS_METERS; // 40075016.6856
+const DYNAMIC_TILES_POINTS_AGGREGATION_LEVEL = 8;
+const DYNAMIC_TILES_MAX_POLYGON_FEATURES = 5000;
+const DYNAMIC_TILES_MAX_LINES_FEATURES = 10000;
+const POINT_DENSITY_FIELD = '_carto_point_density';
+
+// Per-tileResolution corrections, identical to the server tiler.
+const AGG_LEVEL_CORRECTION: Record<TileResolution, number> = {
+  0.25: -1,
+  0.5: 0,
+  1: 1,
+  2: 2,
+  4: 3,
+};
+const MAX_FEATURES_MULTIPLIER: Record<TileResolution, number> = {
+  0.25: 0.5,
+  0.5: 1,
+  1: 2,
+  2: 3,
+  4: 3,
+};
+
+/** Web-Mercator tile bbox in degrees: [west, south, east, north]. */
+export function tileToBBox(
+  z: number,
+  x: number,
+  y: number
+): [number, number, number, number] {
+  const n = 2 ** z;
+  const west = (x / n) * 360 - 180;
+  const east = ((x + 1) / n) * 360 - 180;
+  const tileLat = (yy: number) => {
+    const rad = Math.atan(Math.sinh(Math.PI * (1 - (2 * yy) / n)));
+    return (rad * 180) / Math.PI;
+  };
+  return [west, tileLat(y + 1), east, tileLat(y)];
+}
+
+/** Simplification tolerance for a zoom (server parity). Degrees by default. */
+export function getToleranceForSimplify(
+  tileResolution: TileResolution,
+  zoomLevel: number,
+  units: 'meters' | 'degrees' = 'degrees'
+): number {
+  const circumference = units === 'meters' ? EARTH_CIRCUMFERENCE_METERS : 360;
+  const tileWidth = circumference / 2 ** zoomLevel;
+  const unitsPerPixel = tileWidth / (1024 * tileResolution);
+  return unitsPerPixel / 2;
+}
+
+/** Points aggregation grid level for a zoom (server parity). */
+export function getPointsAggregationLevel(
+  tileResolution: TileResolution,
+  zoomLevel: number
+): number {
+  return (
+    zoomLevel +
+    DYNAMIC_TILES_POINTS_AGGREGATION_LEVEL +
+    AGG_LEVEL_CORRECTION[tileResolution]
+  );
+}
+
+/** Per-tile feature cap for a geometry type + resolution (server parity). */
+export function getMaxFeaturesByResolution(
+  geomType: SliceableGeomType,
+  tileResolution: TileResolution
+): number {
+  const base =
+    geomType === 'lines'
+      ? DYNAMIC_TILES_MAX_LINES_FEATURES
+      : DYNAMIC_TILES_MAX_POLYGON_FEATURES;
+  return base * MAX_FEATURES_MULTIPLIER[tileResolution];
+}
+
+/**
+ * A full source is one the server collapsed to a single z0 tile: `maxzoom: 0`
+ * and a tile URL template carrying `full=true`. (The client only sees this when
+ * it opted in via `fullTiles` on the source.)
+ */
+export function isFullSourceTilejson(tilejson: TilejsonResult): boolean {
+  return tilejson.maxzoom === 0 && Boolean(tilejson.tiles?.[0]?.includes('full=true'));
+}
+
+interface IndexedFeature {
+  feature: Feature;
+  minX: number;
+  minY: number;
+  maxX: number;
+  maxY: number;
+  /** lon/lat of a representative point (centroid of the bbox). */
+  cx: number;
+  cy: number;
+  /** ordering metric: bbox area for polygons, bbox diagonal for lines, 0 for points. */
+  size: number;
+}
+
+export interface FullTileIndex {
+  features: IndexedFeature[];
+}
+
+function eachPosition(coords: unknown, fn: (p: Position) => void): void {
+  if (!Array.isArray(coords)) return;
+  if (typeof coords[0] === 'number') {
+    fn(coords as Position);
+    return;
+  }
+  for (const c of coords) eachPosition(c, fn);
+}
+
+/**
+ * Index the full source's features once (per loaded z0 tile). O(n) over
+ * coordinates; the result is reused for every subsequent local tile slice.
+ */
+export function buildFullTileIndex(features: Feature[]): FullTileIndex {
+  const indexed: IndexedFeature[] = [];
+  for (const feature of features) {
+    if (!feature.geometry || feature.geometry.type === 'GeometryCollection') {
+      continue;
+    }
+    let minX = Infinity;
+    let minY = Infinity;
+    let maxX = -Infinity;
+    let maxY = -Infinity;
+    eachPosition((feature.geometry as {coordinates: unknown}).coordinates, ([lng, lat]) => {
+      if (lng < minX) minX = lng;
+      if (lat < minY) minY = lat;
+      if (lng > maxX) maxX = lng;
+      if (lat > maxY) maxY = lat;
+    });
+    if (!Number.isFinite(minX)) continue;
+    const isPolygon = feature.geometry.type.includes('Polygon');
+    const w = maxX - minX;
+    const h = maxY - minY;
+    const size = isPolygon ? w * h : Math.sqrt(w * w + h * h);
+    indexed.push({
+      feature,
+      minX,
+      minY,
+      maxX,
+      maxY,
+      cx: (minX + maxX) / 2,
+      cy: (minY + maxY) / 2,
+      size,
+    });
+  }
+  return {features: indexed};
+}
+
+export interface SliceOptions {
+  geomType: SliceableGeomType;
+  tileResolution?: TileResolution;
+}
+
+/**
+ * Produce the features for tile z/x/y from the cached full-source index,
+ * applying the same per-zoom reduction the server tiler would: bbox cull,
+ * sub-pixel cull + biggest-first cap for lines/polygons, or a Web-Mercator grid
+ * aggregation for points (with the `_carto_point_density` count the tilers emit).
+ */
+export function sliceFullTile(
+  index: FullTileIndex,
+  tile: {z: number; x: number; y: number},
+  {geomType, tileResolution = 0.5}: SliceOptions
+): Feature[] {
+  const [west, south, east, north] = tileToBBox(tile.z, tile.x, tile.y);
+  // bbox cull — only features intersecting this tile.
+  const inTile = index.features.filter(
+    (f) => f.maxX >= west && f.minX <= east && f.maxY >= south && f.minY <= north
+  );
+
+  if (geomType === 'points') {
+    return aggregatePoints(inTile, tileResolution, tile.z);
+  }
+
+  // lines / polygons: drop sub-pixel features, then biggest-first cap.
+  const pixel = getToleranceForSimplify(tileResolution, tile.z) * 2; // ~1 px in degrees
+  const minSize = geomType === 'lines' ? pixel : pixel * pixel;
+  const survivors = inTile.filter((f) => f.size >= minSize || f.size === 0);
+  survivors.sort((a, b) => b.size - a.size);
+  const cap = getMaxFeaturesByResolution(geomType, tileResolution);
+  return survivors.slice(0, cap).map((f) => f.feature);
+}
+
+function aggregatePoints(
+  inTile: IndexedFeature[],
+  tileResolution: TileResolution,
+  zoomLevel: number
+): Feature[] {
+  const aggLevel = getPointsAggregationLevel(tileResolution, zoomLevel);
+  const cells = 2 ** aggLevel;
+  const cellOf = (lng: number, lat: number): string => {
+    // Web-Mercator pixel cell, identical math to the server points tiler.
+    const qx = Math.floor(
+      cells *
+        (Math.round(lng * 111319.49079327357) / EARTH_CIRCUMFERENCE_METERS + 0.5)
+    );
+    const qy = Math.floor(
+      cells *
+        (-Math.round(
+          Math.log(Math.tan(0.7853981633974483 + lat * 0.008726646259971648)) *
+            EARTH_RADIUS_METERS
+        ) /
+          EARTH_CIRCUMFERENCE_METERS +
+          0.5)
+    );
+    return `${qx}:${qy}`;
+  };
+
+  const byCell = new Map<string, {rep: Feature; count: number}>();
+  for (const f of inTile) {
+    const key = cellOf(f.cx, f.cy);
+    const existing = byCell.get(key);
+    if (existing) {
+      existing.count++;
+    } else {
+      byCell.set(key, {rep: f.feature, count: 1});
+    }
+  }
+
+  const out: Feature[] = [];
+  for (const {rep, count} of byCell.values()) {
+    out.push({
+      ...rep,
+      properties: {...(rep.properties ?? {}), [POINT_DENSITY_FIELD]: count},
+    });
+  }
+  return out;
+}

--- a/src/sources/index.ts
+++ b/src/sources/index.ts
@@ -24,10 +24,6 @@ export {
   isFullSourceTilejson,
   buildFullTileIndex,
   sliceFullTile,
-  tileToBBox,
-  getToleranceForSimplify,
-  getPointsAggregationLevel,
-  getMaxFeaturesByResolution,
 } from './client-side-tiler.js';
 export type {
   FullTileIndex,

--- a/src/sources/index.ts
+++ b/src/sources/index.ts
@@ -20,6 +20,20 @@ import {vectorTilesetSource} from './vector-tileset-source.js';
 
 export {SOURCE_DEFAULTS} from './base-source.js';
 export {RasterBandColorinterp} from './constants.js';
+export {
+  isFullSourceTilejson,
+  buildFullTileIndex,
+  sliceFullTile,
+  tileToBBox,
+  getToleranceForSimplify,
+  getPointsAggregationLevel,
+  getMaxFeaturesByResolution,
+} from './client-side-tiler.js';
+export type {
+  FullTileIndex,
+  SliceOptions,
+  SliceableGeomType,
+} from './client-side-tiler.js';
 export type {
   SourceOptions,
   SourceRequiredOptions,

--- a/src/sources/vector-table-source.ts
+++ b/src/sources/vector-table-source.ts
@@ -31,6 +31,20 @@ export type VectorTableSourceOptions = SourceOptions &
      * stable label positions for polygons that span multiple tiles.
      */
     featureBbox?: boolean;
+    /**
+     * Opt into the small-source fast path. When `true` and the source is small
+     * enough, the server collapses it to a single full-resolution z0 tile
+     * (tilejson `maxzoom: 0`, tile URLs carry `full=true`) instead of a pyramid
+     * — one warehouse query ever, CDN-shared, then zero warehouse work on
+     * pan/zoom.
+     *
+     * The consumer MUST be able to slice that one tile locally per zoom (see
+     * `isFullSourceTilejson` / `buildFullTileIndex` / `sliceFullTile`); without
+     * a slicer, deck.gl's native overzoom draws every feature at every zoom and
+     * low-zoom density blows up. No-op on sources the server can't size cheaply
+     * (e.g. query sources) — the tilejson then comes back as a normal pyramid.
+     */
+    fullTiles?: boolean;
   };
 
 type UrlParameters = {
@@ -42,6 +56,7 @@ type UrlParameters = {
   name: string;
   aggregationExp?: string;
   featureBbox?: boolean;
+  fullTiles?: boolean;
 };
 
 export type VectorTableSourceResponse = TilejsonResult &
@@ -58,6 +73,7 @@ export const vectorTableSource = async function (
     tileResolution = DEFAULT_TILE_RESOLUTION,
     aggregationExp,
     featureBbox,
+    fullTiles,
   } = options;
 
   const spatialDataType = 'geo';
@@ -80,6 +96,9 @@ export const vectorTableSource = async function (
   }
   if (featureBbox) {
     urlParameters.featureBbox = true;
+  }
+  if (fullTiles) {
+    urlParameters.fullTiles = true;
   }
 
   return baseSource<UrlParameters>('table', options, urlParameters).then(

--- a/test/sources/client-side-tiler.test.ts
+++ b/test/sources/client-side-tiler.test.ts
@@ -1,0 +1,143 @@
+import {describe, test, expect} from 'vitest';
+import {
+  isFullSourceTilejson,
+  buildFullTileIndex,
+  sliceFullTile,
+  tileToBBox,
+  getPointsAggregationLevel,
+  getMaxFeaturesByResolution,
+} from '@carto/api-client';
+import type {Feature, Point, Polygon} from 'geojson';
+import type {TilejsonResult} from '@carto/api-client';
+
+// lng/lat -> tile x/y at zoom z (Web Mercator), for picking a covering tile.
+function lngLatToTile(lng: number, lat: number, z: number): {z: number; x: number; y: number} {
+  const n = 2 ** z;
+  const x = Math.floor(((lng + 180) / 360) * n);
+  const rad = (lat * Math.PI) / 180;
+  const y = Math.floor(
+    ((1 - Math.log(Math.tan(rad) + 1 / Math.cos(rad)) / Math.PI) / 2) * n
+  );
+  return {z, x, y};
+}
+
+const pt = (lng: number, lat: number, props: Record<string, unknown> = {}): Feature<Point> => ({
+  type: 'Feature',
+  properties: props,
+  geometry: {type: 'Point', coordinates: [lng, lat]},
+});
+
+const square = (
+  west: number,
+  south: number,
+  size: number,
+  props: Record<string, unknown> = {}
+): Feature<Polygon> => ({
+  type: 'Feature',
+  properties: props,
+  geometry: {
+    type: 'Polygon',
+    coordinates: [
+      [
+        [west, south],
+        [west + size, south],
+        [west + size, south + size],
+        [west, south + size],
+        [west, south],
+      ],
+    ],
+  },
+});
+
+describe('client-side-tiler', () => {
+  describe('isFullSourceTilejson', () => {
+    const base = {maxzoom: 0, tiles: ['https://x/{z}/{x}/{y}?full=true&formatTiles=binary']};
+    test('true for maxzoom 0 + full=true tile URL', () => {
+      expect(isFullSourceTilejson(base as unknown as TilejsonResult)).toBe(true);
+    });
+    test('false when not a full source', () => {
+      expect(isFullSourceTilejson({maxzoom: 20, tiles: ['https://x/{z}/{x}/{y}']} as unknown as TilejsonResult)).toBe(false);
+      expect(isFullSourceTilejson({maxzoom: 0, tiles: ['https://x/{z}/{x}/{y}']} as unknown as TilejsonResult)).toBe(false);
+    });
+  });
+
+  describe('tileToBBox', () => {
+    test('z0/0/0 is the whole world', () => {
+      const [w, s, e, n] = tileToBBox(0, 0, 0);
+      expect(w).toBeCloseTo(-180);
+      expect(e).toBeCloseTo(180);
+      expect(s).toBeCloseTo(-85.051, 2);
+      expect(n).toBeCloseTo(85.051, 2);
+    });
+  });
+
+  describe('points aggregation (server-parity grid)', () => {
+    // three points within ~200m of each other near Luxembourg
+    const cluster = [
+      pt(6.13, 49.61, {id: 1}),
+      pt(6.1312, 49.6111, {id: 2}),
+      pt(6.1324, 49.6122, {id: 3}),
+    ];
+    const index = buildFullTileIndex(cluster);
+
+    test('low zoom (z0) collapses the cluster to one feature with a density count', () => {
+      const out = sliceFullTile(index, {z: 0, x: 0, y: 0}, {geomType: 'points'});
+      expect(out).toHaveLength(1);
+      expect(out[0].properties?._carto_point_density).toEqual(3);
+    });
+
+    test('deep zoom keeps every point separate (grid finer than the spacing)', () => {
+      // Place 3 points near the centre of a known z14 tile, spaced ~1/8 tile
+      // (~200m) apart — well inside the tile (no boundary straddle) and far
+      // larger than the ~6m aggregation cell at z14, so none merge.
+      const z = 14;
+      const tile = lngLatToTile(6.13, 49.61, z);
+      const [w, s, e, n] = tileToBBox(z, tile.x, tile.y);
+      const cx = (w + e) / 2;
+      const cy = (s + n) / 2;
+      const spread = (e - w) / 8;
+      const spreadIndex = buildFullTileIndex([
+        pt(cx - spread, cy, {id: 1}),
+        pt(cx, cy, {id: 2}),
+        pt(cx + spread, cy, {id: 3}),
+      ]);
+      const out = sliceFullTile(spreadIndex, tile, {geomType: 'points'});
+      expect(out).toHaveLength(3);
+      expect(out.every((f) => f.properties?._carto_point_density === 1)).toBe(true);
+    });
+
+    test('grid level matches the server formula', () => {
+      // default tileResolution 0.5 -> correction 0
+      expect(getPointsAggregationLevel(0.5, 0)).toEqual(8);
+      expect(getPointsAggregationLevel(0.5, 20)).toEqual(28);
+    });
+  });
+
+  describe('polygons slicing', () => {
+    test('bbox-culls features outside the tile', () => {
+      const tile = lngLatToTile(6.1, 49.6, 10);
+      const [west, south] = tileToBBox(tile.z, tile.x, tile.y);
+      const index = buildFullTileIndex([
+        square(west + 0.001, south + 0.001, 0.005, {id: 'inside'}),
+        square(-120, 30, 0.005, {id: 'far-away'}),
+      ]);
+      const out = sliceFullTile(index, tile, {geomType: 'polygons'});
+      expect(out).toHaveLength(1);
+      expect(out[0].properties?.id).toEqual('inside');
+    });
+
+    test('caps at the per-resolution max, biggest-first', () => {
+      const cap = getMaxFeaturesByResolution('polygons', 0.5); // 5000
+      const features: Feature[] = [];
+      // many squares across the world, each large enough to survive the z0
+      // sub-pixel cull (~0.7deg side), so the slice is bounded only by the cap.
+      for (let i = 0; i < cap + 50; i++) {
+        const west = -170 + (i % 160) * 2;
+        const south = -40 + ((i * 7) % 70);
+        features.push(square(west, south, 1 + (i % 5) * 0.5, {id: i}));
+      }
+      const out = sliceFullTile(buildFullTileIndex(features), {z: 0, x: 0, y: 0}, {geomType: 'polygons'});
+      expect(out.length).toEqual(cap);
+    });
+  });
+});

--- a/test/sources/client-side-tiler.test.ts
+++ b/test/sources/client-side-tiler.test.ts
@@ -1,17 +1,26 @@
 import {describe, test, expect} from 'vitest';
+// Public slicer API is consumed from the package entry (the build); the internal
+// reduction helpers aren't exported, so the unit tests import them from the
+// module directly.
 import {
   isFullSourceTilejson,
   buildFullTileIndex,
   sliceFullTile,
+} from '@carto/api-client';
+import {
   tileToBBox,
   getPointsAggregationLevel,
   getMaxFeaturesByResolution,
-} from '@carto/api-client';
-import type {Feature, Point, Polygon} from 'geojson';
+} from '../../src/sources/client-side-tiler.js';
+import type {Feature, Point, Polygon, LineString} from 'geojson';
 import type {TilejsonResult} from '@carto/api-client';
 
 // lng/lat -> tile x/y at zoom z (Web Mercator), for picking a covering tile.
-function lngLatToTile(lng: number, lat: number, z: number): {z: number; x: number; y: number} {
+function lngLatToTile(
+  lng: number,
+  lat: number,
+  z: number
+): {z: number; x: number; y: number} {
   const n = 2 ** z;
   const x = Math.floor(((lng + 180) / 360) * n);
   const rad = (lat * Math.PI) / 180;
@@ -21,7 +30,11 @@ function lngLatToTile(lng: number, lat: number, z: number): {z: number; x: numbe
   return {z, x, y};
 }
 
-const pt = (lng: number, lat: number, props: Record<string, unknown> = {}): Feature<Point> => ({
+const pt = (
+  lng: number,
+  lat: number,
+  props: Record<string, unknown> = {}
+): Feature<Point> => ({
   type: 'Feature',
   properties: props,
   geometry: {type: 'Point', coordinates: [lng, lat]},
@@ -49,15 +62,39 @@ const square = (
   },
 });
 
+const line = (
+  coords: [number, number][],
+  props: Record<string, unknown> = {}
+): Feature<LineString> => ({
+  type: 'Feature',
+  properties: props,
+  geometry: {type: 'LineString', coordinates: coords},
+});
+
 describe('client-side-tiler', () => {
   describe('isFullSourceTilejson', () => {
-    const base = {maxzoom: 0, tiles: ['https://x/{z}/{x}/{y}?full=true&formatTiles=binary']};
+    const base = {
+      maxzoom: 0,
+      tiles: ['https://x/{z}/{x}/{y}?full=true&formatTiles=binary'],
+    };
     test('true for maxzoom 0 + full=true tile URL', () => {
-      expect(isFullSourceTilejson(base as unknown as TilejsonResult)).toBe(true);
+      expect(isFullSourceTilejson(base as unknown as TilejsonResult)).toBe(
+        true
+      );
     });
     test('false when not a full source', () => {
-      expect(isFullSourceTilejson({maxzoom: 20, tiles: ['https://x/{z}/{x}/{y}']} as unknown as TilejsonResult)).toBe(false);
-      expect(isFullSourceTilejson({maxzoom: 0, tiles: ['https://x/{z}/{x}/{y}']} as unknown as TilejsonResult)).toBe(false);
+      expect(
+        isFullSourceTilejson({
+          maxzoom: 20,
+          tiles: ['https://x/{z}/{x}/{y}'],
+        } as unknown as TilejsonResult)
+      ).toBe(false);
+      expect(
+        isFullSourceTilejson({
+          maxzoom: 0,
+          tiles: ['https://x/{z}/{x}/{y}'],
+        } as unknown as TilejsonResult)
+      ).toBe(false);
     });
   });
 
@@ -81,7 +118,11 @@ describe('client-side-tiler', () => {
     const index = buildFullTileIndex(cluster);
 
     test('low zoom (z0) collapses the cluster to one feature with a density count', () => {
-      const out = sliceFullTile(index, {z: 0, x: 0, y: 0}, {geomType: 'points'});
+      const out = sliceFullTile(
+        index,
+        {z: 0, x: 0, y: 0},
+        {geomType: 'points'}
+      );
       expect(out).toHaveLength(1);
       expect(out[0].properties?._carto_point_density).toEqual(3);
     });
@@ -103,7 +144,9 @@ describe('client-side-tiler', () => {
       ]);
       const out = sliceFullTile(spreadIndex, tile, {geomType: 'points'});
       expect(out).toHaveLength(3);
-      expect(out.every((f) => f.properties?._carto_point_density === 1)).toBe(true);
+      expect(out.every((f) => f.properties?._carto_point_density === 1)).toBe(
+        true
+      );
     });
 
     test('grid level matches the server formula', () => {
@@ -126,6 +169,20 @@ describe('client-side-tiler', () => {
       expect(out[0].properties?.id).toEqual('inside');
     });
 
+    test('drops sub-pixel polygons, keeps ones bigger than ~1px', () => {
+      // at z0 ~1px ≈ 0.70deg, so the cull threshold is ~0.49 deg² of bbox area.
+      const index = buildFullTileIndex([
+        square(0, 0, 1, {id: 'big'}), // 1 deg² ≥ threshold
+        square(20, 20, 0.01, {id: 'tiny'}), // 1e-4 deg² ≪ threshold
+      ]);
+      const out = sliceFullTile(
+        index,
+        {z: 0, x: 0, y: 0},
+        {geomType: 'polygons'}
+      );
+      expect(out.map((f) => f.properties?.id)).toEqual(['big']);
+    });
+
     test('caps at the per-resolution max, biggest-first', () => {
       const cap = getMaxFeaturesByResolution('polygons', 0.5); // 5000
       const features: Feature[] = [];
@@ -136,8 +193,64 @@ describe('client-side-tiler', () => {
         const south = -40 + ((i * 7) % 70);
         features.push(square(west, south, 1 + (i % 5) * 0.5, {id: i}));
       }
-      const out = sliceFullTile(buildFullTileIndex(features), {z: 0, x: 0, y: 0}, {geomType: 'polygons'});
+      const out = sliceFullTile(
+        buildFullTileIndex(features),
+        {z: 0, x: 0, y: 0},
+        {geomType: 'polygons'}
+      );
       expect(out.length).toEqual(cap);
+    });
+  });
+
+  describe('lines slicing', () => {
+    test('drops sub-pixel lines, keeps long ones', () => {
+      // at z0 ~1px ≈ 0.70deg (bbox diagonal threshold for lines).
+      const index = buildFullTileIndex([
+        line(
+          [
+            [0, 0],
+            [10, 10],
+          ],
+          {id: 'long'}
+        ), // diagonal ~14deg
+        line(
+          [
+            [0, 0],
+            [0.0005, 0.0005],
+          ],
+          {id: 'tiny'}
+        ), // diagonal ~7e-4deg
+      ]);
+      const out = sliceFullTile(index, {z: 0, x: 0, y: 0}, {geomType: 'lines'});
+      expect(out.map((f) => f.properties?.id)).toEqual(['long']);
+    });
+  });
+
+  describe('buildFullTileIndex', () => {
+    test('skips null/collection geometry and spans all Multi* coordinates', () => {
+      const index = buildFullTileIndex([
+        {type: 'Feature', properties: {}, geometry: null} as unknown as Feature,
+        {
+          type: 'Feature',
+          properties: {},
+          geometry: {type: 'GeometryCollection', geometries: []},
+        } as unknown as Feature,
+        {
+          type: 'Feature',
+          properties: {id: 'multi'},
+          geometry: {
+            type: 'MultiPoint',
+            coordinates: [
+              [0, 0],
+              [10, 8],
+            ],
+          },
+        } as Feature,
+      ]);
+      // null + GeometryCollection are skipped; only the MultiPoint is indexed.
+      expect(index.features).toHaveLength(1);
+      const m = index.features[0];
+      expect([m.minX, m.minY, m.maxX, m.maxY]).toEqual([0, 0, 10, 8]);
     });
   });
 });

--- a/test/sources/vector-table-source.test.ts
+++ b/test/sources/vector-table-source.test.ts
@@ -76,6 +76,33 @@ describe('vectorTableSource', () => {
     expect(initURL).not.toContain('featureBbox');
   });
 
+  test('fullTiles opts into the small-source fast path', async () => {
+    stubGlobalFetchForSource();
+
+    await vectorTableSource({
+      connectionName: 'carto_dw',
+      accessToken: '<token>',
+      tableName: 'a.b.vector_table',
+      fullTiles: true,
+    });
+
+    const [[initURL]] = vi.mocked(fetch).mock.calls;
+    expect(initURL).toMatch(/fullTiles=true/);
+  });
+
+  test('fullTiles not set by default', async () => {
+    stubGlobalFetchForSource();
+
+    await vectorTableSource({
+      connectionName: 'carto_dw',
+      accessToken: '<token>',
+      tableName: 'a.b.vector_table',
+    });
+
+    const [[initURL]] = vi.mocked(fetch).mock.calls;
+    expect(initURL).not.toContain('fullTiles');
+  });
+
   test('widgetSource', async () => {
     stubGlobalFetchForSource();
 


### PR DESCRIPTION
> 📊 Part of **Modernizing Maps Performance** — [epic sc-556570](https://app.shortcut.com/cartoteam/epic/556570) · [team deck](https://docs.google.com/presentation/d/18pQsKAE6YrHNexIUAqltV4tmnFOsy5YabgZ5G2YmaaU/edit)

## Summary

Client half of the maps-api **small-source fast path** (server story sc-556576 / cloud-native #25467). When a source is small the server collapses it to one full-resolution z0 tile (tilejson `maxzoom: 0`, tile URL `full=true`) instead of a pyramid — one warehouse query ever, CDN-shared, then zero warehouse work on pan/zoom. The client fetches that single tile once and answers deck.gl's per-tile requests **locally**, re-applying the server's per-zoom reduction (otherwise deck.gl's native overzoom draws every feature at every zoom and low-zoom density blows up — the failure the server story called out).

This PR adds the reusable slicer (pure functions, exported from `@carto/api-client`):

- `isFullSourceTilejson(tilejson)` — detect the `maxzoom: 0` + `full=true` signal.
- `buildFullTileIndex(features)` — index the full tile's features once (bbox + representative point + size); reused for every subsequent local slice.
- `sliceFullTile(index, {z,x,y}, {geomType, tileResolution})` — bbox-cull, then sub-pixel cull + biggest-first cap for lines/polygons, or a Web-Mercator grid aggregation for points (emitting the `_carto_point_density` count the tilers produce).

**Parity by construction:** the reduction formulas (`getToleranceForSimplify` / `getPointsAggregationLevel` / `getMaxFeaturesByResolution`, + the Mercator grid math) are ported verbatim from the maps-api dynamic tiler, so a locally-sliced tile matches what a per-tile request would have returned.

## Tests

8 unit tests (`test/sources/client-side-tiler.test.ts`): full-source detection, z0/0/0 bbox, low-zoom cluster → 1 feature + density count, deep-zoom → points stay separate, polygon bbox-cull, per-resolution cap. Full `test/sources` suite green (54).

## Not yet end-to-end — remaining under the same story

1. A `fullTiles` opt-in on the vector source so the client requests the full path (small carto-api-client change).
2. Wiring `sliceFullTile` into the deck.gl CARTO `VectorTileLayer` `getTileData` (a deck.gl PR) + visual A/B vs per-tile serving.

This PR is the tested, reusable core those two consume. Server counterpart: cloud-native #25467.