### PR TITLE
feat(sources): expose _getPointsAggregationLevel for dynamic point-tile aggregation parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 ## Unreleased
 
-### 0.5.30
-
+- feat(sources): expose `_getPointsAggregationLevel` for maps-api dynamic point-tile aggregation parity (#304)
 - feat(widgetSources): support `featureIds` / `geometryType` request options to filter widget aggregations by a feature selection without relying on the synthetic `_carto_feature_id` column (#294)
 - feat(widgetSources): support `SpatialIndexFilter` (H3/Quadbin cell selection) on `spatialFilter` (#296)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,7 @@ export {
 } from './api/index.js';
 
 export {_getHexagonResolution} from './spatial-index.js';
+export {getPointsAggregationLevel as _getPointsAggregationLevel} from './spatial-index.js';
 
 // For unit testing only.
 export * from './filters/index.js';

--- a/src/spatial-index.ts
+++ b/src/spatial-index.ts
@@ -37,13 +37,14 @@ export function _getHexagonResolution(
 const DYNAMIC_TILES_POINTS_AGGREGATION_LEVEL = 8;
 
 // Per-tileResolution correction, identical to the maps-api dynamic tiler.
-const AGG_LEVEL_CORRECTION_BY_TILE_RESOLUTION: Record<TileResolution, number> = {
-  0.25: -1,
-  0.5: 0,
-  1: 1,
-  2: 2,
-  4: 3,
-};
+const AGG_LEVEL_CORRECTION_BY_TILE_RESOLUTION: Record<TileResolution, number> =
+  {
+    0.25: -1,
+    0.5: 0,
+    1: 1,
+    2: 2,
+    4: 3,
+  };
 
 /**
  * Quadbin level at which the maps-api dynamic tiler implicitly aggregates a

--- a/src/spatial-index.ts
+++ b/src/spatial-index.ts
@@ -1,3 +1,5 @@
+import type {TileResolution} from './sources/types.js';
+
 // Default tile display size in deck.gl, in viewport pixels. May differ
 // from size or resolution assumed when generating the tile data,
 const DEFAULT_TILE_SIZE = 512;
@@ -28,5 +30,43 @@ export function _getHexagonResolution(
   return Math.max(
     0,
     Math.floor(hexagonScaleFactor + latitudeScaleFactor - BIAS)
+  );
+}
+
+// Default of the maps-api setting MAPS_API_V3_DYNAMIC_TILES_POINTS_AGGREGATION_LEVEL.
+const DYNAMIC_TILES_POINTS_AGGREGATION_LEVEL = 8;
+
+// Per-tileResolution correction, identical to the maps-api dynamic tiler.
+const AGG_LEVEL_CORRECTION_BY_TILE_RESOLUTION: Record<TileResolution, number> = {
+  0.25: -1,
+  0.5: 0,
+  1: 1,
+  2: 2,
+  4: 3,
+};
+
+/**
+ * Quadbin level at which the maps-api dynamic tiler implicitly aggregates a
+ * point source for a given tile zoom and resolution. Lets a client reproduce
+ * that level — and so the aggregation cell a point falls into — without an
+ * extra round-trip to the server.
+ *
+ * Ported verbatim from the maps-api dynamic tiler (`getPointsAggregationLevel`).
+ * The base offset mirrors the server default of
+ * `MAPS_API_V3_DYNAMIC_TILES_POINTS_AGGREGATION_LEVEL`; a deployment that
+ * overrides that env var drifts from this computation.
+ * @internal
+ */
+export function getPointsAggregationLevel({
+  tileResolution,
+  zoomLevel,
+}: {
+  tileResolution: TileResolution;
+  zoomLevel: number;
+}): number {
+  return (
+    zoomLevel +
+    DYNAMIC_TILES_POINTS_AGGREGATION_LEVEL +
+    AGG_LEVEL_CORRECTION_BY_TILE_RESOLUTION[tileResolution]
   );
 }

--- a/test/spatial-index.test.ts
+++ b/test/spatial-index.test.ts
@@ -1,5 +1,8 @@
 import {describe, expect, test} from 'vitest';
-import {_getHexagonResolution} from '@carto/api-client';
+import {
+  _getHexagonResolution,
+  _getPointsAggregationLevel,
+} from '@carto/api-client';
 
 describe('_getHexagonResolution', () => {
   test.each([
@@ -17,5 +20,23 @@ describe('_getHexagonResolution', () => {
     [{zoom: 8, latitude: 0, tileSize: 1024}, 2],
   ])('%s -> %i', ({zoom, latitude, tileSize}, expected) => {
     expect(_getHexagonResolution({zoom, latitude}, tileSize)).toBe(expected);
+  });
+});
+
+describe('getPointsAggregationLevel', () => {
+  test.each([
+    // tileResolution correction at a fixed zoom (default offset 8)
+    [{tileResolution: 0.25, zoomLevel: 5}, 12],
+    [{tileResolution: 0.5, zoomLevel: 5}, 13],
+    [{tileResolution: 1, zoomLevel: 5}, 14],
+    [{tileResolution: 2, zoomLevel: 5}, 15],
+    [{tileResolution: 4, zoomLevel: 5}, 16],
+    // zoom scales the level 1:1
+    [{tileResolution: 0.5, zoomLevel: 0}, 8],
+    [{tileResolution: 0.5, zoomLevel: 12}, 20],
+  ] as const)('%o -> %i', ({tileResolution, zoomLevel}, expected) => {
+    expect(_getPointsAggregationLevel({tileResolution, zoomLevel})).toBe(
+      expected
+    );
   });
 });


### PR DESCRIPTION
Expose `_getPointsAggregationLevel({tileResolution, zoomLevel})` — the maps-api dynamic-tiler formula for the quadbin level at which a points source is implicitly aggregated. Lets a client compute the aggregation cell a point falls into without an exact-pick round-trip.

- Ported verbatim from the maps-api dynamic tiler.
- In `src/spatial-index.ts` next to `_getHexagonResolution`; exported with the `_` internal-API convention.

Extracted from https://github.com/CartoDB/carto-api-client/pull/301, as it's also needed by other internal clients.