### PR TITLE
feat(sources): rename featureBbox source option to prepareLabels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- feat(sources): rename `featureBbox` source option to `prepareLabels` (Maps API `featureBbox` param unchanged)
 - feat(sources): expose `_getPointsAggregationLevel` for maps-api dynamic point-tile aggregation parity (#304)
 - feat(widgetSources): support `featureIds` / `geometryType` request options to filter widget aggregations by a feature selection without relying on the synthetic `_carto_feature_id` column (#294)
 - feat(widgetSources): support `SpatialIndexFilter` (H3/Quadbin cell selection) on `spatialFilter` (#296)

--- a/src/fetch-map/fetch-map.ts
+++ b/src/fetch-map/fetch-map.ts
@@ -320,7 +320,7 @@ export async function fetchMap({
       datasetsWithLabels.has(dataset.id) &&
       (dataset.type === 'table' || dataset.type === 'query')
     ) {
-      dataset.featureBbox = true;
+      dataset.prepareLabels = true;
     }
   });
 

--- a/src/fetch-map/source.ts
+++ b/src/fetch-map/source.ts
@@ -106,13 +106,13 @@ export function configureSource({
     tileResolution,
     ...(queryParameters && {queryParameters}),
   } as QuerySourceOptions;
-  const {featureBbox} = dataset;
+  const {prepareLabels} = dataset;
   const vectorOptions = {
     spatialDataColumn,
     ...(columns && {columns}),
     ...(filters && {filters}),
     ...(aggregationExp && {aggregationExp}),
-    ...(featureBbox && {featureBbox}),
+    ...(prepareLabels && {prepareLabels}),
   } as VectorTableSourceOptions;
 
   if (type === 'raster') {

--- a/src/fetch-map/types.ts
+++ b/src/fetch-map/types.ts
@@ -265,7 +265,7 @@ export type Dataset = {
   name?: string | null;
   spatialIndex?: string | null;
   exportToBucketAvailable?: boolean;
-  featureBbox?: boolean;
+  prepareLabels?: boolean;
 };
 
 export type AttributeType = 'String' | 'Number' | 'Timestamp' | 'Boolean';

--- a/src/sources/vector-query-source.ts
+++ b/src/sources/vector-query-source.ts
@@ -30,7 +30,7 @@ export type VectorQuerySourceOptions = SourceOptions &
      * a `"west,south,east,north"` string in WGS84. Used by clients to compute
      * stable label positions for polygons that span multiple tiles.
      */
-    featureBbox?: boolean;
+    prepareLabels?: boolean;
   };
 
 type UrlParameters = {
@@ -59,7 +59,7 @@ export const vectorQuerySource = async function (
     tileResolution = DEFAULT_TILE_RESOLUTION,
     queryParameters,
     aggregationExp,
-    featureBbox,
+    prepareLabels,
   } = options;
 
   const spatialDataType = 'geo';
@@ -83,7 +83,7 @@ export const vectorQuerySource = async function (
   if (aggregationExp) {
     urlParameters.aggregationExp = aggregationExp;
   }
-  if (featureBbox) {
+  if (prepareLabels) {
     urlParameters.featureBbox = true;
   }
 

--- a/src/sources/vector-table-source.ts
+++ b/src/sources/vector-table-source.ts
@@ -30,7 +30,7 @@ export type VectorTableSourceOptions = SourceOptions &
      * a `"west,south,east,north"` string in WGS84. Used by clients to compute
      * stable label positions for polygons that span multiple tiles.
      */
-    featureBbox?: boolean;
+    prepareLabels?: boolean;
   };
 
 type UrlParameters = {
@@ -57,7 +57,7 @@ export const vectorTableSource = async function (
     tableName,
     tileResolution = DEFAULT_TILE_RESOLUTION,
     aggregationExp,
-    featureBbox,
+    prepareLabels,
   } = options;
 
   const spatialDataType = 'geo';
@@ -78,7 +78,7 @@ export const vectorTableSource = async function (
   if (aggregationExp) {
     urlParameters.aggregationExp = aggregationExp;
   }
-  if (featureBbox) {
+  if (prepareLabels) {
     urlParameters.featureBbox = true;
   }
 

--- a/test/sources/vector-query-source.test.ts
+++ b/test/sources/vector-query-source.test.ts
@@ -55,21 +55,21 @@ describe('vectorQuerySource', () => {
     expect(initURL).not.toContain('aggregationExp');
   });
 
-  test('featureBbox', async () => {
+  test('prepareLabels sends featureBbox param', async () => {
     stubGlobalFetchForSource();
 
     await vectorQuerySource({
       connectionName: 'carto_dw',
       accessToken: '<token>',
       sqlQuery: 'SELECT * FROM a.b.vector_table',
-      featureBbox: true,
+      prepareLabels: true,
     });
 
     const [[initURL]] = vi.mocked(fetch).mock.calls;
     expect(initURL).toMatch(/featureBbox=true/);
   });
 
-  test('featureBbox not set by default', async () => {
+  test('featureBbox param not set by default', async () => {
     stubGlobalFetchForSource();
 
     await vectorQuerySource({

--- a/test/sources/vector-table-source.test.ts
+++ b/test/sources/vector-table-source.test.ts
@@ -49,21 +49,21 @@ describe('vectorTableSource', () => {
     expect(initURL).not.toContain('aggregationExp');
   });
 
-  test('featureBbox', async () => {
+  test('prepareLabels sends featureBbox param', async () => {
     stubGlobalFetchForSource();
 
     await vectorTableSource({
       connectionName: 'carto_dw',
       accessToken: '<token>',
       tableName: 'a.b.vector_table',
-      featureBbox: true,
+      prepareLabels: true,
     });
 
     const [[initURL]] = vi.mocked(fetch).mock.calls;
     expect(initURL).toMatch(/featureBbox=true/);
   });
 
-  test('featureBbox not set by default', async () => {
+  test('featureBbox param not set by default', async () => {
     stubGlobalFetchForSource();
 
     await vectorTableSource({


### PR DESCRIPTION
## Summary

Renames the developer-facing source option `featureBbox` (introduced in 0.5.29) to **`prepareLabels`**, which is clearer about intent for app developers. The Maps API contract is **unchanged** — the source still sends the `featureBbox` query parameter.

## Changes

- `vectorTableSource` / `vectorQuerySource`: public option `featureBbox` → `prepareLabels`; internally still sets the `featureBbox` URL param (wire unchanged).
- `fetchMap`: `Dataset.featureBbox` → `prepareLabels`; label detection sets `dataset.prepareLabels`.
- Tests assert `prepareLabels` produces the `featureBbox=true` param.
- CHANGELOG (Unreleased).

## Context

Product feedback: `featureBbox` wasn't understandable at the developer level. This pairs with the cloud-native work for polygon/line labels (sc-547917 / sc-558219).

🤖 Generated with [Claude Code](https://claude.com/claude-code)