### PR TITLE
fix(geo): narrow spatial-filter factory return types to GeometrySpatialFilter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix(geo): narrow `createViewportSpatialFilter` / `createPolygonSpatialFilter` return type to `GeometrySpatialFilter` (#309)
+
 ### 0.5.30
 
 - feat(sources): expose `_getPointsAggregationLevel` for maps-api dynamic point-tile aggregation parity (#304)

--- a/src/geo.ts
+++ b/src/geo.ts
@@ -4,10 +4,10 @@ import union from '@turf/union';
 import {getType} from '@turf/invariant';
 import {polygon, multiPolygon, feature, featureCollection} from '@turf/helpers';
 import type {BBox, Geometry, MultiPolygon, Polygon, Position} from 'geojson';
-import type {SpatialFilter} from './types.js';
+import type {GeometrySpatialFilter} from './types.js';
 
 /**
- * Returns a {@link SpatialFilter} for a given viewport, typically obtained
+ * Returns a {@link GeometrySpatialFilter} for a given viewport, typically obtained
  * from deck.gl's `viewport.getBounds()` method ([west, south, east, north]).
  * If the viewport covers the entire world (to some margin of error in Web
  * Mercator space), `undefined` is returned instead.
@@ -17,7 +17,7 @@ import type {SpatialFilter} from './types.js';
  */
 export function createViewportSpatialFilter(
   viewport: BBox
-): SpatialFilter | undefined {
+): GeometrySpatialFilter | undefined {
   if (_isGlobalViewport(viewport)) {
     return;
   }
@@ -25,14 +25,14 @@ export function createViewportSpatialFilter(
 }
 
 /**
- * Returns a {@link SpatialFilter} for a given {@link Polygon} or
+ * Returns a {@link GeometrySpatialFilter} for a given {@link Polygon} or
  * {@link MultiPolygon}. If the polygon(s) extend outside longitude
  * range [-180, +180], the result may be reformatted for compatibility
  * with CARTO APIs.
  */
 export function createPolygonSpatialFilter(
   spatialFilter: Polygon | MultiPolygon
-): SpatialFilter | undefined {
+): GeometrySpatialFilter | undefined {
   return (spatialFilter && _normalizeGeometry(spatialFilter)) || undefined;
 }
 


### PR DESCRIPTION
Narrow the return type of `createViewportSpatialFilter` and `createPolygonSpatialFilter` from `SpatialFilter` to `GeometrySpatialFilter`.

SpatialFilter type was widened in https://github.com/CartoDB/carto-api-client/pull/296, so we need to fix _pure_ gometry related APIs to use `GeometrySpatialFilter`
