### PR TITLE
chore(deps): pin TypeScript to 5.x (block 6.x too)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,7 +23,8 @@ updates:
     ignore:
       - dependency-name: "@types/react"
         update-types: ["version-update:semver-major"]
-      # TS 7 (native Go rewrite) breaks the build toolchain (tsup + rollup-plugin-dts).
-      # Block 7.x+ only; 6.x is still the JS-based compiler. Remove when the toolchain supports TS 7.
+      # Pin to TS 5.x. TS 7 is the native (Go) rewrite whose API breaks the build
+      # toolchain (tsup + rollup-plugin-dts); TS 6.0 turns the toolchain's baseUrl into a
+      # hard error (TS5101). Unpin once the repo is migrated for TS 6/7.
       - dependency-name: "typescript"
-        versions: [">= 7.0.0"]
+        versions: [">= 6.0.0"]


### PR DESCRIPTION
## What

Tightens the `typescript` ignore rule in `.github/dependabot.yml` from `versions: [">= 7.0.0"]` to `versions: [">= 6.0.0"]`.

## Why

#315 loosened the pin to allow TS 6.x on the theory that 6.x is still the JS-based compiler. In practice that broke the build (PR #318, TS 6.0.3):

```
error TS5101: Option 'baseUrl' is deprecated and will stop functioning in TypeScript 7.0.
```

TS 6.0 is a transitional release that turns deprecated options into hard errors, and the build toolchain (`tsup` → `rollup-plugin-dts`) injects `baseUrl` when emitting `.d.ts`. So 6.x is not safe for this repo yet, and 7.x is the incompatible native (Go) rewrite. Pin to 5.x until the TS 6/7 migration is done deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)