### PR TITLE
chore(deps): group @loaders.gl/* updates into a single Dependabot PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,10 @@ updates:
         patterns:
           - '@deck.gl/*'
           - '@luma.gl/*'
+      # loaders.gl packages are version-locked, so they must upgrade together in one PR.
+      loaders-gl:
+        patterns:
+          - '@loaders.gl/*'
       turf:
         patterns:
           - '@turf/*'
@@ -19,6 +23,7 @@ updates:
         exclude-patterns:
           - '@deck.gl/*'
           - '@luma.gl/*'
+          - '@loaders.gl/*'
           - '@turf/*'
     ignore:
       - dependency-name: "@types/react"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,6 @@ updates:
         patterns:
           - '@deck.gl/*'
           - '@luma.gl/*'
-      # loaders.gl packages are version-locked, so they must upgrade together in one PR.
       loaders-gl:
         patterns:
           - '@loaders.gl/*'


### PR DESCRIPTION
## What

Adds a `loaders-gl` group to `.github/dependabot.yml` so all `@loaders.gl/*` packages are bumped together in a single Dependabot PR, mirroring the existing `deck-luma-gl` grouping. Also excludes `@loaders.gl/*` from the `dev-dependencies` group so they stay in their dedicated group.

## Why

`@loaders.gl/*` packages are version-locked and must upgrade together. Individual bumps (e.g. #320 bumping only `@loaders.gl/schema`) can leave the loaders.gl packages out of sync.

## Notes

- Applies to **future** Dependabot PRs. Existing per-package PRs won't be regrouped automatically — comment `@dependabot recreate` on them if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)