### PR TITLE
fix(parseMap): keep custom-aggregated channels when the saved field is null [sc-561439]

### DIFF
--- a/src/fetch-map/parse-map.ts
+++ b/src/fetch-map/parse-map.ts
@@ -306,12 +306,16 @@ function resolveCustomAggregation({
   if (aggregation !== 'custom') {
     return {field, aggregation, domainOverride: undefined};
   }
-  if (!field || !expression?.trim()) {
+  if (!expression?.trim()) {
     return {field, aggregation: undefined, domainOverride: undefined};
   }
   const alias = compileCustomAggregation(expression, {provider: providerId});
   return {
-    field: {...field, accessorKey: alias},
+    // The alias alone identifies the column, so a saved map that carries no field
+    // for the channel still renders instead of falling back to its fixed color.
+    field: field
+      ? {...field, accessorKey: alias}
+      : {name: alias, type: 'integer', accessorKey: alias},
     aggregation: undefined,
     domainOverride: domain,
   };

--- a/test/fetch-map/parse-map.spec.ts
+++ b/test/fetch-map/parse-map.spec.ts
@@ -409,6 +409,118 @@ describe('parseMap', () => {
       expect(layerDesc.scales.lineWidth?.field?.accessorKey).toBeUndefined();
     });
 
+    // Builder synthesizes the channel field before rendering, so maps persisted by
+    // other writers can reach parseMap with the styling only in visConfig.
+    test('custom color aggregation renders with a null colorField', () => {
+      const keplerMapConfig = {
+        version: 'v1',
+        config: {
+          mapState: {},
+          mapStyle: {},
+          visState: {
+            layers: [
+              {
+                id: 'layer1',
+                type: 'h3',
+                config: {
+                  dataId: 'CUSTOM_AGG_DS',
+                  label: 'Test Layer',
+                  textLabel: [{field: null, size: 12}],
+                  visConfig: {
+                    filled: true,
+                    opacity: 1,
+                    colorAggregation: 'custom',
+                    colorAggregationExp: 'SUM(x)/SUM(y)',
+                    colorAggregationDomain: [0, 100],
+                    colorRange: {
+                      category: 'sequential',
+                      colors: ['#f0f0f0', '#333333'],
+                      colorMap: undefined,
+                      name: 'custom',
+                      type: 'custom',
+                    },
+                  },
+                },
+                visualChannels: {
+                  colorField: null,
+                  colorScale: 'quantize',
+                },
+              },
+            ],
+            layerBlending: 'normal',
+            interactionConfig: {tooltip: {enabled: false}},
+          },
+        },
+      };
+      const map = parseMap({
+        ...METADATA,
+        datasets: [CUSTOM_AGG_DATASET],
+        keplerMapConfig,
+      });
+      const layerDesc = map.layers[0];
+
+      expect(layerDesc.scales.fillColor?.field?.accessorKey).toBe(
+        'custom_agg_cc6f64ff'
+      );
+      expect(layerDesc.scales.fillColor?.type).toBe('quantize');
+      expect(layerDesc.props.getFillColor).toBeTypeOf('function');
+
+      // The graduated ramp is what regresses to a flat fill when the channel is dropped.
+      const colorAt = (value: number) =>
+        layerDesc.props.getFillColor({
+          properties: {custom_agg_cc6f64ff: value},
+        });
+      expect(colorAt(0)).not.toEqual(colorAt(100));
+    });
+
+    test('custom color aggregation with a null colorField and no expression is dropped', () => {
+      const keplerMapConfig = {
+        version: 'v1',
+        config: {
+          mapState: {},
+          mapStyle: {},
+          visState: {
+            layers: [
+              {
+                id: 'layer1',
+                type: 'h3',
+                config: {
+                  dataId: 'CUSTOM_AGG_DS',
+                  label: 'Test Layer',
+                  textLabel: [{field: null, size: 12}],
+                  visConfig: {
+                    filled: true,
+                    opacity: 1,
+                    colorAggregation: 'custom',
+                    colorAggregationExp: '   ',
+                    colorRange: {
+                      category: 'sequential',
+                      colors: ['#f0f0f0', '#333333'],
+                      colorMap: undefined,
+                      name: 'custom',
+                      type: 'custom',
+                    },
+                  },
+                },
+                visualChannels: {
+                  colorField: null,
+                  colorScale: 'quantize',
+                },
+              },
+            ],
+            layerBlending: 'normal',
+            interactionConfig: {tooltip: {enabled: false}},
+          },
+        },
+      };
+      const map = parseMap({
+        ...METADATA,
+        datasets: [CUSTOM_AGG_DATASET],
+        keplerMapConfig,
+      });
+      expect(map.layers[0].scales.fillColor?.field).toBeUndefined();
+    });
+
     test('colorAggregationDomain overrides auto-computed scale domain', () => {
       const keplerMapConfig = {
         version: 'v1',


### PR DESCRIPTION
## Summary

A spatial-index layer styled with a custom aggregation renders as a flat fixed color through `fetchMap` instead of its graduated palette. Builder shows the same map correctly, so the saved config is fine — the divergence is in this package.

Both render paths call the same `parseMap`. The difference is what reaches it: Builder pipes its in-memory layer through a serializer that synthesizes `visualChannels.colorField` from the aggregation expression, then calls `parseMap`. `fetchMap` reads the saved JSON straight from the API, where that field can be `null`, and `resolveCustomAggregation` bailed out on `!field` — so no accessor was built and the layer fell back to its fixed color.

The compiled alias identifies the aggregated column on its own (the function already overwrites `accessorKey` with it), so the field was only a carrier for `name`/`type`. Synthesize it from the alias instead of dropping the channel.

Story: [sc-561439](https://app.shortcut.com/cartoteam/story/561439)

## Builder

<img width="1616" height="761" alt="Captura de pantalla 2026-07-30 a las 13 32 56" src="https://github.com/user-attachments/assets/6dc34ed5-a88e-40ed-af21-db992932dc55" />

## FetchMap before
<img width="1193" height="855" alt="Captura de pantalla 2026-07-30 a las 13 12 43" src="https://github.com/user-attachments/assets/ae182ed7-ebfb-4bf8-89af-89a9bf1a2203" />

## FetchMap after
<img width="1199" height="861" alt="Captura de pantalla 2026-07-30 a las 13 25 22" src="https://github.com/user-attachments/assets/72a72657-8aa9-4553-8736-bb8ad3d8ed52" />


## What changed

- `src/fetch-map/parse-map.ts` — split the `!field || !expression` guard so a missing field with a live expression synthesizes `{name: alias, type: 'integer', accessorKey: alias}`. Empty expression still drops the channel.
- `test/fetch-map/parse-map.spec.ts` — two tests in the existing `custom aggregation` block.

`resolveCustomAggregation` is shared by all five custom-aggregation channels (color, strokeColor, size, height, radius), so this covers them all. It also repopulates `scales.*`, which was left empty — that's what legends read, so the legend came back with it.

## Review focus

The guard change is the whole fix; only one input combination behaves differently:

| `field` | `expression` | before | after |
|---|---|---|---|
| yes | yes | alias path | unchanged |
| yes | no | dropped | unchanged |
| **no** | **yes** | dropped | **synthesized** |
| no | no | dropped | unchanged |

Worth questioning: `type: 'integer'`. It's inert for rendering here (`getColorAccessor` only reads `name`/`colorColumn`/`accessorKey`, and `calculateDomain` keys off the name), but it surfaces in `scales.*.field`, which consumers read for legends. I matched the value Builder persists so both synthesis sites produce identical descriptors — say if you'd rather it were `real`, since a `SUM(x)/SUM(y)` ratio isn't an integer.

## How to validate

Against a saved H3 map whose layer has `colorAggregation: "custom"`, a non-empty `colorAggregationExp` and `visualChannels.colorField: null`:

```js
const {layers} = await fetchMap({cartoMapId, accessToken, apiBaseUrl});
// before: getFillColor is the layer's fixed color array, scales.fillColor is {}
// after:  getFillColor is a function, scales.fillColor.field.accessorKey is the compiled alias
```

Evaluating the accessor across the configured `colorAggregationDomain` yields distinct colors from the palette rather than one repeated value. Verified end-to-end on the reported map (`c4625c4a-4a61-4bae-839c-f236dce04a37`): flat teal `[18,147,154,230]` before, the full Global Warming ramp `#5A1846 → #FFC300` after. Before/after screenshots are on the story.

## Tests

`yarn test` — 460 pass, 2 skipped, no type errors. Lint and Prettier clean.

The new tests cover the regressing case (accessor built, scale `quantize`, and the ramp actually *varies* — a constant accessor would satisfy a weaker assertion) and the empty-expression case, which must keep dropping the channel.

## Risk

Downstream consumers were checked against a local build of this branch: `workspace-www` builder suite (2549 tests), maps suite (194), and `mcp-app` (113) all pass.

One behavior change worth flagging beyond the bug being fixed: in `cloud-native`, `MapPreviewContainer` can load a map from the backend and hand it to `parseMap` without the Builder serializer. Custom-aggregated layers whose saved config lacks the field go from flat to graduated there too — which is the intent, and it converges with what the Builder canvas already shows, but it is a visible change on that surface.

## AI-generated code

Yes, written with Claude Code. The guard change and the `type: 'integer'` choice are the parts worth a human eye.