### PR TITLE
chore(release): v0.5.33

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 ## Unreleased
 
+### 0.5.33
+
 - feat(fetchMap): Support line & polygon stroke dash styles (#297)
-- feat(fetchMap): Support polygon fill patterns (runtime-assembled sprite atlas, `getFillPattern`/`scales.fillPattern`, `fillPatternEnabled`)
+- feat(fetchMap): Support polygon fill patterns (runtime-assembled sprite atlas, `getFillPattern`/`scales.fillPattern`, `fillPatternEnabled`) (#313)
 - feat(fetchMap): expose `_buildPatternAtlas({size, resolution, mipLevels})` — options-driven fill-pattern atlas builder (Figma svg tiles, 64 @ 2, mip depth 2); returns the decoded atlas, mapping, scale adjustment, resolved cell/mip, and sampler `textureParameters` (mips-on `lodMaxClamp` = mip depth + `maxAnisotropy` 4 to suppress zoomed-out moiré) for consumers to drive scale themselves
 
 ### 0.5.32

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "homepage": "https://github.com/CartoDB/carto-api-client#readme",
   "author": "Don McCurdy <donmccurdy@carto.com>",
   "packageManager": "yarn@4.3.1",
-  "version": "0.5.32",
+  "version": "0.5.33",
   "license": "MIT",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Patch release for #297 and #313.

- feat(fetchMap): Support line & polygon stroke dash styles (#297)
- feat(fetchMap): Support polygon fill patterns — runtime-assembled sprite atlas, `getFillPattern`/`scales.fillPattern`, `fillPatternEnabled` (#313)
- feat(fetchMap): expose `_buildPatternAtlas({size, resolution, mipLevels})` (#313)

Supersedes the `0.5.33-alpha.*` line the workspace currently pins (latest alpha `0.5.33-alpha.8f57a80.144`).

Tag `v0.5.33` is pushed. Merging publishes to npm: `ci.yml` gates the release job on `startsWith(head_commit.message, 'chore(release)')`, and the squash commit message is the PR title — so keep the title as-is.
