### PR TITLE
fix(fetchMap): treat a map config without filters as valid input [sc-569943]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix(fetchMap): stop crashing on a map whose config has no `filters` — the shape of every map created programmatically and never saved by Builder. `filters` and `popupSettings` are now optional on `KeplerMapConfig`. [sc-569943]
+
 ### 0.5.33
 
 - feat(fetchMap): Support line & polygon stroke dash styles (#297)

--- a/src/fetch-map/fetch-map.ts
+++ b/src/fetch-map/fetch-map.ts
@@ -110,7 +110,9 @@ export async function fillInMapDatasets(
   {datasets, keplerMapConfig}: {datasets: Dataset[]; keplerMapConfig: any},
   context: _FetchMapContext
 ) {
-  const {filters} = keplerMapConfig.config as KeplerMapConfig;
+  // Builder is not the only producer of map configs: a programmatically created
+  // map carries a minimal config and may have no `filters` key at all.
+  const {filters = {}} = keplerMapConfig.config as KeplerMapConfig;
   const promises = datasets.map((dataset) =>
     _fetchMapDataset(dataset, filters[dataset.id], context)
   );

--- a/src/fetch-map/types.ts
+++ b/src/fetch-map/types.ts
@@ -193,15 +193,17 @@ export interface CustomStyle {
 }
 
 // TODO replace with more complete type from Builder
+// Optional fields are the ones Builder adds when it first saves a map; a config
+// written programmatically carries only mapState, mapStyle and visState.
 export type KeplerMapConfig = {
-  filters: any;
+  filters?: any;
   mapState: any;
   mapStyle: {
     styleType: string;
     visibleLayerGroups: Record<string, boolean>;
   };
   legendSettings?: any;
-  popupSettings: any;
+  popupSettings?: any;
   visState: {
     layers: MapConfigLayer[];
     layerBlending: any;

--- a/test/fetch-map/fetch-map.spec.ts
+++ b/test/fetch-map/fetch-map.spec.ts
@@ -1,8 +1,49 @@
 import {describe, test, expect} from 'vitest';
-import {fetchMap} from '@carto/api-client';
+import {fetchMap, _fillInMapDatasets} from '@carto/api-client';
+import {stubGlobalFetchForSource} from '../__mock-fetch.js';
+
+const CONTEXT = {
+  accessToken: '<token>',
+  apiBaseUrl: 'https://api.carto.com',
+} as any;
+
+// Shape a map has before Builder has ever saved it: no `filters`, and none of
+// the other keys Builder adds on its first save.
+const UNSAVED_MAP_CONFIG = {
+  version: 'v1',
+  config: {
+    mapState: {latitude: 0, longitude: 0, zoom: 5, pitch: 0, bearing: 0},
+    mapStyle: {styleType: 'positron', visibleLayerGroups: {}},
+    visState: {layers: []},
+  },
+} as any;
+
+const DATASET = {
+  id: '2f741aa8-6ef8-49bd-ab99-c40f35547da8',
+  type: 'tileset',
+  source: 'carto-demo-data.demo_tilesets.osm_buildings',
+  connectionName: 'carto_dw',
+  geoColumn: 'geom',
+} as any;
 
 describe('fetchMap', () => {
   test('exports', () => {
     expect(fetchMap).toBeDefined();
+  });
+});
+
+describe('fillInMapDatasets', () => {
+  test('map config without filters', async () => {
+    stubGlobalFetchForSource();
+    const datasets = [{...DATASET}];
+
+    await expect(
+      _fillInMapDatasets(
+        {datasets, keplerMapConfig: UNSAVED_MAP_CONFIG},
+        CONTEXT
+      )
+    ).resolves.toEqual([true]);
+
+    expect(datasets[0].data).toMatchObject({tiles: expect.any(Array)});
   });
 });


### PR DESCRIPTION
## Summary

`fetchMap` crashes on any map created programmatically and never opened in Builder, with `TypeError: Cannot read properties of undefined (reading '<dataset-id>')`. The map itself is valid and renders in Builder; only the `fetchMap` path fails.

`fillInMapDatasets` destructured `config.filters` with no default and then indexed it directly, which is why the dataset id shows up as the property being read. `filters` is one of eight keys Builder adds when it first saves a map; a config written programmatically carries only `widgets`, `mapState`, `mapStyle`, `visState` and `basemapConfig`. Builder is no longer the only producer of map configs, so a minimal config is now treated as supported input rather than an error.

Story: [sc-569943](https://app.shortcut.com/cartoteam/story/569943)

## Changes

- `fetch-map.ts`: default `filters` to `{}` in `fillInMapDatasets`.
- `types.ts`: `KeplerMapConfig.filters` and `KeplerMapConfig.popupSettings` are now optional, since Builder is what adds them.
- New regression test driving `_fillInMapDatasets` with an unsaved-shape config and a tileset dataset.

## Audit of the other Builder-added keys

`filters` was the only one `fetchMap` dereferences.

| Key | Status |
| --- | --- |
| `popupSettings` | Pass-through in `parseMap`, so `undefined` is fine. |
| `uiState`, `mapSettings`, `sqlParameters`, `layerGrouping` | Never referenced in `src/`. |
| `customBaseMaps` | Already guarded (`config.customBaseMaps?.customStyle`). |
| `spatialFilter` | Not read from the map config at all. The `spatialFilter` symbols in `src/` belong to the widget/filter API. |

`parse-map.ts` also reads `filters`, but through `isEmptyObject(filters)`, and `for...in` over `undefined` is a no-op, so that path was already safe.

## Validation

The new test fails with the guard reverted, reproducing the reported error verbatim (`Cannot read properties of undefined (reading '2f741aa8-6ef8-49bd-ab99-c40f35547da8')`, the dataset id from the story), and passes with it.

`yarn lint`, `yarn format:check` and `yarn test` are green locally: 57 files, 492 passed, 2 skipped, no type errors.

## Reproduction

1. Create a map programmatically (MCP `create_map`, or the CLI) and do not open it in Builder.
2. Load it through `fetchMap`, for example MCP `view_map` with `mapId`.
3. Before this change it throws on the dataset id. After it renders.

Opening the map once in Builder and letting it save is the workaround that made the difference in the original report.
